### PR TITLE
keep the styling in the chat manager class

### DIFF
--- a/src/main/java/cf/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/cf/wynntils/modules/utilities/events/ClientEvents.java
@@ -6,13 +6,11 @@ import cf.wynntils.core.framework.enums.Priority;
 import cf.wynntils.core.framework.interfaces.Listener;
 import cf.wynntils.core.framework.interfaces.annotations.EventHandler;
 import cf.wynntils.core.utils.LimitedList;
-import cf.wynntils.core.utils.Pair;
 import cf.wynntils.modules.utilities.managers.ChatManager;
 import cf.wynntils.modules.utilities.managers.DailyReminderManager;
 import cf.wynntils.modules.utilities.managers.TPSManager;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.util.text.TextComponentString;
 import net.minecraftforge.client.event.ClientChatReceivedEvent;
 import net.minecraftforge.client.event.GuiScreenEvent;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
@@ -43,9 +41,8 @@ public class ClientEvents implements Listener {
             DailyReminderManager.openedDaily();
         }
         if(Reference.onWorld) {
-            Pair<String, Boolean> message = ChatManager.applyUpdates(e.getMessage().getFormattedText());
-            e.setMessage(new TextComponentString(message.a));
-            if(message.b) {
+            boolean message = ChatManager.applyUpdates(e.getMessage());
+            if(message) {
                 e.setCanceled(true);
             }
         }

--- a/src/main/java/cf/wynntils/modules/utilities/managers/ChatManager.java
+++ b/src/main/java/cf/wynntils/modules/utilities/managers/ChatManager.java
@@ -138,7 +138,6 @@ public class ChatManager {
         }
 
         lastMessage = message;
-        System.out.println(lastMessage);
 
         return cancel;
     }

--- a/src/main/java/cf/wynntils/modules/utilities/managers/ChatManager.java
+++ b/src/main/java/cf/wynntils/modules/utilities/managers/ChatManager.java
@@ -5,7 +5,6 @@
 package cf.wynntils.modules.utilities.managers;
 
 import cf.wynntils.ModCore;
-import cf.wynntils.core.utils.Pair;
 import cf.wynntils.core.utils.ReflectionFields;
 import cf.wynntils.modules.utilities.configs.UtilitiesConfig;
 import net.minecraft.client.audio.PositionedSoundRecord;
@@ -14,50 +13,104 @@ import net.minecraft.client.gui.GuiNewChat;
 import net.minecraft.init.SoundEvents;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundEvent;
