### PR TITLE
Fixed Alchemy being unselectable in profession filter

### DIFF
--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/IngredientFilterOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/IngredientFilterOverlay.java
@@ -36,11 +36,11 @@ public class IngredientFilterOverlay implements Listener {
             if (gb.id == 11 && gb.isMouseOver()) {
                 char c;
                 if (e.getMouseButton() == 0) {
-                    c = professionArray.get((professionArray.indexOf(gb.displayString) + 2) % 16).charAt(0);
+                    c = professionArray.get((professionArray.indexOf(gb.displayString) + 2) % 18).charAt(0);
                     gb.displayString = Character.toString(c);
                     RarityColorOverlay.setProfessionFilter(gb.displayString);
                 } else if (e.getMouseButton() == 1) {
-                    c = professionArray.get((professionArray.indexOf(gb.displayString) + 14) % 16).charAt(0);
+                    c = professionArray.get((professionArray.indexOf(gb.displayString) + 14) % 18).charAt(0);
                     gb.displayString = Character.toString(c);
                     RarityColorOverlay.setProfessionFilter(gb.displayString);
                 } else if (e.getMouseButton() == 2) {

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/IngredientFilterOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/IngredientFilterOverlay.java
@@ -40,7 +40,7 @@ public class IngredientFilterOverlay implements Listener {
                     gb.displayString = Character.toString(c);
                     RarityColorOverlay.setProfessionFilter(gb.displayString);
                 } else if (e.getMouseButton() == 1) {
-                    c = professionArray.get((professionArray.indexOf(gb.displayString) + 14) % 18).charAt(0);
+                    c = professionArray.get((professionArray.indexOf(gb.displayString) + 16) % 18).charAt(0);
                     gb.displayString = Character.toString(c);
                     RarityColorOverlay.setProfessionFilter(gb.displayString);
                 } else if (e.getMouseButton() == 2) {


### PR DESCRIPTION
If I understand this correctly, those "16"s that were in there before were likely put there because there are 8 professions, times two for the profession name and the corresponding unicode character. Problem is, the professionArray actually contains 18 items, because there's the "no filter" setting at the beginning, So (I believe) the "% 16" was causing it to loop back to "no profession" when left-clicking on the filter button while the Woodworking profession is selected.

That or I could be completely wrong. Guess I'll see tomorrow.