### PR TITLE
Add the time until soul point regen to tooltip

### DIFF
--- a/src/main/java/cf/wynntils/modules/utilities/overlays/inventories/ItemIdentificationOverlay.java
+++ b/src/main/java/cf/wynntils/modules/utilities/overlays/inventories/ItemIdentificationOverlay.java
@@ -4,6 +4,7 @@
 
 package cf.wynntils.modules.utilities.overlays.inventories;
 
+import cf.wynntils.ModCore;
 import cf.wynntils.core.events.custom.GuiOverlapEvent;
 import cf.wynntils.core.framework.interfaces.Listener;
 import cf.wynntils.core.utils.Utils;
@@ -57,6 +58,31 @@ public class ItemIdentificationOverlay implements Listener {
 
     public void drawHoverGuess(ItemStack stack){
         if (stack == null || !stack.hasDisplayName() || stack.isEmpty()) {
+            return;
+        }
+
+        if (stack.getDisplayName().contains("Soul Point")) {
+            List<String> lore = Utils.getLore(stack);
+            if (lore.get(lore.size() - 1).contains("Time until next soul point: ")) {
+                lore.remove(lore.size() - 1);
+                lore.remove(lore.size() - 1);
+            }
+            long worldTimeTicks = ModCore.mc().world.getWorldTime();
+            long currentTime = worldTimeTicks % 24000;
+            long minutesUntilSoulPoint = Math.floorDiv(currentTime, 1200);
+            currentTime -= (minutesUntilSoulPoint * 1200);
+            long secondsUntilSoulPoint = Math.floorDiv(currentTime, 20);
+            minutesUntilSoulPoint = 20 - minutesUntilSoulPoint - 1;
+            secondsUntilSoulPoint = 60 - secondsUntilSoulPoint - 1;
+            lore.add("");
+            lore.add("§bTime until next soul point: §f" + minutesUntilSoulPoint + ":" + String.format("%02d", secondsUntilSoulPoint));
+            NBTTagCompound nbt = stack.getTagCompound();
+            NBTTagCompound display = nbt.getCompoundTag("display");
+            NBTTagList tag = new NBTTagList();
+            lore.forEach(s -> tag.appendTag(new NBTTagString(s)));
+            display.setTag("Lore", tag);
+            nbt.setTag("display", display);
+            stack.setTagCompound(nbt);
             return;
         }
 


### PR DESCRIPTION
This can already be guessed in non-modded by looking at the sky; however now the player would be able to get the exact time until the regen a soul point. Example:
![image](https://user-images.githubusercontent.com/7407004/49857958-aa3bfc80-fdeb-11e8-8c00-909fbb94172e.png)