+import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextComponentString;
-import org.apache.commons.lang3.StringUtils;
+import net.minecraft.util.text.TextFormatting;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
 public class ChatManager {
 
     private static final DateFormat dateFormat = new SimpleDateFormat("HH:mm:ss");
-    private static String lastMessage = "";
+    private static ITextComponent lastMessage = null;
     private  static int lastAmount = 2;
 
     private static final SoundEvent popOffSound = new SoundEvent(new ResourceLocation("minecraft", "entity.blaze.hurt"));
 
-    public static Pair<String, Boolean> applyUpdates(String message) {
-        String after = message;
+    public static Boolean applyUpdates(ITextComponent message) {
 
         boolean cancel = false;
 
-        if(UtilitiesConfig.Chat.INSTANCE.allowChatMentions && message.contains("/") && message.contains(":") && message.contains(ModCore.mc().player.getName())) {
-            String[] messageSplitted = message.split(":", 2);
-            if (messageSplitted[1].contains(ModCore.mc().player.getName())) {
-                String playerName = ModCore.mc().player.getName();
-                String afterSplit = StringUtils.join(Arrays.copyOfRange(messageSplitted, 1, messageSplitted.length));
-                if(afterSplit.contains(playerName)) {
-                    afterSplit = afterSplit.replace(playerName, "§e" + playerName + "§" + afterSplit.charAt(4));
-                    after = messageSplitted[0] + ":" + afterSplit;
+        if(UtilitiesConfig.Chat.INSTANCE.allowChatMentions && message.getSiblings().size() >= 2 && message.getSiblings().get(0).getUnformattedText().contains("/")) {
+            if (message.getFormattedText().contains(ModCore.mc().player.getName())) {
+                boolean hasMention = false;
+                boolean foundStart = false;
+                ArrayList<ITextComponent> components = new ArrayList<ITextComponent>();
+                for (ITextComponent component : message.getSiblings()) {
+                    if (component.getUnformattedComponentText().contains(ModCore.mc().player.getName()) && foundStart) {
+                        hasMention = true;
+                        String[] sections = component.getUnformattedText().split(ModCore.mc().player.getName());
+                        for (int index = 0; index < sections.length; index++) {
+                            String section = sections[index];
+                            ITextComponent sectionComponent = new TextComponentString(section);
+                            sectionComponent.setStyle(component.getStyle().createDeepCopy());
+                            components.add(sectionComponent);
+                            if (index != sections.length - 1) {
+                                ITextComponent playerComponent = new TextComponentString(ModCore.mc().player.getName());
+                                playerComponent.setStyle(component.getStyle().createDeepCopy());
+                                playerComponent.getStyle().setColor(TextFormatting.YELLOW);
+                                components.add(playerComponent);
+                            }
+                            
+                        }
+                        if (component.getUnformattedText().endsWith(ModCore.mc().player.getName())) {
+                            ITextComponent playerComponent = new TextComponentString(ModCore.mc().player.getName());
+                            playerComponent.setStyle(component.getStyle().createDeepCopy());
+                            playerComponent.getStyle().setColor(TextFormatting.YELLOW);
+                            components.add(playerComponent);
+                        }
+                        
+                    } else if (!foundStart) {
+                        foundStart = component.getUnformattedText().contains(":");
+                        components.add(component);
+                    } else {
+                        components.add(component);
+                    }
+                }
+                message.getSiblings().clear();
+                message.getSiblings().addAll(components);
+                if (hasMention) {  
                     ModCore.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.BLOCK_NOTE_PLING, 1.0F));
                 }
             }
         }
 
         if(UtilitiesConfig.Chat.INSTANCE.addTimestampsToChat) {
-            after = "§8[§7" + dateFormat.format(new Date()) + "§8] " + after;
+            List<ITextComponent> timeStamp = new ArrayList<ITextComponent>();
+            ITextComponent startBracket = new TextComponentString("[");
+            startBracket.getStyle().setColor(TextFormatting.DARK_GRAY);
+            timeStamp.add(startBracket);
+            ITextComponent time = new TextComponentString(dateFormat.format(new Date()));
+            time.getStyle().setColor(TextFormatting.GRAY);
+            timeStamp.add(time);
+            ITextComponent endBracket = new TextComponentString("] ");
+            endBracket.getStyle().setColor(TextFormatting.DARK_GRAY);
+            timeStamp.add(endBracket);
+            message.getSiblings().addAll(0, timeStamp);
         }
 
-        if(message.contains(" requires your ") && message.contains(" skill to be at least ")){
+        if(message.getUnformattedText().contains(" requires your ") && message.getUnformattedText().contains(" skill to be at least ")){
             ModCore.mc().player.playSound(popOffSound, 1f, 1f);
         }
+        
+        ITextComponent thisClone = message.createCopy();
+        thisClone.getSiblings().remove(0);
+        thisClone.getSiblings().remove(0);
+        thisClone.getSiblings().remove(0);
+        
+        ITextComponent lastClone = null;
+        if (lastMessage != null) {
+            lastClone = lastMessage.createCopy();
+            lastClone.getSiblings().remove(0);
+            lastClone.getSiblings().remove(0);
+            lastClone.getSiblings().remove(0);
+        }
 
-        if (UtilitiesConfig.Chat.INSTANCE.blockChatSpamFilter && message.replaceFirst("§8\\[§7.*§8\\]", "").equals(lastMessage)) {
+        if (UtilitiesConfig.Chat.INSTANCE.blockChatSpamFilter && thisClone.getUnformattedText().equals(lastClone == null ? null : lastClone.getUnformattedText())) {
             GuiNewChat ch = ModCore.mc().ingameGUI.getChatGUI();
 
             if(ch != null) {
@@ -66,7 +119,14 @@ public class ChatManager {
 
                     if(oldLines != null && oldLines.size() > 0) {
                         ChatLine line = oldLines.get(0);
-                        ReflectionFields.ChatLine_lineString.setValue(line, new TextComponentString(after + " §7[" + lastAmount++ + "x]"));
+                        ITextComponent chatLine = (ITextComponent) ReflectionFields.ChatLine_lineString.getValue(line);
+                        ITextComponent lastComponent = chatLine.getSiblings().get(chatLine.getSiblings().size() - 1);
+                        if (lastComponent.getUnformattedComponentText().matches(" \\[\\d*x]")) {
+                            chatLine.getSiblings().remove(lastComponent);
+                        }
+                        ITextComponent counter = new TextComponentString(" [" + lastAmount++ + "x]");
+                        counter.getStyle().setColor(TextFormatting.GRAY);
+                        ((ITextComponent) ReflectionFields.ChatLine_lineString.getValue(line)).appendSibling(counter);
 
                         ch.refreshChat();
                         cancel = true;
@@ -78,8 +138,9 @@ public class ChatManager {
         }
 
         lastMessage = message;
+        System.out.println(lastMessage);
 
-        return new Pair<>(after, cancel);
+        return cancel;
     }
 
 }


### PR DESCRIPTION
there is some things that don't stay if you convert a text component to a string and back (e.g. opening URLs, hovering over messages)