### PR TITLE
Implement a game update "ticker"

### DIFF
--- a/src/main/java/cf/wynntils/modules/music/instances/MusicPlayer.java
+++ b/src/main/java/cf/wynntils/modules/music/instances/MusicPlayer.java
@@ -7,6 +7,8 @@ package cf.wynntils.modules.music.instances;
 import cf.wynntils.modules.music.configs.MusicConfig;
 import cf.wynntils.modules.music.managers.MusicManager;
 import cf.wynntils.modules.richpresence.RichPresenceModule;
+import cf.wynntils.modules.utilities.configs.OverlayConfig;
+import cf.wynntils.modules.utilities.overlays.hud.GameUpdateOverlay;
 import javazoom.jl.player.JavaSoundAudioDevice;
 import javazoom.jl.player.advanced.AdvancedPlayer;
 import javazoom.jl.player.advanced.PlaybackEvent;
@@ -32,6 +34,11 @@ public class MusicPlayer {
     public void play(File f) {
         if(currentMusic != null && currentMusic.getName().equalsIgnoreCase(f.getName())) return;
 
+        // Queue the music change to the game update ticker
+        if (OverlayConfig.GameUpdate.INSTANCE.enabled && OverlayConfig.GameUpdate.TerritoryChangeMessages.INSTANCE.musicChange) {
+            GameUpdateOverlay.queueMessage(OverlayConfig.GameUpdate.TerritoryChangeMessages.INSTANCE.musicChangeFormat
+                    .replace("%np%", f.getName().replace(".mp3", "")));
+        }
         nextMusic = f;
         setupController();
     }

--- a/src/main/java/cf/wynntils/modules/utilities/UtilitiesModule.java
+++ b/src/main/java/cf/wynntils/modules/utilities/UtilitiesModule.java
@@ -47,6 +47,7 @@ public class UtilitiesModule extends Module {
         registerOverlay(new ExpBarOverlay(), Priority.NORMAL);
         registerOverlay(new LevelingOverlay(), Priority.LOW);
         registerOverlay(new BubblesOverlay(), Priority.HIGHEST);
+        registerOverlay(new GameUpdateOverlay(), Priority.LOW);
 
         registerOverlay(new GammaOverlay(), Priority.NORMAL);
         registerOverlay(new LobbyCleanerOverlay(), Priority.LOW);
@@ -64,6 +65,11 @@ public class UtilitiesModule extends Module {
         registerSettings(OverlayConfig.Mana.class);
         registerSettings(OverlayConfig.WarTimer.class);
         registerSettings(OverlayConfig.Bubbles.class);
+        registerSettings(OverlayConfig.GameUpdate.class);
+        registerSettings(OverlayConfig.GameUpdate.GameUpdateEXPMessages.class);
+        registerSettings(OverlayConfig.GameUpdate.LevelupMessages.class);
+        registerSettings(OverlayConfig.GameUpdate.RedirectSystemMessages.class);
+        registerSettings(OverlayConfig.GameUpdate.TerritoryChangeMessages.class);
     }
 
     public static UtilitiesModule getModule() {

--- a/src/main/java/cf/wynntils/modules/utilities/UtilitiesModule.java
+++ b/src/main/java/cf/wynntils/modules/utilities/UtilitiesModule.java
@@ -67,7 +67,6 @@ public class UtilitiesModule extends Module {
         registerSettings(OverlayConfig.Bubbles.class);
         registerSettings(OverlayConfig.GameUpdate.class);
         registerSettings(OverlayConfig.GameUpdate.GameUpdateEXPMessages.class);
-        registerSettings(OverlayConfig.GameUpdate.LevelupMessages.class);
         registerSettings(OverlayConfig.GameUpdate.RedirectSystemMessages.class);
         registerSettings(OverlayConfig.GameUpdate.TerritoryChangeMessages.class);
     }

--- a/src/main/java/cf/wynntils/modules/utilities/configs/OverlayConfig.java
+++ b/src/main/java/cf/wynntils/modules/utilities/configs/OverlayConfig.java
@@ -154,6 +154,9 @@ public class OverlayConfig extends SettingsClass {
     public static class GameUpdate extends SettingsClass {
         public static GameUpdate INSTANCE;
 
+        // Default settings designed for large gui scale @ 1080p
+        // I personally use gui scale normal - but this works fine with that too
+
         @Setting(displayName = "Message Limit", description = "The maximum amount of ticker messages to display in the game update list")
         @Setting.Limitations.IntLimit(min = 1, max = 20)
         public int messageLimit = 5;
@@ -169,17 +172,16 @@ public class OverlayConfig extends SettingsClass {
         public boolean enabled = true;
 
         @Setting(displayName = "Offset X", description = "How far the ticker should be offset on the X axis")
-        @Setting.Limitations.IntLimit(min = -200, max = 10)
+        @Setting.Limitations.IntLimit(min = -300, max = 10)
         public int offsetX = 0;
 
         @Setting(displayName = "Offset Y", description = "How far the ticker should be offset on the Y axis")
-        @Setting.Limitations.IntLimit(min = -200, max = 10)
-        public int offsetY = 0;
+        @Setting.Limitations.IntLimit(min = -300, max = 10)
+        public int offsetY = -70;
 
         @Setting(displayName = "Max message length", description = "The maximum length of messages in the game update ticker. Messages longer than this value will be truncated. (0 = unlimited)")
         @Setting.Limitations.IntLimit(min = 0, max = 100)
-        // Default setting works for large gui scale @ 1080p
-        public int messageMaxLength = 45;
+        public int messageMaxLength = 0;
 
         @Setting(displayName = "Text Shadow", description = "The text shadow type")
         public SmartFontRenderer.TextShadow textShadow = SmartFontRenderer.TextShadow.OUTLINE;

--- a/src/main/java/cf/wynntils/modules/utilities/configs/OverlayConfig.java
+++ b/src/main/java/cf/wynntils/modules/utilities/configs/OverlayConfig.java
@@ -165,8 +165,21 @@ public class OverlayConfig extends SettingsClass {
         @Setting(displayName = "Invert Growth", description = "Invert the way that the ticker messages grow")
         public boolean invertGrowth = false;
 
-        @Setting(displayName = "Enabled", description = "Should game updates be displayed")
+        @Setting(displayName = "Enabled", description = "Should the game update ticker be displayed")
         public boolean enabled = true;
+
+        @Setting(displayName = "Offset X", description = "How far the ticker should be offset on the X axis")
+        @Setting.Limitations.IntLimit(min = -200, max = 10)
+        public int offsetX = 0;
+
+        @Setting(displayName = "Offset Y", description = "How far the ticker should be offset on the Y axis")
+        @Setting.Limitations.IntLimit(min = -200, max = 10)
+        public int offsetY = 0;
+
+        @Setting(displayName = "Max message length", description = "The maximum length of messages in the game update ticker. Messages longer than this value will be truncated. (0 = unlimited)")
+        @Setting.Limitations.IntLimit(min = 0, max = 100)
+        // Default setting works for large gui scale @ 1080p
+        public int messageMaxLength = 45;
 
         @Setting(displayName = "Text Shadow", description = "The text shadow type")
         public SmartFontRenderer.TextShadow textShadow = SmartFontRenderer.TextShadow.OUTLINE;

--- a/src/main/java/cf/wynntils/modules/utilities/configs/OverlayConfig.java
+++ b/src/main/java/cf/wynntils/modules/utilities/configs/OverlayConfig.java
@@ -28,7 +28,7 @@ public class OverlayConfig extends SettingsClass {
         public boolean enabled = true;
 
         @Setting.Limitations.FloatLimit(min = 0f, max = 10f)
-        @Setting(displayName = "Animation Speed", description = "How fast should the bar changes happen(0 for instant)")
+        @Setting(displayName = "Animation Speed", description = "How fast should the bar changes happen (0 for instant)")
         public float animated = 2f;
 
         @Setting(displayName = "Text Shadow", description = "The HUD Text shadow type")
@@ -149,7 +149,108 @@ public class OverlayConfig extends SettingsClass {
 
 
     }
-    
+
+    @SettingsInfo(name = "game_update_settings", displayPath = "Overlays/Update Ticker")
+    public static class GameUpdate extends SettingsClass {
+        public static GameUpdate INSTANCE;
+
+        @Setting(displayName = "Message Limit", description = "The maximum amount of ticker messages to display in the game update list")
+        @Setting.Limitations.IntLimit(min = 1, max = 20)
+        public int messageLimit = 5;
+
+        @Setting(displayName = "Message Expire Time", description = "The amount of time (in seconds) that a ticker message will remain on-screen")
+        @Setting.Limitations.FloatLimit(min = 0.2f, max = 20f, precision = 0.2f)
+        public float messageTimeLimit = 10f;
+
+        @Setting(displayName = "Invert Growth", description = "Invert the way that the ticker messages grow")
+        public boolean invertGrowth = false;
+
+        @Setting(displayName = "Enabled", description = "Should game updates be displayed")
+        public boolean enabled = true;
+
+        @Setting(displayName = "Text Shadow", description = "The text shadow type")
+        public SmartFontRenderer.TextShadow textShadow = SmartFontRenderer.TextShadow.OUTLINE;
+
+        @Setting(displayName = "New message override", description = "Should new messages force out the oldest previous ones. If disabled, ticker messages will be queued and appear when a previous message disappears.")
+        public boolean overrideNewMessages = true;
+
+        @SettingsInfo(name = "game_update_exp_settings", displayPath = "Overlays/Update Ticker/Experience")
+        public static class GameUpdateEXPMessages extends SettingsClass {
+            public static GameUpdateEXPMessages INSTANCE;
+
+            @Setting(displayName = "Enable EXP messages", description = "Should EXP messages be displayed in the game update ticker")
+            public boolean enabled = false;
+
+            @Setting(displayName = "EXP message update rate", description = "How often EXP change messages (in seconds) should be added to the game update ticker")
+            @Setting.Limitations.FloatLimit(min = 0.2f, max = 10f, precision = 0.2f)
+            public float expUpdateRate = 1f;
+
+            @Setting(displayName = "EXP message format", description = "The format of EXP messages")
+            @Setting.Features.StringParameters(parameters = {"xo", "xn", "xc", "po", "pn", "pc"})
+            @Setting.Limitations.StringLimit(maxLength = 100)
+            public String expMessageFormat = "§2+%xc%XP (§6+%pc%%§2)";
+        }
+
+        @SettingsInfo(name = "game_update_level_settings", displayPath = "Overlays/Update Ticker/Levelups")
+        public static class LevelupMessages extends SettingsClass {
+            public static LevelupMessages INSTANCE;
+
+            @Setting(displayName = "Enable levelup messages", description = "Should levelup messages be displayed in the game update ticker")
+            public boolean enabled = false;
+
+            @Setting(displayName = "Levelup message format", description = "The format of levelup ticker")
+            @Setting.Features.StringParameters(parameters = {"ol", "nl"})
+            @Setting.Limitations.StringLimit(maxLength = 100)
+            public String lvlupMessageFormat = "§5Level Up! [§d%ol%§5>§d%nl%§5]";
+        }
+
+        @SettingsInfo(name = "game_update_redirect_settings", displayPath = "Overlays/Update Ticker/Redirect Messages")
+        public static class RedirectSystemMessages extends SettingsClass {
+            public static RedirectSystemMessages INSTANCE;
+
+            @Setting(displayName = "Redirect combat messages", description = "Should combat chat messages be redirected to game update ticker")
+            public boolean redirectCombat = true;
+
+            @Setting(displayName = "Redirect horse messages", description = "Should messages related to the horse be redirected game update ticker")
+            public boolean redirectHorse = true;
+
+            @Setting(displayName = "Redirect login messages", description = "Should local login messages (for people with ranks) be redirected to the game update ticker")
+            public boolean redirectLogin = true;
+
+            @Setting(displayName = "Redirect merchant messages", description = "Should item buyer & identifier messages be redirected to the game update ticker")
+            public boolean redirectMerchants = false;
+
+            @Setting(displayName = "Redirect other messages", description = "Should skill point; other user level up; and identification required messages be redirected to the game update ticker")
+            public boolean redirectOther = true;
+
+            @Setting(displayName = "Redirect server status", description = "Should server shutdown messages be redirected to the game update ticker")
+            public boolean redirectServer = false;
+        }
+
+        @SettingsInfo(name = "game_update_territory_settings", displayPath = "Overlays/Update Ticker/Territory Change")
+        public static class TerritoryChangeMessages extends SettingsClass {
+            public static TerritoryChangeMessages INSTANCE;
+
+            @Setting(displayName = "Enable territory change", description = "Should territory change messages be displayed in the game update ticker")
+            public boolean enabled = false;
+
+            @Setting(displayName = "Enable territory enter", description = "Should territory enter messages be displayed in the game update ticker")
+            public boolean enter = true;
+
+            @Setting(displayName = "Enable territory leave", description = "Should territory leave messages be displayed in the game update ticker")
+            public boolean leave = true;
+
+            @Setting(displayName = "Territory enter format", description = "The format of territory enter ticker messages")
+            @Setting.Features.StringParameters(parameters = {"t"})
+            @Setting.Limitations.StringLimit(maxLength = 100)
+            public String territoryEnterFormat = "§7Now Entering [%t%]";
+
+            @Setting(displayName = "Territory leave format", description = "The format of territory leave ticker messages")
+            @Setting.Features.StringParameters(parameters = {"t"})
+            @Setting.Limitations.StringLimit(maxLength = 100)
+            public String territoryLeaveFormat = "§7Now Leaving [%t%]";
+        }
+    }
     
     @SettingsInfo(name = "war_timer_settings", displayPath = "Overlays/War Timer")
     public static class WarTimer extends SettingsClass {

--- a/src/main/java/cf/wynntils/modules/utilities/configs/OverlayConfig.java
+++ b/src/main/java/cf/wynntils/modules/utilities/configs/OverlayConfig.java
@@ -191,40 +191,33 @@ public class OverlayConfig extends SettingsClass {
             public String expMessageFormat = "§2+%xc%XP (§6+%pc%%§2)";
         }
 
-        @SettingsInfo(name = "game_update_level_settings", displayPath = "Overlays/Update Ticker/Levelups")
-        public static class LevelupMessages extends SettingsClass {
-            public static LevelupMessages INSTANCE;
-
-            @Setting(displayName = "Enable levelup messages", description = "Should levelup messages be displayed in the game update ticker")
-            public boolean enabled = false;
-
-            @Setting(displayName = "Levelup message format", description = "The format of levelup ticker")
-            @Setting.Features.StringParameters(parameters = {"ol", "nl"})
-            @Setting.Limitations.StringLimit(maxLength = 100)
-            public String lvlupMessageFormat = "§5Level Up! [§d%ol%§5>§d%nl%§5]";
-        }
-
         @SettingsInfo(name = "game_update_redirect_settings", displayPath = "Overlays/Update Ticker/Redirect Messages")
         public static class RedirectSystemMessages extends SettingsClass {
             public static RedirectSystemMessages INSTANCE;
 
             @Setting(displayName = "Redirect combat messages", description = "Should combat chat messages be redirected to game update ticker")
-            public boolean redirectCombat = true;
+            public boolean redirectCombat = false;
 
             @Setting(displayName = "Redirect horse messages", description = "Should messages related to the horse be redirected game update ticker")
-            public boolean redirectHorse = true;
+            public boolean redirectHorse = false;
 
-            @Setting(displayName = "Redirect login messages", description = "Should local login messages (for people with ranks) be redirected to the game update ticker")
-            public boolean redirectLogin = true;
+            @Setting(displayName = "Redirect local login messages", description = "Should local login messages (for people with ranks) be redirected to the game update ticker")
+            public boolean redirectLoginLocal = false;
+
+            @Setting(displayName = "Redirect friend login messages", description = "Should login messages for friends by redirected to the game update ticker")
+            public boolean redirectLoginFriend = false;
 
             @Setting(displayName = "Redirect merchant messages", description = "Should item buyer & identifier messages be redirected to the game update ticker")
             public boolean redirectMerchants = false;
 
             @Setting(displayName = "Redirect other messages", description = "Should skill point; other user level up; and identification required messages be redirected to the game update ticker")
-            public boolean redirectOther = true;
+            public boolean redirectOther = false;
 
             @Setting(displayName = "Redirect server status", description = "Should server shutdown messages be redirected to the game update ticker")
             public boolean redirectServer = false;
+
+            @Setting(displayName = "Redirect quest messages", description = "Redirect quest started and questbook updated messages to the game update ticker")
+            public boolean redirectQuest = false;
         }
 
         @SettingsInfo(name = "game_update_territory_settings", displayPath = "Overlays/Update Ticker/Territory Change")
@@ -238,7 +231,10 @@ public class OverlayConfig extends SettingsClass {
             public boolean enter = true;
 
             @Setting(displayName = "Enable territory leave", description = "Should territory leave messages be displayed in the game update ticker")
-            public boolean leave = true;
+            public boolean leave = false;
+
+            @Setting(displayName = "Enable music change", description = "Should music change messages be displayed in the game update ticker (no effect if the music module is disabled)")
+            public boolean musicChange = false;
 
             @Setting(displayName = "Territory enter format", description = "The format of territory enter ticker messages")
             @Setting.Features.StringParameters(parameters = {"t"})
@@ -249,6 +245,11 @@ public class OverlayConfig extends SettingsClass {
             @Setting.Features.StringParameters(parameters = {"t"})
             @Setting.Limitations.StringLimit(maxLength = 100)
             public String territoryLeaveFormat = "§7Now Leaving [%t%]";
+
+            @Setting(displayName = "Music change format", description = "The format of music change ticker messages")
+            @Setting.Features.StringParameters(parameters = {"np"})
+            @Setting.Limitations.StringLimit(maxLength = 100)
+            public String musicChangeFormat = "§7♫ %np%";
         }
     }
     

--- a/src/main/java/cf/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/cf/wynntils/modules/utilities/events/ClientEvents.java
@@ -4,14 +4,18 @@ import cf.wynntils.ModCore;
 import cf.wynntils.Reference;
 import cf.wynntils.core.events.custom.GuiOverlapEvent;
 import cf.wynntils.core.events.custom.PacketEvent;
+import cf.wynntils.core.events.custom.WynnClassChangeEvent;
+import cf.wynntils.core.events.custom.WynnTerritoryChangeEvent;
 import cf.wynntils.core.framework.instances.PlayerInfo;
 import cf.wynntils.core.framework.interfaces.Listener;
 import cf.wynntils.modules.utilities.UtilitiesModule;
+import cf.wynntils.modules.utilities.configs.OverlayConfig;
 import cf.wynntils.modules.utilities.configs.UtilitiesConfig;
 import cf.wynntils.modules.utilities.managers.DailyReminderManager;
 import cf.wynntils.modules.utilities.managers.KeyManager;
 import cf.wynntils.modules.utilities.managers.NametagManager;
 import cf.wynntils.modules.utilities.managers.TPSManager;
+import cf.wynntils.modules.utilities.overlays.hud.GameUpdateOverlay;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.audio.PositionedSoundRecord;
 import net.minecraft.init.SoundEvents;
@@ -25,6 +29,7 @@ import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
 
+import java.text.DecimalFormat;
 import java.util.HashSet;
 
 /**
@@ -33,11 +38,55 @@ import java.util.HashSet;
  */
 public class ClientEvents implements Listener {
 
+    /* XP Gain Messages */
+    public static int oldxp = 0;
+    public static String oldxppercent = "0.0";
+    public static int oldlevel = 0;
+    public static int xpticks = 0;
+
     @SubscribeEvent
     public void clientTick(TickEvent.ClientTickEvent e) {
-        if(Reference.onWorld) {
-            TPSManager.updateTPS();
-            DailyReminderManager.checkDailyReminder(ModCore.mc().player);
+        if(!Reference.onWorld)
+            return;
+        TPSManager.updateTPS();
+        DailyReminderManager.checkDailyReminder(ModCore.mc().player);
+
+        if (OverlayConfig.GameUpdate.INSTANCE.enabled) {
+            /* XP Gain Messages */
+            if (OverlayConfig.GameUpdate.GameUpdateEXPMessages.INSTANCE.enabled) {
+                if (xpticks == 0) {
+                    if (oldxp != PlayerInfo.getPlayerInfo().getCurrentXP()) {
+                        if (!PlayerInfo.getPlayerInfo().getCurrentXPAsPercentage().equals("")) {
+                            if (oldxp < PlayerInfo.getPlayerInfo().getCurrentXP()) {
+                                DecimalFormat df = new DecimalFormat("0.0");
+                                float xpchange = Float.valueOf(PlayerInfo.getPlayerInfo().getCurrentXPAsPercentage()) - Float.valueOf(oldxppercent);
+                                GameUpdateOverlay.queueMessage(OverlayConfig.GameUpdate.GameUpdateEXPMessages.INSTANCE.expMessageFormat
+                                        .replace("%xo%", Integer.toString(oldxp))
+                                        .replace("%xn%", Integer.toString(PlayerInfo.getPlayerInfo().getCurrentXP()))
+                                        .replace("%xc%", Integer.toString(PlayerInfo.getPlayerInfo().getCurrentXP() - oldxp))
+                                        .replace("%po%", oldxppercent)
+                                        .replace("%pn%", PlayerInfo.getPlayerInfo().getCurrentXPAsPercentage())
+                                        .replace("%pc%", df.format(xpchange)));
+                            }
+                            oldxp = PlayerInfo.getPlayerInfo().getCurrentXP();
+                            oldxppercent = PlayerInfo.getPlayerInfo().getCurrentXPAsPercentage();
+                        }
+                    }
+                    xpticks = (int) (OverlayConfig.GameUpdate.GameUpdateEXPMessages.INSTANCE.expUpdateRate * 20f);
+                } else {
+                    xpticks--;
+                }
+            }
+
+            /* Levelup Messages */
+            if (OverlayConfig.GameUpdate.LevelupMessages.INSTANCE.enabled) {
+                if (oldlevel < PlayerInfo.getPlayerInfo().getLevel()) {
+                    GameUpdateOverlay.queueMessage(OverlayConfig.GameUpdate.LevelupMessages.INSTANCE.lvlupMessageFormat
+                            .replace("%ol%", Integer.toString(oldlevel))
+                            .replace("%nl%", Integer.toString(PlayerInfo.getPlayerInfo().getLevel())));
+                    oldlevel = PlayerInfo.getPlayerInfo().getLevel();
+                }
+            }
         }
     }
 
@@ -165,9 +214,85 @@ public class ClientEvents implements Listener {
             e.setCanceled(true);
     }
 
+    @SubscribeEvent
+    public void onClassChange(WynnClassChangeEvent e) {
+        GameUpdateOverlay.resetMessages();
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOW)
+    public void onChatToRedirect(ClientChatReceivedEvent e) {
+        if (!Reference.onWorld || !OverlayConfig.GameUpdate.INSTANCE.enabled || e.getType() == ChatType.GAME_INFO)
+            return;
+        if (OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectHorse) {
+            if (e.getMessage().getUnformattedText().contains("There is no room for a horse.")) {
+                GameUpdateOverlay.queueMessage("§4There is no room for a horse.");
+                e.setCanceled(true);
+                return;
+            } else if (e.getMessage().getUnformattedText().contains("Since you interacted with your inventory, your horse has despawned.")) {
+                GameUpdateOverlay.queueMessage("§dHorse despawned.");
+                e.setCanceled(true);
+                return;
+            }
+        }
+        if (OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectCombat) {
+            if (e.getMessage().getUnformattedText().contains("You don't have enough mana to do that spell!")) {
+                GameUpdateOverlay.queueMessage("§4Not enough mana.");
+                e.setCanceled(true);
+                return;
+            } else if (e.getMessage().getUnformattedText().contains("You have not unlocked this spell!")) {
+                GameUpdateOverlay.queueMessage("§4Spell not unlocked.");
+                e.setCanceled(true);
+                return;
+            } else if (e.getMessage().getUnformattedText().contains("Sorry, you can't teleport... Try moving away from blocks.")) {
+                GameUpdateOverlay.queueMessage("§4Can't teleport - move away from blocks.");
+                e.setCanceled(true);
+                return;
+            }
+        }
+        if (OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectOther) {
+            if (e.getMessage().getUnformattedText().contains(" unused skill points! Click with your compass to use them!")) {
+                String[] res = e.getMessage().getUnformattedText().split(" ");
+                GameUpdateOverlay.queueMessage("§e" + res[3] + " §6skill points available.");
+                e.setCanceled(true);
+                return;
+            } else if (e.getMessage().getUnformattedText().contains(" is now level ")) {
+                String[] res = e.getMessage().getUnformattedText().split(" ");
+                GameUpdateOverlay.queueMessage("§e" + res[0] + " §6is now level §e" + res[4]);
+                e.setCanceled(true);
+                return;
+            } else if (e.getMessage().getUnformattedText().contains("You must identify this item before using it.")) {
+                GameUpdateOverlay.queueMessage("§4Item not identified.");
+                e.setCanceled(true);
+                return;
+            }
+        }
+        if (OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectServer) {
+            if (e.getMessage().getUnformattedText().contains("The server is restarting in ")) {
+                String[] res = e.getMessage().getUnformattedText().split(" ");
+                GameUpdateOverlay.queueMessage("§4" + res[5] + " " + res[6].replace(".", "") + " until server restart");
+                e.setCanceled(true);
+                return;
+            }
+        }
+    }
+
+    @SubscribeEvent
+    public void onWynnTerritoyChange(WynnTerritoryChangeEvent e) {
+        if (OverlayConfig.GameUpdate.TerritoryChangeMessages.INSTANCE.enabled) {
+            if (OverlayConfig.GameUpdate.TerritoryChangeMessages.INSTANCE.leave && !e.getOldTerritory().equals("Waiting")) {
+                GameUpdateOverlay.queueMessage(OverlayConfig.GameUpdate.TerritoryChangeMessages.INSTANCE.territoryLeaveFormat
+                        .replace("%t%", e.getOldTerritory()));
+            }
+            if (OverlayConfig.GameUpdate.TerritoryChangeMessages.INSTANCE.enter && !e.getNewTerritory().equals("Waiting")) {
+                GameUpdateOverlay.queueMessage(OverlayConfig.GameUpdate.TerritoryChangeMessages.INSTANCE.territoryEnterFormat
+                        .replace("%t%", e.getNewTerritory()));
+            }
+        }
+    }
+
     private boolean checkDropState(int slot, int key) {
         if(!Reference.onWorld) return false;
-        
+
         if(key == Minecraft.getMinecraft().gameSettings.keyBindDrop.getKeyCode()) {
             if(!UtilitiesConfig.INSTANCE.locked_slots.containsKey(PlayerInfo.getPlayerInfo().getClassId())) return false;
 

--- a/src/main/java/cf/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/cf/wynntils/modules/utilities/events/ClientEvents.java
@@ -4,18 +4,14 @@ import cf.wynntils.ModCore;
 import cf.wynntils.Reference;
 import cf.wynntils.core.events.custom.GuiOverlapEvent;
 import cf.wynntils.core.events.custom.PacketEvent;
-import cf.wynntils.core.events.custom.WynnClassChangeEvent;
-import cf.wynntils.core.events.custom.WynnTerritoryChangeEvent;
 import cf.wynntils.core.framework.instances.PlayerInfo;
 import cf.wynntils.core.framework.interfaces.Listener;
 import cf.wynntils.modules.utilities.UtilitiesModule;
-import cf.wynntils.modules.utilities.configs.OverlayConfig;
 import cf.wynntils.modules.utilities.configs.UtilitiesConfig;
 import cf.wynntils.modules.utilities.managers.DailyReminderManager;
 import cf.wynntils.modules.utilities.managers.KeyManager;
 import cf.wynntils.modules.utilities.managers.NametagManager;
 import cf.wynntils.modules.utilities.managers.TPSManager;
-import cf.wynntils.modules.utilities.overlays.hud.GameUpdateOverlay;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.audio.PositionedSoundRecord;
 import net.minecraft.init.SoundEvents;
@@ -29,7 +25,6 @@ import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
 
-import java.text.DecimalFormat;
 import java.util.HashSet;
 
 /**
@@ -38,56 +33,12 @@ import java.util.HashSet;
  */
 public class ClientEvents implements Listener {
 
-    /* XP Gain Messages */
-    public static int oldxp = 0;
-    public static String oldxppercent = "0.0";
-    public static int oldlevel = 0;
-    public static int xpticks = 0;
-
     @SubscribeEvent
     public void clientTick(TickEvent.ClientTickEvent e) {
         if(!Reference.onWorld)
             return;
         TPSManager.updateTPS();
         DailyReminderManager.checkDailyReminder(ModCore.mc().player);
-
-        if (OverlayConfig.GameUpdate.INSTANCE.enabled) {
-            /* XP Gain Messages */
-            if (OverlayConfig.GameUpdate.GameUpdateEXPMessages.INSTANCE.enabled) {
-                if (xpticks == 0) {
-                    if (oldxp != PlayerInfo.getPlayerInfo().getCurrentXP()) {
-                        if (!PlayerInfo.getPlayerInfo().getCurrentXPAsPercentage().equals("")) {
-                            if (oldxp < PlayerInfo.getPlayerInfo().getCurrentXP()) {
-                                DecimalFormat df = new DecimalFormat("0.0");
-                                float xpchange = Float.valueOf(PlayerInfo.getPlayerInfo().getCurrentXPAsPercentage()) - Float.valueOf(oldxppercent);
-                                GameUpdateOverlay.queueMessage(OverlayConfig.GameUpdate.GameUpdateEXPMessages.INSTANCE.expMessageFormat
-                                        .replace("%xo%", Integer.toString(oldxp))
-                                        .replace("%xn%", Integer.toString(PlayerInfo.getPlayerInfo().getCurrentXP()))
-                                        .replace("%xc%", Integer.toString(PlayerInfo.getPlayerInfo().getCurrentXP() - oldxp))
-                                        .replace("%po%", oldxppercent)
-                                        .replace("%pn%", PlayerInfo.getPlayerInfo().getCurrentXPAsPercentage())
-                                        .replace("%pc%", df.format(xpchange)));
-                            }
-                            oldxp = PlayerInfo.getPlayerInfo().getCurrentXP();
-                            oldxppercent = PlayerInfo.getPlayerInfo().getCurrentXPAsPercentage();
-                        }
-                    }
-                    xpticks = (int) (OverlayConfig.GameUpdate.GameUpdateEXPMessages.INSTANCE.expUpdateRate * 20f);
-                } else {
-                    xpticks--;
-                }
-            }
-
-            /* Levelup Messages */
-            if (OverlayConfig.GameUpdate.LevelupMessages.INSTANCE.enabled) {
-                if (oldlevel < PlayerInfo.getPlayerInfo().getLevel()) {
-                    GameUpdateOverlay.queueMessage(OverlayConfig.GameUpdate.LevelupMessages.INSTANCE.lvlupMessageFormat
-                            .replace("%ol%", Integer.toString(oldlevel))
-                            .replace("%nl%", Integer.toString(PlayerInfo.getPlayerInfo().getLevel())));
-                    oldlevel = PlayerInfo.getPlayerInfo().getLevel();
-                }
-            }
-        }
     }
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
@@ -212,82 +163,6 @@ public class ClientEvents implements Listener {
 
         if(UtilitiesConfig.INSTANCE.locked_slots.get(PlayerInfo.getPlayerInfo().getClassId()).contains(Minecraft.getMinecraft().player.inventory.currentItem))
             e.setCanceled(true);
-    }
-
-    @SubscribeEvent
-    public void onClassChange(WynnClassChangeEvent e) {
-        GameUpdateOverlay.resetMessages();
-    }
-
-    @SubscribeEvent(priority = EventPriority.LOW)
-    public void onChatToRedirect(ClientChatReceivedEvent e) {
-        if (!Reference.onWorld || !OverlayConfig.GameUpdate.INSTANCE.enabled || e.getType() == ChatType.GAME_INFO)
-            return;
-        if (OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectHorse) {
-            if (e.getMessage().getUnformattedText().contains("There is no room for a horse.")) {
-                GameUpdateOverlay.queueMessage("§4There is no room for a horse.");
-                e.setCanceled(true);
-                return;
-            } else if (e.getMessage().getUnformattedText().contains("Since you interacted with your inventory, your horse has despawned.")) {
-                GameUpdateOverlay.queueMessage("§dHorse despawned.");
-                e.setCanceled(true);
-                return;
-            }
-        }
-        if (OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectCombat) {
-            if (e.getMessage().getUnformattedText().contains("You don't have enough mana to do that spell!")) {
-                GameUpdateOverlay.queueMessage("§4Not enough mana.");
-                e.setCanceled(true);
-                return;
-            } else if (e.getMessage().getUnformattedText().contains("You have not unlocked this spell!")) {
-                GameUpdateOverlay.queueMessage("§4Spell not unlocked.");
-                e.setCanceled(true);
-                return;
-            } else if (e.getMessage().getUnformattedText().contains("Sorry, you can't teleport... Try moving away from blocks.")) {
-                GameUpdateOverlay.queueMessage("§4Can't teleport - move away from blocks.");
-                e.setCanceled(true);
-                return;
-            }
-        }
-        if (OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectOther) {
-            if (e.getMessage().getUnformattedText().contains(" unused skill points! Click with your compass to use them!")) {
-                String[] res = e.getMessage().getUnformattedText().split(" ");
-                GameUpdateOverlay.queueMessage("§e" + res[3] + " §6skill points available.");
-                e.setCanceled(true);
-                return;
-            } else if (e.getMessage().getUnformattedText().contains(" is now level ")) {
-                String[] res = e.getMessage().getUnformattedText().split(" ");
-                GameUpdateOverlay.queueMessage("§e" + res[0] + " §6is now level §e" + res[4]);
-                e.setCanceled(true);
-                return;
-            } else if (e.getMessage().getUnformattedText().contains("You must identify this item before using it.")) {
-                GameUpdateOverlay.queueMessage("§4Item not identified.");
-                e.setCanceled(true);
-                return;
-            }
-        }
-        if (OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectServer) {
-            if (e.getMessage().getUnformattedText().contains("The server is restarting in ")) {
-                String[] res = e.getMessage().getUnformattedText().split(" ");
-                GameUpdateOverlay.queueMessage("§4" + res[5] + " " + res[6].replace(".", "") + " until server restart");
-                e.setCanceled(true);
-                return;
-            }
-        }
-    }
-
-    @SubscribeEvent
-    public void onWynnTerritoyChange(WynnTerritoryChangeEvent e) {
-        if (OverlayConfig.GameUpdate.TerritoryChangeMessages.INSTANCE.enabled) {
-            if (OverlayConfig.GameUpdate.TerritoryChangeMessages.INSTANCE.leave && !e.getOldTerritory().equals("Waiting")) {
-                GameUpdateOverlay.queueMessage(OverlayConfig.GameUpdate.TerritoryChangeMessages.INSTANCE.territoryLeaveFormat
-                        .replace("%t%", e.getOldTerritory()));
-            }
-            if (OverlayConfig.GameUpdate.TerritoryChangeMessages.INSTANCE.enter && !e.getNewTerritory().equals("Waiting")) {
-                GameUpdateOverlay.queueMessage(OverlayConfig.GameUpdate.TerritoryChangeMessages.INSTANCE.territoryEnterFormat
-                        .replace("%t%", e.getNewTerritory()));
-            }
-        }
     }
 
     private boolean checkDropState(int slot, int key) {

--- a/src/main/java/cf/wynntils/modules/utilities/overlays/OverlayEvents.java
+++ b/src/main/java/cf/wynntils/modules/utilities/overlays/OverlayEvents.java
@@ -136,7 +136,7 @@ public class OverlayEvents implements Listener {
                 return;
             } else if (Utils.stripColor(e.getMessage().getFormattedText()).matches(".+ gave you \\[\\+\\d+ ❤\\]")) {
                 String[] res = e.getMessage().getFormattedText().split(" ");
-                GameUpdateOverlay.queueMessage("§4" + res[3].substring(2) + " ❤] §7(§b" + res[0] + "§7)");
+                GameUpdateOverlay.queueMessage("§4" + res[3].substring(2) + " ❤] §7(§b" + res[0].replace("§r", "") + "§7)");
                 e.setCanceled(true);
                 return;
             } else if (Utils.stripColor(e.getMessage().getFormattedText()).matches("\\[\\+\\d+ ❤\\] Cleared all potion effects\\.")) {
@@ -146,8 +146,8 @@ public class OverlayEvents implements Listener {
                 return;
             } else if (Utils.stripColor(e.getMessage().getFormattedText()).matches(".+ gave you \\[\\+\\d+ ❤\\] Cleared all potion effects\\.")) {
                 String[] res = e.getMessage().getFormattedText().split(" ");
-                GameUpdateOverlay.queueMessage("§4" + res[3].substring(2) + " ❤] §7(§b" + res[0] + "§7)");
-                GameUpdateOverlay.queueMessage("§bCleared §7all potion effects (§b" + res[0] + "§7)");
+                GameUpdateOverlay.queueMessage("§4" + res[3].substring(2) + " ❤] §7(§b" + res[0].replace("§r", "") + "§7)");
+                GameUpdateOverlay.queueMessage("§bCleared §7all potion effects (§b" + res[0].replace("§r", "") + "§7)");
                 e.setCanceled(true);
                 return;
             } else if (Utils.stripColor(e.getMessage().getFormattedText()).matches("\\[\\+\\d+ ❤\\] Cleared all potion effects Removed all fire\\.")) {
@@ -158,9 +158,9 @@ public class OverlayEvents implements Listener {
                 return;
             } else if (Utils.stripColor(e.getMessage().getFormattedText()).matches(".+ gave you \\[\\+\\d+ ❤\\] Cleared all potion effects Removed all fire\\.")) {
                 String[] res = e.getMessage().getFormattedText().split(" ");
-                GameUpdateOverlay.queueMessage("§4" + res[3].substring(2) + " ❤] §7(§b" + res[0] + "§7)");
-                GameUpdateOverlay.queueMessage("§bCleared §7all potion effects (§b" + res[0] + "§7)");
-                GameUpdateOverlay.queueMessage("§bRemoved §7all fire (§b" + res[0] + "§7)");
+                GameUpdateOverlay.queueMessage("§4" + res[3].substring(2) + " ❤] §7(§b" + res[0].replace("§r", "") + "§7)");
+                GameUpdateOverlay.queueMessage("§bCleared §7all potion effects (§b" + res[0].replace("§r", "") + "§7)");
+                GameUpdateOverlay.queueMessage("§bRemoved §7all fire (§b" + res[0].replace("§r", "") + "§7)");
                 e.setCanceled(true);
                 return;
             // ARCHER
@@ -169,7 +169,7 @@ public class OverlayEvents implements Listener {
                 e.setCanceled(true);
                 return;
             } else if (Utils.stripColor(e.getMessage().getFormattedText()).matches(".+ gave you \\+3 minutes speed boost\\.")) {
-                GameUpdateOverlay.queueMessage("§b+3 minutes §7speed boost (" + e.getMessage().getFormattedText().split(" ")[0] + "§7)");
+                GameUpdateOverlay.queueMessage("§b+3 minutes §7speed boost (" + e.getMessage().getFormattedText().split(" ")[0].replace("§r", "") + "§7)");
                 e.setCanceled(true);
                 return;
             }

--- a/src/main/java/cf/wynntils/modules/utilities/overlays/OverlayEvents.java
+++ b/src/main/java/cf/wynntils/modules/utilities/overlays/OverlayEvents.java
@@ -1,11 +1,23 @@
 package cf.wynntils.modules.utilities.overlays;
 
+import cf.wynntils.Reference;
 import cf.wynntils.core.events.custom.PacketEvent;
+import cf.wynntils.core.events.custom.WynnClassChangeEvent;
+import cf.wynntils.core.events.custom.WynnTerritoryChangeEvent;
 import cf.wynntils.core.events.custom.WynnWorldJoinEvent;
+import cf.wynntils.core.framework.instances.PlayerInfo;
 import cf.wynntils.core.framework.interfaces.Listener;
+import cf.wynntils.core.utils.Utils;
+import cf.wynntils.modules.utilities.configs.OverlayConfig;
+import cf.wynntils.modules.utilities.overlays.hud.GameUpdateOverlay;
 import cf.wynntils.modules.utilities.overlays.hud.WarTimerOverlay;
+import net.minecraft.util.text.ChatType;
 import net.minecraftforge.client.event.ClientChatReceivedEvent;
+import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.TickEvent;
+
+import java.text.DecimalFormat;
 
 /**
  * Created by HeyZeer0 on 03/02/2018.
@@ -28,4 +40,213 @@ public class OverlayEvents implements Listener {
         WarTimerOverlay.onTitle(e);
     }
 
+    public static long tickcounter = 0;
+
+    /* XP Gain Messages */
+    public static int oldxp = 0;
+    public static String oldxppercent = "0.0";
+
+    @SubscribeEvent
+    public void onClientTick(TickEvent.ClientTickEvent e) {
+        if (OverlayConfig.GameUpdate.INSTANCE.enabled && Reference.onWorld) {
+            /* XP Gain Messages */
+            if (OverlayConfig.GameUpdate.GameUpdateEXPMessages.INSTANCE.enabled) {
+                if (tickcounter % (int) (OverlayConfig.GameUpdate.GameUpdateEXPMessages.INSTANCE.expUpdateRate * 20f) == 0) {
+                    if (oldxp != PlayerInfo.getPlayerInfo().getCurrentXP()) {
+                        if (!PlayerInfo.getPlayerInfo().getCurrentXPAsPercentage().equals("")) {
+                            if (oldxp < PlayerInfo.getPlayerInfo().getCurrentXP()) {
+                                DecimalFormat df = new DecimalFormat("0.0");
+                                float xpchange = Float.valueOf(PlayerInfo.getPlayerInfo().getCurrentXPAsPercentage()) - Float.valueOf(oldxppercent);
+                                GameUpdateOverlay.queueMessage(OverlayConfig.GameUpdate.GameUpdateEXPMessages.INSTANCE.expMessageFormat
+                                        .replace("%xo%", Integer.toString(oldxp))
+                                        .replace("%xn%", Integer.toString(PlayerInfo.getPlayerInfo().getCurrentXP()))
+                                        .replace("%xc%", Integer.toString(PlayerInfo.getPlayerInfo().getCurrentXP() - oldxp))
+                                        .replace("%po%", oldxppercent)
+                                        .replace("%pn%", PlayerInfo.getPlayerInfo().getCurrentXPAsPercentage())
+                                        .replace("%pc%", df.format(xpchange)));
+                            }
+                            oldxp = PlayerInfo.getPlayerInfo().getCurrentXP();
+                            oldxppercent = PlayerInfo.getPlayerInfo().getCurrentXPAsPercentage();
+                        }
+                    }
+                }
+            }
+        }
+        tickcounter++;
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOW)
+    public void onChatToRedirect(ClientChatReceivedEvent e) {
+        if (!Reference.onWorld || !OverlayConfig.GameUpdate.INSTANCE.enabled || e.getType() == ChatType.GAME_INFO)
+            return;
+        if (OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectHorse) {
+            if (e.getMessage().getUnformattedText().contains("There is no room for a horse.")) {
+                GameUpdateOverlay.queueMessage("§4There is no room for a horse.");
+                e.setCanceled(true);
+                return;
+            } else if (e.getMessage().getUnformattedText().contains("Since you interacted with your inventory, your horse has despawned.")) {
+                GameUpdateOverlay.queueMessage("§dHorse despawned.");
+                e.setCanceled(true);
+                return;
+            }
+        }
+        if (OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectCombat) {
+            if (e.getMessage().getUnformattedText().contains("You don't have enough mana to do that spell!")) {
+                GameUpdateOverlay.queueMessage("§4Not enough mana.");
+                e.setCanceled(true);
+                return;
+            } else if (e.getMessage().getUnformattedText().contains("You have not unlocked this spell!")) {
+                GameUpdateOverlay.queueMessage("§4Spell not unlocked.");
+                e.setCanceled(true);
+                return;
+            } else if (e.getMessage().getUnformattedText().contains("Sorry, you can't teleport... Try moving away from blocks.")) {
+                GameUpdateOverlay.queueMessage("§4Can't teleport - move away from blocks.");
+                e.setCanceled(true);
+                return;
+            }
+        }
+        if (OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectOther) {
+            if (e.getMessage().getUnformattedText().contains(" unused skill points! Click with your compass to use them!")) {
+                String[] res = e.getMessage().getUnformattedText().split(" ");
+                GameUpdateOverlay.queueMessage("§e" + res[3] + " §6skill points available.");
+                e.setCanceled(true);
+                return;
+            } else if (e.getMessage().getUnformattedText().contains(" is now level ")) {
+                String[] res = e.getMessage().getUnformattedText().split(" ");
+                GameUpdateOverlay.queueMessage("§e" + res[0] + " §6is now level §e" + res[4]);
+                e.setCanceled(true);
+                return;
+            } else if (e.getMessage().getUnformattedText().contains("You must identify this item before using it.")) {
+                GameUpdateOverlay.queueMessage("§4Item not identified.");
+                e.setCanceled(true);
+                return;
+            }
+        }
+        if (OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectServer) {
+            if (e.getMessage().getUnformattedText().contains("The server is restarting in ")) {
+                String[] res = e.getMessage().getUnformattedText().split(" ");
+                GameUpdateOverlay.queueMessage("§4" + res[5] + " " + res[6].replace(".", "") + " until server restart");
+                e.setCanceled(true);
+                return;
+            }
+        }
+        if (OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectQuest) {
+            if (Utils.stripColor(e.getMessage().getFormattedText()).startsWith("[Quest Book Updated]")) {
+                GameUpdateOverlay.queueMessage("§7Quest book updated.");
+                e.setCanceled(true);
+                return;
+            } else if (Utils.stripColor(e.getMessage().getFormattedText()).startsWith("[New Quest Started:")) {
+                GameUpdateOverlay.queueMessage(e.getMessage().getFormattedText().replace("[", "").replace("]", "").replace("§r", ""));
+                e.setCanceled(true);
+                return;
+            }
+        }
+        if (OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectMerchants) {
+            if (Utils.stripColor(e.getMessage().getFormattedText()).equals("Item Identifier: Okay, I'll identify them now!")) {
+                GameUpdateOverlay.queueMessage("§dIdentifying Item(s)...");
+                e.setCanceled(true);
+                return;
+            } else if (Utils.stripColor(e.getMessage().getFormattedText()).matches("Item Identifier: It is done\\. Your items? has been identified\\. The magic it contains will now blossom\\.")) {
+                GameUpdateOverlay.queueMessage("§dItem(s) Identified!");
+                e.setCanceled(true);
+                return;
+            } else if (Utils.stripColor(e.getMessage().getFormattedText()).startsWith("Item Buyer: You sold me: ")) {
+                String[] res = e.getMessage().getFormattedText().split("§");
+                int countCommon = 0;
+                int countUnique = 0;
+                int countRare = 0;
+                int countSet = 0;
+                int countLegendary = 0;
+                int countMythic = 0;
+                int total = 0;
+                for (String s : res) {
+                    if (s.startsWith("f")) {
+                        countCommon++;
+                        total++;
+                    } else if (s.startsWith("b")) {
+                        countLegendary++;
+                        total++;
+                    } else if (s.startsWith("5") && !s.equals("5Item Buyer: ")) {
+                        countMythic++;
+                        total++;
+                    } else if (s.startsWith("d") && !s.equals("dYou sold me: ") && !s.equals("d, ") && !s.equals("d and ") && !s.equals("d for a total of ")) {
+                        countRare++;
+                        total++;
+                    } else if (s.startsWith("a")) {
+                        countSet++;
+                        total++;
+                    } else if (s.startsWith("e")) {
+                        if (s.matches("e\\d+")) {
+                            GameUpdateOverlay.queueMessage("§dSold " + total + " (§f" + countCommon + "§d/§e" + countUnique + "§d/" + countRare + "/§a" + countSet + "§d/§b" + countLegendary + "§d/§5" + countMythic + "§d) items for §a" + s.replace("e", "") + (char) 0xB2 + "§d.");
+                            e.setCanceled(true);
+                        } else {
+                            countUnique++;
+                            total++;
+                        }
+                    }
+                }
+                return;
+            } else if (Utils.stripColor(e.getMessage().getFormattedText()).endsWith(" Merchant: Thank you for your business. Come again!")) {
+                GameUpdateOverlay.queueMessage("§dPurchase complete.");
+                e.setCanceled(true);
+                return;
+            } else if (Utils.stripColor(e.getMessage().getFormattedText()).endsWith(" Merchant: I'm afraid you cannot afford that item.")) {
+                GameUpdateOverlay.queueMessage("§dYou cannot afford that item.");
+                e.setCanceled(true);
+                return;
+            }
+        }
+        if (OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectLoginLocal) {
+            String colorStrippedMessage = Utils.stripColor(e.getMessage().getFormattedText());
+            if (colorStrippedMessage.endsWith(" has just logged in!")) {
+                if (colorStrippedMessage.startsWith("[HERO]")) {
+                    GameUpdateOverlay.queueMessage("§a→ §5[§dHERO§5] §d" + colorStrippedMessage.split(" ")[1]);
+                    e.setCanceled(true);
+                    return;
+                } else if (colorStrippedMessage.startsWith("[VIP+]")) {
+                    GameUpdateOverlay.queueMessage("§a→ §3[§bVIP+§3] §b" + colorStrippedMessage.split(" ")[1]);
+                    e.setCanceled(true);
+                    return;
+                } else if (colorStrippedMessage.startsWith("[VIP]")) {
+                    GameUpdateOverlay.queueMessage("§a→ §2[§aVIP§2] §a" + colorStrippedMessage.split(" ")[1]);
+                    e.setCanceled(true);
+                    return;
+                }
+            }
+        }
+        if (OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectLoginFriend) {
+            String colorStrippedMessage = Utils.stripColor(e.getMessage().getFormattedText());
+            if (colorStrippedMessage.contains(" has logged into server ") && colorStrippedMessage.contains(" as a")) {
+                String[] res = colorStrippedMessage.split(" ");
+                if (res.length == 9) {
+                    GameUpdateOverlay.queueMessage("§a→ §2" + res[0] + " [§a" + res[5] + "§2/§a" + res[8] + "§2]");
+                    e.setCanceled(true);
+                    return;
+                } else if (res.length == 10) {
+                    GameUpdateOverlay.queueMessage("§a→ §2" + res[0] + " [§a" + res[5] + "§2/§a" + res[8] + " " + res[9] + "§2]");
+                    e.setCanceled(true);
+                    return;
+                }
+            }
+        }
+    }
+
+    @SubscribeEvent
+    public void onWynnTerritoyChange(WynnTerritoryChangeEvent e) {
+        if (OverlayConfig.GameUpdate.TerritoryChangeMessages.INSTANCE.enabled) {
+            if (OverlayConfig.GameUpdate.TerritoryChangeMessages.INSTANCE.leave && !e.getOldTerritory().equals("Waiting")) {
+                GameUpdateOverlay.queueMessage(OverlayConfig.GameUpdate.TerritoryChangeMessages.INSTANCE.territoryLeaveFormat
+                        .replace("%t%", e.getOldTerritory()));
+            }
+            if (OverlayConfig.GameUpdate.TerritoryChangeMessages.INSTANCE.enter && !e.getNewTerritory().equals("Waiting")) {
+                GameUpdateOverlay.queueMessage(OverlayConfig.GameUpdate.TerritoryChangeMessages.INSTANCE.territoryEnterFormat
+                        .replace("%t%", e.getNewTerritory()));
+            }
+        }
+    }
+
+    @SubscribeEvent
+    public void onClassChange(WynnClassChangeEvent e) {
+        GameUpdateOverlay.resetMessages();
+    }
 }

--- a/src/main/java/cf/wynntils/modules/utilities/overlays/OverlayEvents.java
+++ b/src/main/java/cf/wynntils/modules/utilities/overlays/OverlayEvents.java
@@ -91,6 +91,7 @@ public class OverlayEvents implements Listener {
             }
         }
         if (OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectCombat) {
+            // GENERAL
             if (e.getMessage().getUnformattedText().contains("You don't have enough mana to do that spell!")) {
                 GameUpdateOverlay.queueMessage("§4Not enough mana.");
                 e.setCanceled(true);
@@ -103,10 +104,36 @@ public class OverlayEvents implements Listener {
                 GameUpdateOverlay.queueMessage("§4Can't teleport - move away from blocks.");
                 e.setCanceled(true);
                 return;
+            // POTIONS
             } else if (Utils.stripColor(e.getMessage().getFormattedText()).matches("\\[\\+\\d+ ❤\\]")) {
                 GameUpdateOverlay.queueMessage("§4" + Utils.stripColor(e.getMessage().getFormattedText()));
                 e.setCanceled(true);
                 return;
+            } else if (Utils.stripColor(e.getMessage().getFormattedText()).matches("\\[\\+\\d+ ✺ for \\d+ seconds\\]")) {
+                GameUpdateOverlay.queueMessage("§b" + Utils.stripColor(e.getMessage().getFormattedText()));
+                e.setCanceled(true);
+                return;
+            } else if (Utils.stripColor(e.getMessage().getFormattedText()).matches("\\[\\+\\d+ ✤ Strength for \\d+ seconds]")) {
+                GameUpdateOverlay.queueMessage("§2" + Utils.stripColor(e.getMessage().getFormattedText()));
+                e.setCanceled(true);
+                return;
+            } else if (Utils.stripColor(e.getMessage().getFormattedText()).matches("\\[\\+\\d+ ❋ Agility for \\d+ seconds]")) {
+                GameUpdateOverlay.queueMessage("§f" + Utils.stripColor(e.getMessage().getFormattedText()));
+                e.setCanceled(true);
+                return;
+            } else if (Utils.stripColor(e.getMessage().getFormattedText()).matches("\\[\\+\\d+ ✦ Dexterity for \\d+ seconds]")) {
+                GameUpdateOverlay.queueMessage("§e" + Utils.stripColor(e.getMessage().getFormattedText()));
+                e.setCanceled(true);
+                return;
+            } else if (Utils.stripColor(e.getMessage().getFormattedText()).matches("\\[\\+\\d+ ❉ Intelligence for \\d+ seconds]")) {
+                GameUpdateOverlay.queueMessage("§b" + Utils.stripColor(e.getMessage().getFormattedText()));
+                e.setCanceled(true);
+                return;
+            } else if (Utils.stripColor(e.getMessage().getFormattedText()).matches("\\[\\+\\d+ ✹ Defense for \\d+ seconds]")) {
+                GameUpdateOverlay.queueMessage("§4" + Utils.stripColor(e.getMessage().getFormattedText()));
+                e.setCanceled(true);
+                return;
+            // MAGE
             } else if (Utils.stripColor(e.getMessage().getFormattedText()).matches(".+ gave you \\[\\+\\d+ ❤\\]")) {
                 String[] res = e.getMessage().getFormattedText().split(" ");
                 GameUpdateOverlay.queueMessage("§4" + res[3].substring(2) + " ❤] §7(§b" + res[0] + "§7)");
@@ -136,6 +163,7 @@ public class OverlayEvents implements Listener {
                 GameUpdateOverlay.queueMessage("§bRemoved §7all fire (§b" + res[0] + "§7)");
                 e.setCanceled(true);
                 return;
+            // ARCHER
             } else if (Utils.stripColor(e.getMessage().getFormattedText()).equals("+3 minutes speed boost.")) {
                 GameUpdateOverlay.queueMessage("§b+3 minutes §7speed boost");
                 e.setCanceled(true);
@@ -232,7 +260,7 @@ public class OverlayEvents implements Listener {
                         total++;
                     } else if (s.startsWith("e")) {
                         if (s.matches("e\\d+")) {
-                            GameUpdateOverlay.queueMessage("§dSold " + total + " (§f" + countCommon + "§d/§e" + countUnique + "§d/" + countRare + "/§a" + countSet + "§d/§b" + countLegendary + "§d/§5" + countMythic + "§d) items for §a" + s.replace("e", "") + (char) 0xB2 + "§d.");
+                            GameUpdateOverlay.queueMessage("§dSold " + total + " (§f" + countCommon + "§d/§e" + countUnique + "§d/" + countRare + "/§a" + countSet + "§d/§b" + countLegendary + "§d/§5" + countMythic + "§d) item(s) for §a" + s.replace("e", "") + (char) 0xB2 + "§d.");
                             e.setCanceled(true);
                         } else {
                             countUnique++;
@@ -275,13 +303,11 @@ public class OverlayEvents implements Listener {
                 String[] res = colorStrippedMessage.split(" ");
                 if (res.length == 9) {
                     GameUpdateOverlay.queueMessage("§a→ §2" + res[0] + " [§a" + res[5] + "§2/§a" + res[8] + "§2]");
-                    e.setCanceled(true);
-                    return;
                 } else if (res.length == 10) {
                     GameUpdateOverlay.queueMessage("§a→ §2" + res[0] + " [§a" + res[5] + "§2/§a" + res[8] + " " + res[9] + "§2]");
-                    e.setCanceled(true);
-                    return;
                 }
+                e.setCanceled(true);
+                return;
             } else if (colorStrippedMessage.matches(".+ left the game\\.")) {
                 GameUpdateOverlay.queueMessage("§4← §2" + colorStrippedMessage.split(" ")[0]);
                 e.setCanceled(true);

--- a/src/main/java/cf/wynntils/modules/utilities/overlays/OverlayEvents.java
+++ b/src/main/java/cf/wynntils/modules/utilities/overlays/OverlayEvents.java
@@ -100,17 +100,13 @@ public class OverlayEvents implements Listener {
                 GameUpdateOverlay.queueMessage("§4Spell not unlocked.");
                 e.setCanceled(true);
                 return;
-            } else if (e.getMessage().getUnformattedText().contains("Sorry, you can't teleport... Try moving away from blocks.")) {
-                GameUpdateOverlay.queueMessage("§4Can't teleport - move away from blocks.");
-                e.setCanceled(true);
-                return;
             // POTIONS
             } else if (Utils.stripColor(e.getMessage().getFormattedText()).matches("\\[\\+\\d+ ❤\\]")) {
                 GameUpdateOverlay.queueMessage("§4" + Utils.stripColor(e.getMessage().getFormattedText()));
                 e.setCanceled(true);
                 return;
             } else if (Utils.stripColor(e.getMessage().getFormattedText()).matches("\\[\\+\\d+ ✺ for \\d+ seconds\\]")) {
-                GameUpdateOverlay.queueMessage("§b" + Utils.stripColor(e.getMessage().getFormattedText()));
+                GameUpdateOverlay.queueMessage("§b" + Utils.stripColor(e.getMessage().getFormattedText()).replace("for", "over"));
                 e.setCanceled(true);
                 return;
             } else if (Utils.stripColor(e.getMessage().getFormattedText()).matches("\\[\\+\\d+ ✤ Strength for \\d+ seconds]")) {
@@ -134,6 +130,10 @@ public class OverlayEvents implements Listener {
                 e.setCanceled(true);
                 return;
             // MAGE
+            } else if (e.getMessage().getUnformattedText().contains("Sorry, you can't teleport... Try moving away from blocks.")) {
+                GameUpdateOverlay.queueMessage("§4Can't teleport - move away from blocks.");
+                e.setCanceled(true);
+                return;
             } else if (Utils.stripColor(e.getMessage().getFormattedText()).matches(".+ gave you \\[\\+\\d+ ❤\\]")) {
                 String[] res = e.getMessage().getFormattedText().split(" ");
                 GameUpdateOverlay.queueMessage("§4" + res[3].substring(2) + " ❤] §7(§b" + res[0] + "§7)");

--- a/src/main/java/cf/wynntils/modules/utilities/overlays/OverlayEvents.java
+++ b/src/main/java/cf/wynntils/modules/utilities/overlays/OverlayEvents.java
@@ -103,7 +103,49 @@ public class OverlayEvents implements Listener {
                 GameUpdateOverlay.queueMessage("§4Can't teleport - move away from blocks.");
                 e.setCanceled(true);
                 return;
+            } else if (Utils.stripColor(e.getMessage().getFormattedText()).matches("\\[\\+\\d+ ❤\\]")) {
+                GameUpdateOverlay.queueMessage("§4" + Utils.stripColor(e.getMessage().getFormattedText()));
+                e.setCanceled(true);
+                return;
+            } else if (Utils.stripColor(e.getMessage().getFormattedText()).matches(".+ gave you \\[\\+\\d+ ❤\\]")) {
+                String[] res = e.getMessage().getFormattedText().split(" ");
+                GameUpdateOverlay.queueMessage("§4" + res[3].substring(2) + " ❤] §7(§b" + res[0] + "§7)");
+                e.setCanceled(true);
+                return;
+            } else if (Utils.stripColor(e.getMessage().getFormattedText()).matches("\\[\\+\\d+ ❤\\] Cleared all potion effects\\.")) {
+                GameUpdateOverlay.queueMessage("§4" + e.getMessage().getFormattedText().split(" ")[0].substring(2) + " ❤]");
+                GameUpdateOverlay.queueMessage("§bCleared §7all potion effects");
+                e.setCanceled(true);
+                return;
+            } else if (Utils.stripColor(e.getMessage().getFormattedText()).matches(".+ gave you \\[\\+\\d+ ❤\\] Cleared all potion effects\\.")) {
+                String[] res = e.getMessage().getFormattedText().split(" ");
+                GameUpdateOverlay.queueMessage("§4" + res[3].substring(2) + " ❤] §7(§b" + res[0] + "§7)");
+                GameUpdateOverlay.queueMessage("§bCleared §7all potion effects (§b" + res[0] + "§7)");
+                e.setCanceled(true);
+                return;
+            } else if (Utils.stripColor(e.getMessage().getFormattedText()).matches("\\[\\+\\d+ ❤\\] Cleared all potion effects Removed all fire\\.")) {
+                GameUpdateOverlay.queueMessage("§4" + e.getMessage().getFormattedText().split(" ")[0].substring(2) + " ❤]");
+                GameUpdateOverlay.queueMessage("§bCleared §7all potion effects");
+                GameUpdateOverlay.queueMessage("§bRemoved §7all fire");
+                e.setCanceled(true);
+                return;
+            } else if (Utils.stripColor(e.getMessage().getFormattedText()).matches(".+ gave you \\[\\+\\d+ ❤\\] Cleared all potion effects Removed all fire\\.")) {
+                String[] res = e.getMessage().getFormattedText().split(" ");
+                GameUpdateOverlay.queueMessage("§4" + res[3].substring(2) + " ❤] §7(§b" + res[0] + "§7)");
+                GameUpdateOverlay.queueMessage("§bCleared §7all potion effects (§b" + res[0] + "§7)");
+                GameUpdateOverlay.queueMessage("§bRemoved §7all fire (§b" + res[0] + "§7)");
+                e.setCanceled(true);
+                return;
+            } else if (Utils.stripColor(e.getMessage().getFormattedText()).equals("+3 minutes speed boost.")) {
+                GameUpdateOverlay.queueMessage("§b+3 minutes §7speed boost");
+                e.setCanceled(true);
+                return;
+            } else if (Utils.stripColor(e.getMessage().getFormattedText()).matches(".+ gave you \\+3 minutes speed boost\\.")) {
+                GameUpdateOverlay.queueMessage("§b+3 minutes §7speed boost (" + e.getMessage().getFormattedText().split(" ")[0] + "§7)");
+                e.setCanceled(true);
+                return;
             }
+            //TODO: Combat messages for Assassin & Warrior
         }
         if (OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectOther) {
             if (e.getMessage().getUnformattedText().contains(" unused skill points! Click with your compass to use them!")) {
@@ -118,6 +160,19 @@ public class OverlayEvents implements Listener {
                 return;
             } else if (e.getMessage().getUnformattedText().contains("You must identify this item before using it.")) {
                 GameUpdateOverlay.queueMessage("§4Item not identified.");
+                e.setCanceled(true);
+                return;
+            } else if (Utils.stripColor(e.getMessage().getFormattedText()).matches(".+ is not a .+ weapon\\. You must use a .+\\.")) {
+                GameUpdateOverlay.queueMessage("§4This weapon is not from your class.");
+                e.setCanceled(true);
+                return;
+            } else if (Utils.stripColor(e.getMessage().getFormattedText()).matches(".+ is for level \\d+\\+ only\\.")) {
+                GameUpdateOverlay.queueMessage("§4You are not a high enough level to use this item.");
+                e.setCanceled(true);
+                return;
+            } else if (Utils.stripColor(e.getMessage().getFormattedText()).matches(".+ requires your .+ skill to be at least \\d+\\.")) {
+                String[] res = Utils.stripColor(e.getMessage().getFormattedText()).split(" ");
+                GameUpdateOverlay.queueMessage("§4You don't have enough " + res[res.length - 7] + " to use this item.");
                 e.setCanceled(true);
                 return;
             }
@@ -227,6 +282,10 @@ public class OverlayEvents implements Listener {
                     e.setCanceled(true);
                     return;
                 }
+            } else if (colorStrippedMessage.matches(".+ left the game\\.")) {
+                GameUpdateOverlay.queueMessage("§4← §2" + colorStrippedMessage.split(" ")[0]);
+                e.setCanceled(true);
+                return;
             }
         }
     }

--- a/src/main/java/cf/wynntils/modules/utilities/overlays/hud/BubblesOverlay.java
+++ b/src/main/java/cf/wynntils/modules/utilities/overlays/hud/BubblesOverlay.java
@@ -24,7 +24,7 @@ public class BubblesOverlay extends Overlay {
     private static float animation = 300.0f;
 
     @Setting.Limitations.FloatLimit(min = 0f, max = 10f)
-    @Setting(displayName = "Animation Speed",description = "How fast should the bar changes happen(0 for instant)")
+    @Setting(displayName = "Animation Speed",description = "How fast should the bar changes happen (0 for instant)")
     public float animated = 2f;
 
     @Setting(displayName = "Flip", description = "Should the filling of the bar be flipped")

--- a/src/main/java/cf/wynntils/modules/utilities/overlays/hud/GameUpdateOverlay.java
+++ b/src/main/java/cf/wynntils/modules/utilities/overlays/hud/GameUpdateOverlay.java
@@ -18,7 +18,7 @@ import java.util.*;
 public class GameUpdateOverlay extends Overlay {
 
     public GameUpdateOverlay() {
-        super("Game News Overlay", 20, 20, true, 1f, 1f, -3, -10);
+        super("Game Update Ticker Overlay", 20, 20, true, 1f, 1f, -3, -10);
     }
 
     @Setting(displayName = "Message Limit", description = "The maximum amount of messages to display in the game update list")
@@ -98,7 +98,7 @@ public class GameUpdateOverlay extends Overlay {
                 message = message.substring(0, OverlayConfig.GameUpdate.INSTANCE.messageMaxLength - 5);
             message = message + "...";
         }
-        LogManager.getFormatterLogger("gameupdate").info("Message Queued: " + message);
+        LogManager.getFormatterLogger("gameupdateticker").info("Message Queued: " + message);
         messageQueue.add(new Pair<>(message, (int) (OverlayConfig.GameUpdate.INSTANCE.messageTimeLimit * 20f)));
         if (OverlayConfig.GameUpdate.INSTANCE.overrideNewMessages && messageQueue.size() > OverlayConfig.GameUpdate.INSTANCE.messageLimit)
             messageQueue.remove(0);

--- a/src/main/java/cf/wynntils/modules/utilities/overlays/hud/GameUpdateOverlay.java
+++ b/src/main/java/cf/wynntils/modules/utilities/overlays/hud/GameUpdateOverlay.java
@@ -1,0 +1,93 @@
+package cf.wynntils.modules.utilities.overlays.hud;
+
+import cf.wynntils.Reference;
+import cf.wynntils.core.framework.enums.ClassType;
+import cf.wynntils.core.framework.overlays.Overlay;
+import cf.wynntils.core.framework.rendering.SmartFontRenderer;
+import cf.wynntils.core.framework.rendering.colors.CommonColors;
+import cf.wynntils.core.framework.settings.annotations.Setting;
+import cf.wynntils.core.utils.Pair;
+import cf.wynntils.modules.utilities.configs.OverlayConfig;
+import net.minecraftforge.client.event.RenderGameOverlayEvent;
+import net.minecraftforge.fml.common.gameevent.TickEvent;
+
+import java.util.*;
+
+public class GameUpdateOverlay extends Overlay {
+
+    public GameUpdateOverlay() {
+        super("Game News Overlay", 20, 20, true, 1f, 1f, -3, -10);
+    }
+
+    @Setting(displayName = "Message Limit", description = "The maximum amount of messages to display in the game update list")
+    @Setting.Limitations.IntLimit(min = 1, max = 20)
+    public int messageLimit = 5;
+
+    @Setting(displayName = "Message Expire Time", description = "The amount of time (in seconds) that a message will remain on-screen")
+    @Setting.Limitations.FloatLimit(min = 0.05f, max = 20f, precision = 0.05f)
+    public float messageTimeLimit = 5f;
+
+    @Setting(displayName = "Message Fade Time", description = "The amount of time (in seconds) that a message should take to fade out when it's expired")
+    @Setting.Limitations.FloatLimit(min = 0f, max = 5f, precision = 0.05f)
+    public float messageFadeTime = 0.5f;
+
+    @Setting(displayName = "Enabled", description = "Should game updates be displayed")
+    public boolean enabled = true;
+
+    @Setting(displayName = "Text Shadow", description = "The HUD Text shadow type")
+    public SmartFontRenderer.TextShadow textShadow = SmartFontRenderer.TextShadow.OUTLINE;
+
+    /* Message Management */
+    public static List<Pair<String, Integer>> messageQueue = new LinkedList<>();
+
+    /* Rendering */
+    public static final int LINE_HEIGHT = 12;
+
+    @Override
+    public void tick(TickEvent.ClientTickEvent event, long ticks) {
+        if (!Reference.onWorld || getPlayerInfo().getCurrentClass() == ClassType.NONE || !OverlayConfig.GameUpdate.INSTANCE.enabled)
+            return;
+        List<Pair<String, Integer>> updatedList = new ArrayList<>();
+        for (Pair<String, Integer> message : messageQueue) {
+            int toSet = message.b - 1;
+            if (toSet == 0)
+                continue;
+            updatedList.add(new Pair<>(message.a, toSet));
+        }
+        messageQueue = updatedList;
+    }
+
+    @Override
+    public void render(RenderGameOverlayEvent.Pre event) {
+        if (!Reference.onWorld || getPlayerInfo().getCurrentClass() == ClassType.NONE || !OverlayConfig.GameUpdate.INSTANCE.enabled || !(event.getType() == RenderGameOverlayEvent.ElementType.EXPERIENCE || event.getType() == RenderGameOverlayEvent.ElementType.JUMPBAR))
+            return;
+        int lines = 0;
+        for (Pair<String, Integer> message : new ArrayList<>(messageQueue)) {
+            if (lines < OverlayConfig.GameUpdate.INSTANCE.messageLimit) {
+                if (OverlayConfig.GameUpdate.INSTANCE.invertGrowth) {
+                    drawString(message.a, 0, (0 - OverlayConfig.GameUpdate.INSTANCE.messageLimit * LINE_HEIGHT) + (LINE_HEIGHT * lines), CommonColors.GREEN, SmartFontRenderer.TextAlignment.RIGHT_LEFT, OverlayConfig.GameUpdate.INSTANCE.textShadow);
+                } else {
+                    drawString(message.a, 0, 0 - (LINE_HEIGHT * lines), CommonColors.GREEN, SmartFontRenderer.TextAlignment.RIGHT_LEFT, OverlayConfig.GameUpdate.INSTANCE.textShadow);
+                }
+                lines++;
+            } else
+                return;
+        }
+    }
+
+    public static boolean queueMessage(String message) {
+        if (!Reference.onWorld || !OverlayConfig.GameUpdate.INSTANCE.enabled)
+            return false;
+        System.out.println("Queue message: " + message);
+        messageQueue.add(new Pair<>(message, (int) (OverlayConfig.GameUpdate.INSTANCE.messageTimeLimit * 20f)));
+        if (OverlayConfig.GameUpdate.INSTANCE.overrideNewMessages && messageQueue.size() > OverlayConfig.GameUpdate.INSTANCE.messageLimit)
+            messageQueue.remove(0);
+        return true;
+    }
+
+    public static void resetMessages() {
+        if (!Reference.onWorld || !OverlayConfig.GameUpdate.INSTANCE.enabled)
+            return;
+        messageQueue.clear();
+    }
+}


### PR DESCRIPTION
Adds a new overlay that messages can be sent to on the right hand side of the screen. Messages that get sent here appear for a configurable amount of time and then disappear. This PR adds the system and a decent amount of configurable messages that can be send to it, including: XP gains; territory changes; and redirecting common chat messages to it. Some examples:

* [Territory change messages](https://i.imgur.com/Pwf05SK.png)
* [XP gain messages](https://i.imgur.com/lPKYQ9J.jpg)
* [Horse messages](https://i.imgur.com/ylqfOBD.png)
* Various combat messages: 
   * [Not enough mana/Spell not unlocked](https://i.imgur.com/TBfe5Kk.png)
   * [Spell effects (1)](https://i.imgur.com/PUR5lui.png)
   * [Spell effects (2)](https://i.imgur.com/QgHykt4.png)
   * [Potions (1)](https://i.imgur.com/FbrkSHf.png)
   * [Potions (2)](https://i.imgur.com/9NKF42Z.jpg)
* [Ranked player logins](https://i.imgur.com/5tDqOhs.jpg)
* [Friend logins/Friend logouts](https://i.imgur.com/NhPayNo.jpg)
* Merchant messages:
   * [Item buyer](https://i.imgur.com/e86uiPd.png)
   * [Item identifier](https://i.imgur.com/P2lfRhL.png)
   * [Other merchants](https://i.imgur.com/YwFlegW.png)

If this is going to be merged there is still some work to do: I'm missing combat messages for Assassin & Warrior, because I don't have a high class on any account to test these classes' messages. Also I've add 4 tabs to the settings ui, so the text renders [quite far off screen](https://i.imgur.com/lq3QL5Z.png); I couldn't find my way around the settings ui code. Finally, everything is disabled by default because I didn't want to judge what should and shouldn't be enabled for all users.