### PR TITLE
Add basic powder highlighting

### DIFF
--- a/src/main/java/cf/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/cf/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -135,6 +135,13 @@ public class UtilitiesConfig extends SettingsClass {
         @Setting(displayName = "Show emerald count in inventory", description = "Show emerald count in the player's inventory")
         public boolean emeraldCountInventory = true;
 
+        @Setting(displayName = "Highlight powders", description = "Should powders be highlighted")
+        public boolean powderHighlight = true;
+
+        @Setting(displayName = "Min powder tier highlight", description = "The minimum tier of powder that should be highlighted. No effect if powder highlighting is disabled")
+        @Setting.Limitations.IntLimit(min = 1, max = 6)
+        public int minPowderTier = 4;
+
         @Override
         public void onSettingChanged(String name) {
 

--- a/src/main/java/cf/wynntils/modules/utilities/overlays/inventories/RarityColorOverlay.java
+++ b/src/main/java/cf/wynntils/modules/utilities/overlays/inventories/RarityColorOverlay.java
@@ -107,6 +107,12 @@ public class RarityColorOverlay implements Listener {
                 r = 0; g = 1; b = 0;
             } else if (lore.contains("§fNormal") && UtilitiesConfig.Items.INSTANCE.normalHighlight) {
                 r = 1; g = 1; b = 1;
+            } else if (isPowder(is) && UtilitiesConfig.Items.INSTANCE.powderHighlight) {
+                if (getPowderTier(is) < UtilitiesConfig.Items.INSTANCE.minPowderTier)
+                    continue;
+                r = getPowderColor(is)[0];
+                g = getPowderColor(is)[1];
+                b = getPowderColor(is)[2];
             } else if (floor >= 4) {
                 armorfloor++;
                 continue;
@@ -287,6 +293,12 @@ public class RarityColorOverlay implements Listener {
                     r = 1; g = 0; b = 1;
                 } else if (lore.contains("§fCommon") && lore.contains("Reward") && UtilitiesConfig.Items.INSTANCE.commonEffectsHighlight) {
                     r = 1; g = 1; b = 1;
+                } else if (isPowder(is) && UtilitiesConfig.Items.INSTANCE.powderHighlight) {
+                    if (getPowderTier(is) < UtilitiesConfig.Items.INSTANCE.minPowderTier)
+                        continue;
+                    r = getPowderColor(is)[0];
+                    g = getPowderColor(is)[1];
+                    b = getPowderColor(is)[2];
                 } else if (floor >= 4) {
                     continue;
                 } else {
@@ -374,6 +386,12 @@ public class RarityColorOverlay implements Listener {
                     r = 0; g = 1; b = 0;
                 } else if (lore.contains("§fNormal") && UtilitiesConfig.Items.INSTANCE.normalHighlight) {
                     r = 1; g = 1; b = 1;
+                } else if (isPowder(is) && UtilitiesConfig.Items.INSTANCE.powderHighlight) {
+                    if (getPowderTier(is) < UtilitiesConfig.Items.INSTANCE.minPowderTier)
+                        continue;
+                    r = getPowderColor(is)[0];
+                    g = getPowderColor(is)[1];
+                    b = getPowderColor(is)[2];
                 } else if (floor >= 4) {
                     continue;
                 } else {
@@ -520,5 +538,41 @@ public class RarityColorOverlay implements Listener {
                 GlStateManager.enableLighting();
             }
         }
+    }
+
+    private boolean isPowder(ItemStack is) {
+        return (is.hasDisplayName() && is.getDisplayName().contains("Powder"));
+    }
+
+    private int getPowderTier(ItemStack is) {
+        if (is.getDisplayName().endsWith("III")) {
+            return 3;
+        } else if (is.getDisplayName().endsWith("IV")) {
+            return 4;
+        } else if (is.getDisplayName().endsWith("VI")) {
+            return 6;
+        } else if (is.getDisplayName().endsWith("V")) {
+            return 5;
+        } else if (is.getDisplayName().endsWith("II")) {
+            return 2;
+        } else {
+            return 1;
+        }
+    }
+
+    private float[] getPowderColor(ItemStack is) {
+        float[] returnVal;
+        if (is.getDisplayName().startsWith("§e")) {
+            returnVal = new float[]{1f, 1f, 0.333f};
+        } else if (is.getDisplayName().startsWith("§b")) {
+            returnVal = new float[]{0.333f, 1f, 1f};
+        } else if (is.getDisplayName().startsWith("§f")) {
+            returnVal = new float[]{1f, 1f, 1f};
+        } else if (is.getDisplayName().startsWith("§2")) {
+            returnVal = new float[]{0f, 0.666f, 0f};
+        } else {
+            returnVal = new float[]{1f, 0.333f, 0.333f};
+        }
+        return returnVal;
     }
 }

--- a/src/main/java/cf/wynntils/modules/utilities/overlays/inventories/RarityColorOverlay.java
+++ b/src/main/java/cf/wynntils/modules/utilities/overlays/inventories/RarityColorOverlay.java
@@ -563,14 +563,19 @@ public class RarityColorOverlay implements Listener {
     private float[] getPowderColor(ItemStack is) {
         float[] returnVal;
         if (is.getDisplayName().startsWith("§e")) {
+            // Lightning
             returnVal = new float[]{1f, 1f, 0.333f};
         } else if (is.getDisplayName().startsWith("§b")) {
+            // Water
             returnVal = new float[]{0.333f, 1f, 1f};
         } else if (is.getDisplayName().startsWith("§f")) {
+            // Air
             returnVal = new float[]{1f, 1f, 1f};
         } else if (is.getDisplayName().startsWith("§2")) {
+            // Earth
             returnVal = new float[]{0f, 0.666f, 0f};
         } else {
+            // Fire
             returnVal = new float[]{1f, 0.333f, 0.333f};
         }
         return returnVal;


### PR DESCRIPTION
Added basic powder highlighting - at the moment it just piggybacks off item rarity handling (using the exact same style, just with different colours). By default the overlay is enabled and will highlight all tier 4+ powders, however both the minimum tier and whether the overlay is active can be configured.