### PR TITLE
Minor bug fixes

### DIFF
--- a/src/main/java/cf/wynntils/modules/chat/overlays/ChatOverlay.java
+++ b/src/main/java/cf/wynntils/modules/chat/overlays/ChatOverlay.java
@@ -220,7 +220,7 @@ public class ChatOverlay extends GuiNewChat {
 
         ChatTab selectedTab = ChatTab.GLOBAL;
 
-        if(chatComponent.getFormattedText().startsWith("§3[§r")) selectedTab = ChatTab.GUILD;
+        if(chatComponent.getFormattedText().startsWith("§3[§r") && !chatComponent.getUnformattedText().endsWith("has just logged in!")) selectedTab = ChatTab.GUILD;
         else if(chatComponent.getFormattedText().startsWith("§7[§r§e")) selectedTab = ChatTab.PARTY;
 
         if(selectedTab != currentTab) {
@@ -305,7 +305,7 @@ public class ChatOverlay extends GuiNewChat {
     public void addToSentMessages(String message) {
         ChatTab selectedTab = ChatTab.GLOBAL;
 
-        if(message.startsWith("§3§3[§r")) selectedTab = ChatTab.GUILD;
+        if(message.startsWith("§3§3[§r") && !message.endsWith("has just logged in!")) selectedTab = ChatTab.GUILD;
         else if(message.startsWith("§7[§r§e")) selectedTab = ChatTab.PARTY;
 
         sentMessages.get(selectedTab).add(message);

--- a/src/main/java/cf/wynntils/modules/questbook/managers/QuestManager.java
+++ b/src/main/java/cf/wynntils/modules/questbook/managers/QuestManager.java
@@ -120,7 +120,7 @@ public class QuestManager {
     public static void updateTrackedQuest() {
         if(trackedQuest == null) return;
 
-        QuestInfo questInfo = currentQuestsData.stream().filter(c -> c.getName().equals(trackedQuest.getName())).filter(c -> c.getStatus() == QuestStatus.STARTED).findFirst().orElse(null);
+        QuestInfo questInfo = currentQuestsData.stream().filter(c -> c.getName().equals(trackedQuest.getName())).filter(c -> c.getStatus() == QuestStatus.STARTED || c.getStatus() == QuestStatus.CAN_START).findFirst().orElse(null);
         if(questInfo != null && questInfo.getCurrentDescription().equals(trackedQuest.getCurrentDescription())) {
             return;
         }

--- a/src/main/java/cf/wynntils/modules/questbook/overlays/ui/QuestBookGUI.java
+++ b/src/main/java/cf/wynntils/modules/questbook/overlays/ui/QuestBookGUI.java
@@ -205,7 +205,7 @@ public class QuestBookGUI extends GuiScreen {
     public void mouseClicked(int mouseX, int mouseY, int mouseButton) throws IOException {
         if(overQuest != null) {
             if (mouseButton != 1) {
-                if (overQuest.getStatus() == QuestStatus.COMPLETED)
+                if (overQuest.getStatus() == QuestStatus.COMPLETED || overQuest.getStatus() == QuestStatus.CANNOT_START)
                     return;
                 if (QuestManager.getTrackedQuest() != null && QuestManager.getTrackedQuest().getName().equals(overQuest.getName())) {
                     QuestManager.setTrackedQuest(null);

--- a/src/main/java/cf/wynntils/modules/utilities/overlays/inventories/RarityColorOverlay.java
+++ b/src/main/java/cf/wynntils/modules/utilities/overlays/inventories/RarityColorOverlay.java
@@ -524,7 +524,7 @@ public class RarityColorOverlay implements Listener {
     }
 
     private boolean isPowder(ItemStack is) {
-        return (is.hasDisplayName() && is.getDisplayName().contains("Powder"));
+        return (is.hasDisplayName() && is.getDisplayName().contains("Powder") && Utils.stripColor(Utils.getStringLore(is)).contains("Effect on Weapons"));
     }
 
     private int getPowderTier(ItemStack is) {


### PR DESCRIPTION
Four bugs fixed:

- When quest that can be started is tracked, opening the quest book would untrack that quest
- Quests that can't be started could be tracked
- When the powder highlight setting was set to minimum tier 1, items such as [creeper powder](https://wynncraft.gamepedia.com/Creeper_Powder) and [blaze powder](https://wynncraft.gamepedia.com/Blaze_Powder) would be highlighted.
- VIP+ login messages would appear in the guild chat tab