### PR TITLE
Prevent closing loot chests that contain mythic items

### DIFF
--- a/src/main/java/cf/wynntils/core/utils/Utils.java
+++ b/src/main/java/cf/wynntils/core/utils/Utils.java
@@ -120,6 +120,14 @@ public class Utils {
         return lore;
     }
 
+    public static String getStringLore(ItemStack is){
+        StringBuilder toReturn = new StringBuilder();
+        for (String x : getLore(is)) {
+            toReturn.append(x);
+        }
+        return toReturn.toString();
+    }
+
     public static String arrayWithCommas(ArrayList<String> values) {
         StringBuilder total = new StringBuilder();
 

--- a/src/main/java/cf/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/cf/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -31,6 +31,9 @@ public class UtilitiesConfig extends SettingsClass {
     @Setting(displayName = "Show players armor", description = "Should what players are wearing be listed in their name tag")
     public boolean showArmors = false;
 
+    @Setting(displayName = "Prevent mythic loot chest closing", description = "Should the closing of loot chests be prevented when that loot chest contains a mythic")
+    public boolean preventMythicChestClose = true;
+
     //HeyZeer0: Do not add @Setting here, or it will be displayed on the configuration
     public HashMap<Integer, HashSet<Integer>> locked_slots = new HashMap<>();
 

--- a/src/main/java/cf/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/cf/wynntils/modules/utilities/events/ClientEvents.java
@@ -7,7 +7,6 @@ import cf.wynntils.core.events.custom.PacketEvent;
 import cf.wynntils.core.framework.instances.PlayerInfo;
 import cf.wynntils.core.framework.interfaces.Listener;
 import cf.wynntils.core.utils.Pair;
-import cf.wynntils.core.utils.Utils;
 import cf.wynntils.modules.utilities.UtilitiesModule;
 import cf.wynntils.modules.utilities.configs.UtilitiesConfig;
 import cf.wynntils.modules.utilities.managers.*;
@@ -95,13 +94,15 @@ public class ClientEvents implements Listener {
                 IInventory inv = e.getGuiInventory().getLowerInv();
                 if (inv.getDisplayName().getUnformattedText().contains("Loot Chest")) {
                     for (int i = 0; i < inv.getSizeInventory(); i++) {
-                        ItemStack inSlot = inv.getStackInSlot(i);
-                        if (Utils.getStringLore(inSlot).contains("§5Mythic")) {
+                        if(inv.getStackInSlot(i).hasDisplayName() && inv.getStackInSlot(i).getDisplayName().startsWith("§5")) {
+                            Minecraft.getMinecraft().player.sendMessage(new TextComponentString("§cYou cannot close this loot chest while there is mythic in it!"));
+                            Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.BLOCK_NOTE_BASS, 1f));
                             e.setCanceled(true);
-                            return;
+                            break;
                         }
                     }
                 }
+                return;
             }
         }
 

--- a/src/main/java/cf/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/cf/wynntils/modules/utilities/events/ClientEvents.java
@@ -11,6 +11,8 @@ import cf.wynntils.modules.utilities.UtilitiesModule;
 import cf.wynntils.modules.utilities.configs.UtilitiesConfig;
 import cf.wynntils.modules.utilities.managers.*;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.audio.PositionedSoundRecord;
+import net.minecraft.init.SoundEvents;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.text.ChatType;

--- a/src/main/java/cf/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/cf/wynntils/modules/utilities/events/ClientEvents.java
@@ -7,10 +7,13 @@ import cf.wynntils.core.events.custom.PacketEvent;
 import cf.wynntils.core.framework.instances.PlayerInfo;
 import cf.wynntils.core.framework.interfaces.Listener;
 import cf.wynntils.core.utils.Pair;
+import cf.wynntils.core.utils.Utils;
 import cf.wynntils.modules.utilities.UtilitiesModule;
 import cf.wynntils.modules.utilities.configs.UtilitiesConfig;
 import cf.wynntils.modules.utilities.managers.*;
 import net.minecraft.client.Minecraft;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.text.ChatType;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraftforge.client.event.ClientChatReceivedEvent;
@@ -20,6 +23,7 @@ import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
 
