### PR TITLE
Implement Quest Giver Icons

### DIFF
--- a/src/main/java/cf/wynntils/modules/questbook/configs/QuestBookConfig.java
+++ b/src/main/java/cf/wynntils/modules/questbook/configs/QuestBookConfig.java
@@ -19,4 +19,7 @@ public class QuestBookConfig extends SettingsClass {
     @Setting(displayName = "Set quest location to compass", description = "Should the compass follow the quest coordinates")
     public boolean compassFollowQuests = true;
 
+    @Setting(displayName = "Quest NPC icons", description = "Should quest NPCs have icons above their heads")
+    public boolean questGiverIcons = true;
+
 }

--- a/src/main/java/cf/wynntils/modules/questbook/events/ClientEvents.java
+++ b/src/main/java/cf/wynntils/modules/questbook/events/ClientEvents.java
@@ -61,7 +61,7 @@ public class ClientEvents implements Listener {
                 for (QuestInfo info : infoList) {
                     if (info.getStatus() == QuestStatus.COMPLETED || info.getStatus() == QuestStatus.CANNOT_START)
                         continue;
-                    if (info.getCurrentDescription().contains(Utils.stripColor(npcNameStand.getDisplayName().getUnformattedText()))) {
+                    if (info.getCurrentDescription().toLowerCase().contains(Utils.stripColor(npcNameStand.getDisplayName().getUnformattedText().toLowerCase()))) {
                         if (info.getStatus() == QuestStatus.CAN_START) {
                             drawQuestNameplate(e.getRenderer().getRenderManager().getFontRenderer(), "§e!", (float) e.getX(), (float) e.getY(), (float) e.getZ(), e.getRenderer().getRenderManager().playerViewY, e.getRenderer().getRenderManager().playerViewX, e.getRenderer().getRenderManager().options.thirdPersonView == 2);
                         } else {

--- a/src/main/java/cf/wynntils/modules/questbook/events/ClientEvents.java
+++ b/src/main/java/cf/wynntils/modules/questbook/events/ClientEvents.java
@@ -4,15 +4,31 @@
 
 package cf.wynntils.modules.questbook.events;
 
+import cf.wynntils.ModCore;
+import cf.wynntils.Reference;
 import cf.wynntils.core.framework.interfaces.Listener;
 import cf.wynntils.core.utils.Utils;
 import cf.wynntils.modules.questbook.QuestBookModule;
 import cf.wynntils.modules.questbook.configs.QuestBookConfig;
+import cf.wynntils.modules.questbook.enums.QuestStatus;
+import cf.wynntils.modules.questbook.instances.QuestInfo;
 import cf.wynntils.modules.questbook.managers.QuestManager;
+import cf.wynntils.modules.utilities.configs.UtilitiesConfig;
+import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.renderer.BufferBuilder;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
+import net.minecraft.entity.item.EntityArmorStand;
+import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraftforge.client.event.ClientChatReceivedEvent;
+import net.minecraftforge.client.event.RenderLivingEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class ClientEvents implements Listener {
 
@@ -29,6 +45,77 @@ public class ClientEvents implements Listener {
         if(e.getMessage().getFormattedText().contains("§6[Quest Completed]")) {
             QuestManager.requestQuestBookReading();
         }
+    }
+
+    @SubscribeEvent
+    public void onRenderEntity(RenderLivingEvent.Specials.Pre e) {
+        if (!Reference.onWorld) return;
+
+        if (QuestBookConfig.INSTANCE.questGiverIcons && e.getEntity() instanceof EntityArmorStand && e.getEntity().hasCustomName() && e.getEntity().getAlwaysRenderNameTagForRender()) {
+            if (e.getEntity().getDisplayName().getUnformattedText().contains("NPC")) {
+                EntityArmorStand npcTagStand = (EntityArmorStand) e.getEntity();
+                if (ModCore.mc().world.getEntitiesWithinAABB(EntityArmorStand.class, new AxisAlignedBB(npcTagStand.getPosition())).isEmpty())
+                    return;
+                EntityArmorStand npcNameStand = ModCore.mc().world.getEntitiesWithinAABB(EntityArmorStand.class, new AxisAlignedBB(npcTagStand.getPosition())).get(0);
+                List<QuestInfo> infoList = new ArrayList(QuestManager.getCurrentQuestsData());
+                for (QuestInfo info : infoList) {
+                    if (info.getStatus() == QuestStatus.COMPLETED || info.getStatus() == QuestStatus.CANNOT_START)
+                        continue;
+                    if (info.getCurrentDescription().contains(Utils.stripColor(npcNameStand.getDisplayName().getUnformattedText()))) {
+                        if (info.getStatus() == QuestStatus.CAN_START) {
+                            drawQuestNameplate(e.getRenderer().getRenderManager().getFontRenderer(), "§e!", (float) e.getX(), (float) e.getY(), (float) e.getZ(), e.getRenderer().getRenderManager().playerViewY, e.getRenderer().getRenderManager().playerViewX, e.getRenderer().getRenderManager().options.thirdPersonView == 2);
+                        } else {
+                            drawQuestNameplate(e.getRenderer().getRenderManager().getFontRenderer(), "§e?", (float) e.getX(), (float) e.getY(), (float) e.getZ(), e.getRenderer().getRenderManager().playerViewY, e.getRenderer().getRenderManager().playerViewX, e.getRenderer().getRenderManager().options.thirdPersonView == 2);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private static void drawQuestNameplate(FontRenderer fontRendererIn, String str, float x, float y, float z, float viewerYaw, float viewerPitch, boolean isThirdPersonFrontal)
+    {
+        int VERTICAL_SHIFT = -20;
+        float SCALE = 3f;
+        float RED = 1f;
+        float GREEN = 1f;
+        float BLUE = 0f;
+        GlStateManager.pushMatrix();
+        GlStateManager.scale(SCALE, SCALE, SCALE);
+        GlStateManager.translate(x/SCALE, y/SCALE, z/SCALE);
+        GlStateManager.glNormal3f(0.0F, 1.0F, 0.0F);
+        GlStateManager.rotate(-viewerYaw, 0.0F, 1.0F, 0.0F);
+        GlStateManager.rotate((float)(isThirdPersonFrontal ? -1 : 1) * viewerPitch, 1.0F, 0.0F, 0.0F);
+        GlStateManager.scale(-0.025F, -0.025F, 0.025F);
+        GlStateManager.disableLighting();
+        GlStateManager.depthMask(false);
+
+        if (!UtilitiesConfig.INSTANCE.hideNametags) {
+            GlStateManager.disableDepth();
+        }
+
+        if (!UtilitiesConfig.INSTANCE.hideNametagBox) {
+            GlStateManager.enableBlend();
+            GlStateManager.tryBlendFuncSeparate(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA, GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ZERO);
+            int i = fontRendererIn.getStringWidth(str) / 2;
+            GlStateManager.disableTexture2D();
+            Tessellator tessellator = Tessellator.getInstance();
+            BufferBuilder vertexbuffer = tessellator.getBuffer();
+            vertexbuffer.begin(7, DefaultVertexFormats.POSITION_COLOR);
+            vertexbuffer.pos((double) (-i - 1), (double) (-21 + VERTICAL_SHIFT), 0.0D).color(RED, GREEN, BLUE, 0.25F).endVertex();
+            vertexbuffer.pos((double) (-i - 1), (double) (8 + VERTICAL_SHIFT), 0.0D).color(RED, GREEN, BLUE, 0.25F).endVertex();
+            vertexbuffer.pos((double) (i + 1), (double) (8 + VERTICAL_SHIFT), 0.0D).color(RED, GREEN, BLUE, 0.25F).endVertex();
+            vertexbuffer.pos((double) (i + 1), (double) (-1 + VERTICAL_SHIFT), 0.0D).color(RED, GREEN, BLUE, 0.25F).endVertex();
+            tessellator.draw();
+            GlStateManager.enableTexture2D();
+        }
+
+        GlStateManager.depthMask(true);
+        fontRendererIn.drawString(str, -fontRendererIn.getStringWidth(str) / 2, VERTICAL_SHIFT, -1);
+        GlStateManager.enableLighting();
+        GlStateManager.disableBlend();
+        GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
+        GlStateManager.popMatrix();
     }
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)


### PR DESCRIPTION
At the moment, this is by no means a perfect implementation. It's issues include:

- Only working when a NPC has the grey 'NPC' label
- Detecting quest-relevant NPCs when their name appears in the current step description of a quest, meaning:
  - NPCs are only given icons if their name appears in the quest text, certain NPCs could therefore be ignored (e.g. in the quest "King's Recruit", the final step says: "Talk to the King.", however the NPC is called 'Ragni's King', which means no icon is drawn)
  - NPCs could be given icons when you don't actually need to talk to them (e.g. in the quest "Enzan's Brother", the final step says: "Find Enzan's brother", because the name 'Enzan' is in this text, the NPC 'Enzan' has a question mark over their head even though you don't need to talk to them again in that quest)
- I've reused the nameplate drawing code instead of drawing an image, this means that the quest NPCs don't look as good as they could:
  - [Quest can be started](https://i.imgur.com/zQTcvBA.png)
  - [Quest in progress](https://i.imgur.com/KyoRr9k.png)
- There's some weirdness when moving the camera angle around, this doesn't ruin it, but probably could be improved:
  - https://i.imgur.com/kMV5qem.png
  - https://i.imgur.com/ipZ9rK4.png
I've recorded an example of me going through the first 3 quests: King's Recruit, Enzan's brother and Poisoning the Pest: https://youtu.be/fwT9VW7Y_5o