### PR TITLE
Map updates

### DIFF
--- a/src/main/java/com/wynntils/modules/map/configs/MapConfig.java
+++ b/src/main/java/com/wynntils/modules/map/configs/MapConfig.java
@@ -37,7 +37,10 @@ public class MapConfig extends SettingsClass {
     @Setting.Limitations.IntLimit(min = 75, max = 200)
     public int mapSize = 100;
 
-    @Setting(displayName = "Display Only North", description = "Should only north be displayed on the minimap?", order = 6)
+    @Setting(displayName = "Minimap Coordinates", description = "Should your coordinates be displayed below the minimap?", order = 6)
+    public boolean showCoords = false;
+
+    @Setting(displayName = "Display Only North", description = "Should only north be displayed on the minimap?", order = 7)
     public boolean northOnly = false;
 
     @Setting(displayName = "Minimap Zoom", description = "How far zoomed out should the minimap be?")
@@ -66,6 +69,9 @@ public class MapConfig extends SettingsClass {
         @Setting(displayName = "Show Territory Areas", description = "Should territory rectangles be visible?")
         public boolean territoryArea = true;
 
+        // If this ever needs to be configurable, make these into @Setting s.
+        final public int maxZoom = 150;  // Note that this is the most zoomed out
+        final public int minZoom = -10;  // And this is the most zoomed in
     }
 
     @SettingsInfo(name = "map_textures", displayPath = "Map/Textures")

--- a/src/main/java/com/wynntils/modules/map/instances/MapProfile.java
+++ b/src/main/java/com/wynntils/modules/map/instances/MapProfile.java
@@ -76,6 +76,14 @@ public class MapProfile {
         return (float)(posZ - centerZ + imageHeight);
     }
 
+    public int getWorldXPosition(double textureX) {
+        return (int) Math.round(textureX + centerX - imageWidth);
+    }
+
+    public int getWorldZPosition(double textureY) {
+        return (int) Math.round(textureY + centerZ - imageHeight);
+    }
+
     public boolean isReadyToUse() {
         return readyToUse;
     }

--- a/src/main/java/com/wynntils/modules/map/overlays/MiniMapOverlay.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/MiniMapOverlay.java
@@ -6,6 +6,7 @@ package com.wynntils.modules.map.overlays;
 
 import com.wynntils.Reference;
 import com.wynntils.core.framework.overlays.Overlay;
+import com.wynntils.core.framework.rendering.SmartFontRenderer;
 import com.wynntils.core.framework.rendering.colors.CommonColors;
 import com.wynntils.core.framework.rendering.textures.Textures;
 import com.wynntils.modules.map.MapModule;
@@ -184,6 +185,13 @@ public class MiniMapOverlay extends Overlay {
                         drawString("W", -2, mapCentre - 3, CommonColors.WHITE);
                     }
                 }
+            }
+
+            if (MapConfig.INSTANCE.showCoords) {
+                drawString(
+                        String.join(", ",Long.toString(Math.round(mc.player.posX)), Long.toString(Math.round(mc.player.posY)), Long.toString(Math.round(mc.player.posZ))),
+                        mapSize / 2f, mapSize + 6, CommonColors.WHITE, SmartFontRenderer.TextAlignment.MIDDLE, SmartFontRenderer.TextShadow.OUTLINE
+                );
             }
 
             //GlStateManager.disableTexture2D();

--- a/src/main/java/com/wynntils/modules/map/overlays/objects/MapIcon.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/objects/MapIcon.java
@@ -39,6 +39,13 @@ public class MapIcon {
         this.sizeZ = (texSizeZ - texPosZ) / size;
     }
 