+import java.awt.event.KeyEvent;
 import java.util.HashSet;
 
 /**
@@ -86,6 +90,21 @@ public class ClientEvents implements Listener {
     @SubscribeEvent
     public void keyPressOnChest(GuiOverlapEvent.ChestOverlap.KeyTyped e) {
         if(!Reference.onWorld) return;
+
+        if (UtilitiesConfig.INSTANCE.preventMythicChestClose) {
+            if (e.getKeyCode() == 1 || e.getKeyCode() == ModCore.mc().gameSettings.keyBindInventory.getKeyCode()) {
+                IInventory inv = e.getGuiInventory().getLowerInv();
+                if (inv.getDisplayName().getUnformattedText().contains("Loot Chest")) {
+                    for (int i = 0; i < inv.getSizeInventory(); i++) {
+                        ItemStack inSlot = inv.getStackInSlot(i);
+                        if (Utils.getStringLore(inSlot).contains("§5Mythic")) {
+                            e.setCanceled(true);
+                            return;
+                        }
+                    }
+                }
+            }
+        }
 
         if(e.getKeyCode() == KeyManager.getLockInventoryKey().getKeyBinding().getKeyCode()) {
             if(e.getGuiInventory().getSlotUnderMouse() != null && Minecraft.getMinecraft().player.inventory == e.getGuiInventory().getSlotUnderMouse().inventory) {

--- a/src/main/java/cf/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/cf/wynntils/modules/utilities/events/ClientEvents.java
@@ -23,7 +23,6 @@ import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
 
-import java.awt.event.KeyEvent;
 import java.util.HashSet;
 
 /**

--- a/src/main/java/cf/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/cf/wynntils/modules/utilities/events/ClientEvents.java
@@ -17,6 +17,7 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.text.ChatType;
 import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.TextComponentString;
 import net.minecraftforge.client.event.ClientChatReceivedEvent;
 import net.minecraftforge.client.event.GuiScreenEvent;
 import net.minecraftforge.client.event.RenderLivingEvent;

--- a/src/main/java/cf/wynntils/modules/utilities/overlays/inventories/RarityColorOverlay.java
+++ b/src/main/java/cf/wynntils/modules/utilities/overlays/inventories/RarityColorOverlay.java
@@ -91,7 +91,7 @@ public class RarityColorOverlay implements Listener {
 
             float r, g, b;
 
-            String lore = getStringLore(is);
+            String lore = Utils.getStringLore(is);
 
             if (lore.contains("Reward") || StringUtils.containsIgnoreCase(lore, "rewards")) {
                 continue;
@@ -263,7 +263,7 @@ public class RarityColorOverlay implements Listener {
                     continue;
                 }
 
-                String lore = getStringLore(is);
+                String lore = Utils.getStringLore(is);
 
                 float r, g, b;
 
@@ -358,7 +358,7 @@ public class RarityColorOverlay implements Listener {
 
                 float r, g, b;
 
-                String lore = getStringLore(is);
+                String lore = Utils.getStringLore(is);
 
                 if (lore.contains("Reward") || StringUtils.containsIgnoreCase(lore, "rewards")) {
                     continue;
@@ -521,15 +521,4 @@ public class RarityColorOverlay implements Listener {
             }
         }
     }
-
-    public static String getStringLore(ItemStack is){
-        StringBuilder toReturn = new StringBuilder();
-
-        for (String x : Utils.getLore(is)) {
-            toReturn.append(x);
-        }
-
-        return toReturn.toString();
-    }
-
 }

--- a/src/main/java/cf/wynntils/modules/utilities/overlays/inventories/SkillPointOverlay.java
+++ b/src/main/java/cf/wynntils/modules/utilities/overlays/inventories/SkillPointOverlay.java
@@ -6,6 +6,7 @@ package cf.wynntils.modules.utilities.overlays.inventories;
 
 import cf.wynntils.core.events.custom.GuiOverlapEvent;
 import cf.wynntils.core.framework.interfaces.Listener;
+import cf.wynntils.core.utils.Utils;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
 public class SkillPointOverlay implements Listener {
@@ -14,7 +15,7 @@ public class SkillPointOverlay implements Listener {
     public void onChestInventory(GuiOverlapEvent.ChestOverlap.DrawGuiContainerForegroundLayer e) {
         if(e.getGuiInventory().getSlotUnderMouse() == null || !e.getGuiInventory().getSlotUnderMouse().getHasStack()) return;
 
-        String lore = RarityColorOverlay.getStringLore(e.getGuiInventory().getSlotUnderMouse().getStack());
+        String lore = Utils.getStringLore(e.getGuiInventory().getSlotUnderMouse().getStack());
         if (e.getGuiInventory().getLowerInv().getName().contains("skill points remaining") && lore.contains("points")) {
             lore = lore.replace("§", "");
             String[] tokens = lore.split("[0-9]{1,3} points");


### PR DESCRIPTION
Not actually tested for mythics (for obvious reasons) - but worked when I tested it using rares/uniques. Couldn't find any events in forge to handle closing an inventory, so this looked like the best way of doing it.