+    public MapIcon setPosition(int posX, int posZ) {
+        this.posX = posX;
+        this.posZ = posZ;
+
+        return this;
+    }
+
     public MapIcon setZoomNeded(int zoomNeded) {
         this.zoomNeded = zoomNeded;
 

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/WaypointCreationMenu.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/WaypointCreationMenu.java
@@ -37,9 +37,23 @@ public class WaypointCreationMenu extends GuiScreen {
     private WaypointProfile wp;
     private GuiScreen previousGui;
 
+    private int initialX;
+    private int initialZ;
 
     public WaypointCreationMenu(GuiScreen previousGui) {
         this.previousGui = previousGui;
+
+        initialX = Minecraft.getMinecraft().player.getPosition().getX();
+        initialZ = Minecraft.getMinecraft().player.getPosition().getZ();
+    }
+
+    // Create a waypoint at a position other than the current player's position
+    // TODO: use this (Maybe double clicking somewhere on the main map would create a waypoint at that position?)
+    public WaypointCreationMenu(GuiScreen previousGui, int initialX, int initialZ) {
+        this.previousGui = previousGui;
+
+        this.initialX = initialX;
+        this.initialZ = initialZ;
     }
 
     public WaypointCreationMenu(WaypointProfile wp, GuiScreen previousGui) {
@@ -61,8 +75,8 @@ public class WaypointCreationMenu extends GuiScreen {
         buttonList.add(saveButton = new GuiButton(101, this.width/2 + 25, this.height - 80, 45, 18, "Save"));
         saveButton.enabled = false;
 
-        xCoordField.setText(Integer.toString(Minecraft.getMinecraft().player.getPosition().getX()));
-        zCoordField.setText(Integer.toString(Minecraft.getMinecraft().player.getPosition().getZ()));
+        xCoordField.setText(Integer.toString(initialX));
+        zCoordField.setText(Integer.toString(initialZ));
         yCoordField.setText(Integer.toString(Minecraft.getMinecraft().player.getPosition().getY()));
         waypointType  = WaypointType.FLAG;
 

--- a/src/main/java/com/wynntils/modules/utilities/managers/KeyManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/KeyManager.java
@@ -21,6 +21,8 @@ public class KeyManager {
 
     private static KeyHolder lockInventoryKey;
     private static KeyHolder checkForUpdatesKey;
+    private static KeyHolder zoomInKey;
+    private static KeyHolder zoomOutKey;
 
     public static void registerKeys() {
         UtilitiesModule.getModule().registerKeyBinding("Gammabright", Keyboard.KEY_G, "Wynntils", true, () -> {
@@ -42,13 +44,13 @@ public class KeyManager {
 
         lockInventoryKey = UtilitiesModule.getModule().registerKeyBinding("Lock Slot", Keyboard.KEY_H, "Wynntils", true, () -> {});
 
-        CoreModule.getModule().registerKeyBinding("Zoom In", Keyboard.KEY_EQUALS, "Wynntils", true, () -> {
+        zoomInKey = CoreModule.getModule().registerKeyBinding("Zoom In", Keyboard.KEY_EQUALS, "Wynntils", true, () -> {
             if (MapConfig.INSTANCE.mapZoom >= 5) {
                 MapConfig.INSTANCE.mapZoom -= 5;
             }
         });
 
-        CoreModule.getModule().registerKeyBinding("Zoom Out", Keyboard.KEY_MINUS, "Wynntils", true, () -> {
+        zoomOutKey = CoreModule.getModule().registerKeyBinding("Zoom Out", Keyboard.KEY_MINUS, "Wynntils", true, () -> {
             if (MapConfig.INSTANCE.mapZoom <= 95) {
                 MapConfig.INSTANCE.mapZoom += 5;
             }
@@ -68,5 +70,13 @@ public class KeyManager {
 
     public static KeyHolder getCheckForUpdatesKey() {
         return checkForUpdatesKey;
+    }
+
+    public static KeyHolder getZoomInKey() {
+        return zoomInKey;
+    }
+
+    public static KeyHolder getZoomOutKey() {
+        return zoomOutKey;
     }
 }


### PR DESCRIPTION
Added a new setting called "Minimap Coordinates" in MapConfig. If true, displays the current coordinates under the map. Defaults to false.

The minimap zoom in / out keys will now also zoom the main map when it is active (4x faster than default scroll zoom)

Added coordinates of where mouse is hovering in main map (Like map.wynncraft.com has in the corner)

Middle clicking on the main map will create a compass beacon at the location middle clicked

Fixed a bug where the compass beacon icon didn't refresh until map was closed.

Also changed default zoom range (Can zoom in and out further, controlled by [`com.wynntils.modules.map.configs.MapConfig.WorldMap.minZoom` / `maxZoom`](https://github.com/Wynntils/Wynntils/pull/101/files#diff-d594ef30017a8115a28bafd940850741R72))

---

I also added another constructor for WaypointCreationMenu so that this can be added somewhere to `com.wynntils.modules.map.overlays.ui.WorldMapUI`:

```java
// Prompt to create a waypoint where the mouse currently is
MapProfile map = MapModule.getModule().getMainMap();
int worldX = getMouseWorldX(mouseX, map);
int worldZ = getMouseWorldZ(mouseY, map);

Minecraft.getMinecraft().displayGuiScreen(new WaypointCreationMenu(null, worldX, worldZ));
```

But I couldn't think of a button combination to make a waypoint.