### PR TITLE
Waypoint colours and disable waypoints

### DIFF
--- a/src/main/java/com/wynntils/core/framework/rendering/colors/CustomColor.java
+++ b/src/main/java/com/wynntils/core/framework/rendering/colors/CustomColor.java
@@ -51,6 +51,14 @@ public class CustomColor {
                 float b = ((float) Integer.parseInt(string.substring(4, 6), 16) / 255f);
                 return new CustomColor(r,g,b,a);
             } catch(Exception ignored) { }
+        } else if (string.length() == 3) {
+            // "rgb" -> "rrggbb"
+            try {
+                float r = (Integer.parseInt(string.substring(0, 1), 16) * 0x11 / 255f);
+                float g = (Integer.parseInt(string.substring(1, 2), 16) * 0x11 / 255f);
+                float b = (Integer.parseInt(string.substring(2, 3), 16) * 0x11 / 255f);
+                return new CustomColor(r,g,b,a);
+            } catch(Exception ignored) { }
         }
         return fromString(DigestUtils.sha1Hex(string).substring(0,6),a);
     }

--- a/src/main/java/com/wynntils/modules/map/configs/MapConfig.java
+++ b/src/main/java/com/wynntils/modules/map/configs/MapConfig.java
@@ -10,7 +10,7 @@ import com.wynntils.core.framework.settings.annotations.Setting;
 import com.wynntils.core.framework.settings.annotations.SettingsInfo;
 import com.wynntils.core.framework.settings.instances.SettingsClass;
 import com.wynntils.modules.map.instances.WaypointProfile;
-import com.wynntils.modules.map.overlays.objects.MapWaypointIconInfo;
+import com.wynntils.modules.map.overlays.objects.MapWaypointIcon;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -136,12 +136,12 @@ public class MapConfig extends SettingsClass {
         @Override
         public void saveSettings(Module m) {
             super.saveSettings(m);
-            MapWaypointIconInfo.resetWaypoints();
+            MapWaypointIcon.resetWaypoints();
         }
 
         @Override
         public void onSettingChanged(String name) {
-            MapWaypointIconInfo.resetWaypoints();
+            MapWaypointIcon.resetWaypoints();
         }
     }
 

--- a/src/main/java/com/wynntils/modules/map/configs/MapConfig.java
+++ b/src/main/java/com/wynntils/modules/map/configs/MapConfig.java
@@ -10,7 +10,7 @@ import com.wynntils.core.framework.settings.annotations.Setting;
 import com.wynntils.core.framework.settings.annotations.SettingsInfo;
 import com.wynntils.core.framework.settings.instances.SettingsClass;
 import com.wynntils.modules.map.instances.WaypointProfile;
-import com.wynntils.modules.map.overlays.objects.MapIconInfo;
+import com.wynntils.modules.map.overlays.objects.MapWaypointIconInfo;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -136,12 +136,12 @@ public class MapConfig extends SettingsClass {
         @Override
         public void saveSettings(Module m) {
             super.saveSettings(m);
-            MapIconInfo.resetWaypoints();
+            MapWaypointIconInfo.resetWaypoints();
         }
 
         @Override
         public void onSettingChanged(String name) {
-            MapIconInfo.resetWaypoints();
+            MapWaypointIconInfo.resetWaypoints();
         }
     }
 

--- a/src/main/java/com/wynntils/modules/map/overlays/MiniMapOverlay.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/MiniMapOverlay.java
@@ -14,7 +14,7 @@ import com.wynntils.modules.core.managers.CompassManager;
 import com.wynntils.modules.map.MapModule;
 import com.wynntils.modules.map.configs.MapConfig;
 import com.wynntils.modules.map.instances.MapProfile;
-import com.wynntils.modules.map.overlays.objects.MapIconInfo;
+import com.wynntils.modules.map.overlays.objects.MapIcon;
 import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.Tessellator;
@@ -130,7 +130,7 @@ public class MiniMapOverlay extends Overlay {
                 int maxWorldX = (int) mc.player.posX + mapSize / 2 + zoom;
                 int maxWorldZ = (int) mc.player.posZ + mapSize / 2 + zoom;
 
-                Consumer<MapIconInfo> consumer = c -> {
+                Consumer<MapIcon> consumer = c -> {
                     int posX = c.getPosX();
                     int posZ = c.getPosZ();
                     float sizeX = c.getSizeX();
@@ -161,11 +161,11 @@ public class MiniMapOverlay extends Overlay {
                     c.renderAt(this, dx + halfMapSize, dz + halfMapSize, sizeMultiplier);
                 };
 
-                MapIconInfo.getApiMarkers(MapConfig.INSTANCE.iconTexture).forEach(consumer);
-                MapIconInfo.getWaypoints().forEach(consumer);
+                MapIcon.getApiMarkers(MapConfig.INSTANCE.iconTexture).forEach(consumer);
+                MapIcon.getWaypoints().forEach(consumer);
 
                 if (CompassManager.getCompassLocation() != null) {
-                    MapIconInfo compassIcon = MapIconInfo.getCompass();
+                    MapIcon compassIcon = MapIcon.getCompass();
 
                     float dx = (float) (compassIcon.getPosX() - mc.player.posX) * scaleFactor;
                     float dz = (float) (compassIcon.getPosZ() - mc.player.posZ) * scaleFactor;

--- a/src/main/java/com/wynntils/modules/map/overlays/MiniMapOverlay.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/MiniMapOverlay.java
@@ -14,7 +14,6 @@ import com.wynntils.modules.core.managers.CompassManager;
 import com.wynntils.modules.map.MapModule;
 import com.wynntils.modules.map.configs.MapConfig;
 import com.wynntils.modules.map.instances.MapProfile;
-import com.wynntils.modules.map.overlays.objects.MapCompassIconInfo;
 import com.wynntils.modules.map.overlays.objects.MapIconInfo;
 import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.GlStateManager;
@@ -114,6 +113,8 @@ public class MiniMapOverlay extends Overlay {
                 final float scaleFactor = mapSize / (mapSize + 2f * zoom);
                 final float sizeMultiplier = 0.8f * MapConfig.INSTANCE.minimapIconSizeMultiplier * (1 - (1 - scaleFactor) * (1 - scaleFactor));
                 final double rotationRadians = mc.player.rotationYaw * Math.PI / 180;
+                final float sinRotationRadians = (float) Math.sin(rotationRadians);
+                final float cosRotationRadians = (float) -Math.cos(rotationRadians);
 
                 // These two points for a box bigger than the actual minimap so the icons outside
                 // can quickly be filtered out
@@ -130,59 +131,48 @@ public class MiniMapOverlay extends Overlay {
                 int maxWorldZ = (int) mc.player.posZ + mapSize / 2 + zoom;
 
                 Consumer<MapIconInfo> consumer = c -> {
+                    int posX = c.getPosX();
+                    int posZ = c.getPosZ();
+                    float sizeX = c.getSizeX();
+                    float sizeZ = c.getSizeZ();
                     if (
-                            !(minFastWorldX <= c.getPosX() + c.getSizeX() && c.getPosX() - c.getSizeX() <= maxFastWorldX) ||
-                            !(minFastWorldZ <= c.getPosZ() + c.getSizeZ() && c.getPosZ() - c.getSizeZ() <= maxFastWorldZ)
+                            c.isEnabled() &&
+                            !(minFastWorldX <= posX + sizeX && posX - sizeX <= maxFastWorldX) ||
+                            !(minFastWorldZ <= posZ + sizeZ && posZ - sizeZ <= maxFastWorldZ)
                     ) {
                         return;
                     }
-                    float dx = (float) (c.getPosX() - mc.player.posX) * scaleFactor;
-                    float dz = (float) (c.getPosZ() - mc.player.posZ) * scaleFactor;
+                    float dx = (float) (posX - mc.player.posX) * scaleFactor;
+                    float dz = (float) (posZ - mc.player.posZ) * scaleFactor;
 
                     if (MapConfig.INSTANCE.followPlayerRotation) {
                         // Rotate dx and dz
-                        float sin = (float) Math.sin(rotationRadians);
-                        float cos = (float) -Math.cos(rotationRadians);
-
-                        float new_dx = dx * cos - dz * sin;
-                        dz = dx * sin + dz * cos;
-                        dx = new_dx;
+                        float temp = dx * cosRotationRadians - dz * sinRotationRadians;
+                        dz = dx * sinRotationRadians + dz * cosRotationRadians;
+                        dx = temp;
                     }
 
-                    float cornerX = Math.abs(dx) - c.getSizeX() * sizeMultiplier * 2;
-                    float cornerZ = Math.abs(dz) - c.getSizeZ() * sizeMultiplier * 2;
+                    float cornerX = Math.abs(dx) - sizeX * sizeMultiplier * 2;
+                    float cornerZ = Math.abs(dz) - sizeZ * sizeMultiplier * 2;
                     if (cornerX * cornerX + cornerZ * cornerZ > maxDistance) {
                         return;
                     }
 
-                    dx += halfMapSize;
-                    dz += halfMapSize;
-
-                    drawRectF(
-                            c.getTexture(),
-                            dx - c.getSizeX() * sizeMultiplier,
-                            dz - c.getSizeZ() * sizeMultiplier,
-                            dx + c.getSizeX() * sizeMultiplier,
-                            dz + c.getSizeZ() * sizeMultiplier,
-                            c.getTexPosX(), c.getTexPosZ(), c.getTexSizeX(), c.getTexSizeZ()
-                    );
+                    c.renderAt(this, dx + halfMapSize, dz + halfMapSize, sizeMultiplier);
                 };
 
                 MapIconInfo.getApiMarkers(MapConfig.INSTANCE.iconTexture).forEach(consumer);
                 MapIconInfo.getWaypoints().forEach(consumer);
 
                 if (CompassManager.getCompassLocation() != null) {
-                    MapIconInfo compassIcon = MapCompassIconInfo.getInstance();
+                    MapIconInfo compassIcon = MapIconInfo.getCompass();
 
                     float dx = (float) (compassIcon.getPosX() - mc.player.posX) * scaleFactor;
                     float dz = (float) (compassIcon.getPosZ() - mc.player.posZ) * scaleFactor;
 
                     if (MapConfig.INSTANCE.followPlayerRotation) {
-                        float sin = (float) Math.sin(rotationRadians);
-                        float cos = (float) -Math.cos(rotationRadians);
-
-                        float temp = dx * cos - dz * sin;
-                        dz = dx * sin + dz * cos;
+                        float temp = dx * cosRotationRadians - dz * sinRotationRadians;
+                        dz = dx * sinRotationRadians + dz * cosRotationRadians;
                         dx = temp;
                     }
 
@@ -194,7 +184,7 @@ public class MiniMapOverlay extends Overlay {
                     if (MapConfig.INSTANCE.mapFormat == MapConfig.MapFormat.SQUARE) {
                         newDx = Math.max(-halfMapSize + compassSize, Math.min(halfMapSize - compassSize, dx));
                         newDz = Math.max(-halfMapSize + compassSize, Math.min(halfMapSize - compassSize, dz));
-                        scaled = newDx != dx || newDz != dz;
+                        scaled = (newDx != dx) || (newDz != dz);
                         if (!scaled) {
                             dx = newDx;
                             dz = newDz;
@@ -244,18 +234,7 @@ public class MiniMapOverlay extends Overlay {
 
                         GlStateManager.popMatrix();
                     } else {
-                        dx += halfMapSize;
-                        dz += halfMapSize;
-
-                        drawRectF(
-                                compassIcon.getTexture(),
-                                dx - compassIcon.getSizeX() * sizeMultiplier,
-                                dz - compassIcon.getSizeZ() * sizeMultiplier,
-                                dx + compassIcon.getSizeX() * sizeMultiplier,
-                                dz + compassIcon.getSizeZ() * sizeMultiplier,
-                                compassIcon.getTexPosX(), compassIcon.getTexPosZ(),
-                                compassIcon.getTexSizeX(), compassIcon.getTexSizeZ()
-                        );
+                        compassIcon.renderAt(this, dx + halfMapSize, dz + halfMapSize, sizeMultiplier);
                     }
                 }
             }

--- a/src/main/java/com/wynntils/modules/map/overlays/objects/MapApiIcon.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/objects/MapApiIcon.java
@@ -17,7 +17,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-public class MapApiIconInfo extends MapIconInfo {
+public class MapApiIcon extends MapIcon {
     private static final HashMap<String, String> MAPMARKERNAME_TRANSLATION = new HashMap<String, String>() {{
         put("Content_Dungeon", "Dungeons");
         put("Merchant_Accessory", "Accessory Merchant");
@@ -61,7 +61,7 @@ public class MapApiIconInfo extends MapIconInfo {
 
     private String translatedName;
 
-    MapApiIconInfo(MapMarkerProfile mmp, MapConfig.IconTexture iconTexture) {
+    MapApiIcon(MapMarkerProfile mmp, MapConfig.IconTexture iconTexture) {
         JsonObject iconMapping = Mappings.Map.map_icons_mappings.get(iconTexture == MapConfig.IconTexture.Classic ? "CLASSIC" : "MEDIVAL").getAsJsonObject().get(mmp.getIcon()).getAsJsonObject();
 
         this.mmp = mmp;
@@ -143,8 +143,8 @@ public class MapApiIconInfo extends MapIconInfo {
         );
     }
 
-    private static List<MapIconInfo> classicApiMarkers = null;
-    private static List<MapIconInfo> medievalApiMarkers = null;
+    private static List<MapIcon> classicApiMarkers = null;
+    private static List<MapIcon> medievalApiMarkers = null;
 
     public static void resetApiMarkers() {
         if (Textures.Map.map_icons == null) return;
@@ -159,14 +159,14 @@ public class MapApiIconInfo extends MapIconInfo {
             medievalApiMarkers.clear();
         }
         for (MapMarkerProfile mmp : WebManager.getMapMarkers()) {
-            if (isApiMarkerValid(mmp, MapConfig.IconTexture.Classic)) classicApiMarkers.add(new MapApiIconInfo(mmp, MapConfig.IconTexture.Classic));
-            if (isApiMarkerValid(mmp, MapConfig.IconTexture.Medieval)) medievalApiMarkers.add(new MapApiIconInfo(mmp, MapConfig.IconTexture.Medieval));
+            if (isApiMarkerValid(mmp, MapConfig.IconTexture.Classic)) classicApiMarkers.add(new MapApiIcon(mmp, MapConfig.IconTexture.Classic));
+            if (isApiMarkerValid(mmp, MapConfig.IconTexture.Medieval)) medievalApiMarkers.add(new MapApiIcon(mmp, MapConfig.IconTexture.Medieval));
         }
     }
 
     public static void resetApiMarkers(MapConfig.IconTexture iconTexture) {
         if (Textures.Map.map_icons == null) return;
-        List<MapIconInfo> markers;
+        List<MapIcon> markers;
         switch (iconTexture) {
             case Classic:
                 if (classicApiMarkers == null) {
@@ -188,11 +188,11 @@ public class MapApiIconInfo extends MapIconInfo {
                 return;
         }
         for (MapMarkerProfile mmp : WebManager.getMapMarkers()) {
-            if (isApiMarkerValid(mmp, iconTexture)) markers.add(new MapApiIconInfo(mmp, iconTexture));
+            if (isApiMarkerValid(mmp, iconTexture)) markers.add(new MapApiIcon(mmp, iconTexture));
         }
     }
 
-    public static List<MapIconInfo> getApiMarkers(MapConfig.IconTexture iconTexture) {
+    public static List<MapIcon> getApiMarkers(MapConfig.IconTexture iconTexture) {
         if (classicApiMarkers == null && medievalApiMarkers == null) resetApiMarkers();
         switch (iconTexture) {
             case Classic:

--- a/src/main/java/com/wynntils/modules/map/overlays/objects/MapApiIconInfo.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/objects/MapApiIconInfo.java
@@ -5,12 +5,17 @@
 package com.wynntils.modules.map.overlays.objects;
 
 import com.google.gson.JsonObject;
+import com.wynntils.core.framework.rendering.ScreenRenderer;
+import com.wynntils.core.framework.rendering.textures.AssetsTexture;
 import com.wynntils.core.framework.rendering.textures.Mappings;
 import com.wynntils.core.framework.rendering.textures.Textures;
 import com.wynntils.modules.map.configs.MapConfig;
+import com.wynntils.webapi.WebManager;
 import com.wynntils.webapi.profiles.MapMarkerProfile;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 public class MapApiIconInfo extends MapIconInfo {
     private static final HashMap<String, String> MAPMARKERNAME_TRANSLATION = new HashMap<String, String>() {{
@@ -49,24 +54,159 @@ public class MapApiIconInfo extends MapIconInfo {
         put("Merchant_Emerald", "Emerald Merchant");
     }};
 
+    private MapMarkerProfile mmp;
+    private int texPosX, texPosZ, texSizeX, texSizeZ;
+    private float sizeX, sizeZ;
+    private int zoomNeeded;
+
     private String translatedName;
 
-    private MapApiIconInfo(MapMarkerProfile mmp, JsonObject iconMapping) {
-        super(
-                Textures.Map.map_icons, mmp.getName(),
-                mmp.getX(), mmp.getZ(),
-                iconMapping.get("size").getAsFloat(),
-                iconMapping.get("texPosX").getAsInt(), iconMapping.get("texPosZ").getAsInt(),
-                iconMapping.get("texSizeX").getAsInt(), iconMapping.get("texSizeZ").getAsInt(),
-                iconMapping.get("zoomNeeded").getAsInt()
+    MapApiIconInfo(MapMarkerProfile mmp, MapConfig.IconTexture iconTexture) {
+        JsonObject iconMapping = Mappings.Map.map_icons_mappings.get(iconTexture == MapConfig.IconTexture.Classic ? "CLASSIC" : "MEDIVAL").getAsJsonObject().get(mmp.getIcon()).getAsJsonObject();
+
+        this.mmp = mmp;
+
+        texPosX = iconMapping.get("texPosX").getAsInt();
+        texPosZ = iconMapping.get("texPosZ").getAsInt();
+        texSizeX = iconMapping.get("texSizeX").getAsInt();
+        texSizeZ = iconMapping.get("texSizeZ").getAsInt();
+        float size = iconMapping.get("size").getAsFloat();
+        sizeX = (texSizeX - texPosX) / size;
+        sizeZ = (texSizeZ - texPosZ) / size;
+        zoomNeeded = iconMapping.get("zoomNeeded").getAsInt();
+
+        translatedName = MAPMARKERNAME_TRANSLATION.get(mmp.getIcon());
+    }
+
+    @Override public AssetsTexture getTexture() {
+        return Textures.Map.map_icons;
+    }
+
+    @Override public int getPosX() {
+        return mmp.getX();
+    }
+
+    @Override public int getPosZ() {
+        return mmp.getZ();
+    }
+
+    @Override public String getName() {
+        return mmp.getName();
+    }
+
+    @Override public int getTexPosX() {
+        return texPosX;
+    }
+
+    @Override public int getTexPosZ() {
+        return texPosZ;
+    }
+
+    @Override public int getTexSizeX() {
+        return texSizeX;
+    }
+
+    @Override public int getTexSizeZ() {
+        return texSizeZ;
+    }
+
+    @Override public float getSizeX() {
+        return sizeX;
+    }
+
+    @Override public float getSizeZ() {
+        return sizeZ;
+    }
+
+    @Override public int getZoomNeeded() {
+        return zoomNeeded;
+    }
+
+    @Override public boolean isEnabled() {
+        return MapConfig.INSTANCE.enabledMapIcons.getOrDefault(translatedName, true);
+    }
+
+    public MapMarkerProfile getMapMarkerProfile() {
+        return mmp;
+    }
+
+    // As an optimisation, so methods don't need to be called all the time
+    @Override
+    public void renderAt(ScreenRenderer renderer, float centreX, float centreZ, float sizeMultiplier) {
+        float sizeX = this.sizeX * sizeMultiplier;
+        float sizeZ = this.sizeZ * sizeMultiplier;
+        renderer.drawRectF(
+                Textures.Map.map_icons,
+                centreX - sizeX, centreZ - sizeZ,
+                centreX + sizeX, centreZ + sizeZ,
+                texPosX, texPosZ, texSizeX, texSizeZ
         );
     }
 
-    MapApiIconInfo(MapMarkerProfile mmp, MapConfig.IconTexture iconTexture) {
-        this(mmp, Mappings.Map.map_icons_mappings.get(iconTexture == MapConfig.IconTexture.Classic ? "CLASSIC" : "MEDIVAL").getAsJsonObject().get(mmp.getIcon()).getAsJsonObject());
+    private static List<MapIconInfo> classicApiMarkers = null;
+    private static List<MapIconInfo> medievalApiMarkers = null;
+
+    public static void resetApiMarkers() {
+        if (Textures.Map.map_icons == null) return;
+        if (classicApiMarkers == null) {
+            classicApiMarkers = new ArrayList<>();
+        } else {
+            classicApiMarkers.clear();
+        }
+        if (medievalApiMarkers == null) {
+            medievalApiMarkers = new ArrayList<>();
+        } else {
+            medievalApiMarkers.clear();
+        }
+        for (MapMarkerProfile mmp : WebManager.getMapMarkers()) {
+            if (isApiMarkerValid(mmp, MapConfig.IconTexture.Classic)) classicApiMarkers.add(new MapApiIconInfo(mmp, MapConfig.IconTexture.Classic));
+            if (isApiMarkerValid(mmp, MapConfig.IconTexture.Medieval)) medievalApiMarkers.add(new MapApiIconInfo(mmp, MapConfig.IconTexture.Medieval));
+        }
     }
 
-    public boolean isEnabled() {
-        return MapConfig.INSTANCE.enabledMapIcons.getOrDefault(translatedName, true);
+    public static void resetApiMarkers(MapConfig.IconTexture iconTexture) {
+        if (Textures.Map.map_icons == null) return;
+        List<MapIconInfo> markers;
+        switch (iconTexture) {
+            case Classic:
+                if (classicApiMarkers == null) {
+                    markers = classicApiMarkers = new ArrayList<>();
+                } else {
+                    markers = classicApiMarkers;
+                    markers.clear();
+                }
+                break;
+            case Medieval:
+                if (medievalApiMarkers == null) {
+                    markers = medievalApiMarkers = new ArrayList<>();
+                } else {
+                    markers = medievalApiMarkers;
+                    markers.clear();
+                }
+                break;
+            default:
+                return;
+        }
+        for (MapMarkerProfile mmp : WebManager.getMapMarkers()) {
+            if (isApiMarkerValid(mmp, iconTexture)) markers.add(new MapApiIconInfo(mmp, iconTexture));
+        }
+    }
+
+    public static List<MapIconInfo> getApiMarkers(MapConfig.IconTexture iconTexture) {
+        if (classicApiMarkers == null && medievalApiMarkers == null) resetApiMarkers();
+        switch (iconTexture) {
+            case Classic:
+                if (classicApiMarkers == null) resetApiMarkers(MapConfig.IconTexture.Classic);
+                return classicApiMarkers;
+            case Medieval:
+                if (medievalApiMarkers == null) resetApiMarkers(MapConfig.IconTexture.Medieval);
+                return medievalApiMarkers;
+            default:
+                return null;
+        }
+    }
+
+    private static boolean isApiMarkerValid(MapMarkerProfile mmp, MapConfig.IconTexture iconTexture) {
+        return Mappings.Map.map_icons_mappings.get(iconTexture == MapConfig.IconTexture.Classic ? "CLASSIC" : "MEDIVAL").getAsJsonObject().has(mmp.getIcon());
     }
 }

--- a/src/main/java/com/wynntils/modules/map/overlays/objects/MapCompassIcon.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/objects/MapCompassIcon.java
@@ -8,15 +8,15 @@ import com.wynntils.core.framework.rendering.textures.AssetsTexture;
 import com.wynntils.core.framework.rendering.textures.Textures;
 import com.wynntils.modules.core.managers.CompassManager;
 
-public class MapCompassIconInfo extends MapIconInfo {
-    private static MapCompassIconInfo instance = null;
+public class MapCompassIcon extends MapIcon {
+    private static MapCompassIcon instance = null;
 
-    public static MapCompassIconInfo getCompass() {
-        if (instance == null && Textures.Map.map_icons != null) instance = new MapCompassIconInfo();
+    public static MapCompassIcon getCompass() {
+        if (instance == null && Textures.Map.map_icons != null) instance = new MapCompassIcon();
         return instance;
     }
 
-    private MapCompassIconInfo() {}
+    private MapCompassIcon() {}
 
     @Override public AssetsTexture getTexture() {
         return Textures.Map.map_icons;

--- a/src/main/java/com/wynntils/modules/map/overlays/objects/MapCompassIconInfo.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/objects/MapCompassIconInfo.java
@@ -4,27 +4,68 @@
 
 package com.wynntils.modules.map.overlays.objects;
 
+import com.wynntils.core.framework.rendering.textures.AssetsTexture;
 import com.wynntils.core.framework.rendering.textures.Textures;
 import com.wynntils.modules.core.managers.CompassManager;
 
 public class MapCompassIconInfo extends MapIconInfo {
     private static MapCompassIconInfo instance = null;
 
-    public static MapCompassIconInfo getInstance() {
+    public static MapCompassIconInfo getCompass() {
         if (instance == null && Textures.Map.map_icons != null) instance = new MapCompassIconInfo();
         return instance;
     }
 
-    private MapCompassIconInfo() {
-        super(Textures.Map.map_icons, "Compass Beacon", Integer.MAX_VALUE, Integer.MAX_VALUE, 2.5f, 0, 53, 14, 71, -1000);
+    private MapCompassIconInfo() {}
+
+    @Override public AssetsTexture getTexture() {
+        return Textures.Map.map_icons;
     }
 
-    @Override
-    public int getPosX() {
+    @Override public int getPosX() {
         return (int) CompassManager.getCompassLocation().getX();
     }
 
-    public int getPosZ() {
+    @Override public int getPosZ() {
         return (int) CompassManager.getCompassLocation().getZ();
     }
+
+    @Override public String getName() {
+        return "Compass Beacon";
+    }
+
+    @Override public int getTexPosX() {
+        return 0;
+    }
+
+    @Override public int getTexPosZ() {
+        return 53;
+    }
+
+    @Override public int getTexSizeX() {
+        return 14;
+    }
+
+    @Override public int getTexSizeZ() {
+        return 71;
+    }
+
+    @Override public float getSizeX() {
+        // return (getTexSizeX() - getTexPosX()) / 2.5f;
+        return 5.6f;
+    }
+
+    @Override public float getSizeZ() {
+        // return (getTexSizeZ() - getTexPosZ()) / 2.5f;
+        return 7.2f;
+    }
+
+    @Override public int getZoomNeeded() {
+        return ANY_ZOOM;
+    }
+
+    @Override public boolean isEnabled() {
+        return true;
+    }
+
 }

--- a/src/main/java/com/wynntils/modules/map/overlays/objects/MapIcon.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/objects/MapIcon.java
@@ -10,7 +10,7 @@ import com.wynntils.modules.map.configs.MapConfig;
 
 import java.util.List;
 
-public abstract class MapIconInfo {
+public abstract class MapIcon {
     public static final int ANY_ZOOM = -1000;
 
     public abstract AssetsTexture getTexture();
@@ -37,15 +37,15 @@ public abstract class MapIconInfo {
         );
     }
 
-    public static List<MapIconInfo> getApiMarkers(MapConfig.IconTexture iconTexture) {
-        return MapApiIconInfo.getApiMarkers(iconTexture);
+    public static List<MapIcon> getApiMarkers(MapConfig.IconTexture iconTexture) {
+        return MapApiIcon.getApiMarkers(iconTexture);
     }
 
-    public static List<MapIconInfo> getWaypoints() {
-        return MapWaypointIconInfo.getWaypoints();
+    public static List<MapIcon> getWaypoints() {
+        return MapWaypointIcon.getWaypoints();
     }
 
-    public static MapIconInfo getCompass() {
-        return MapCompassIconInfo.getCompass();
+    public static MapIcon getCompass() {
+        return MapCompassIcon.getCompass();
     }
 }

--- a/src/main/java/com/wynntils/modules/map/overlays/objects/MapIconInfo.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/objects/MapIconInfo.java
@@ -4,227 +4,48 @@
 
 package com.wynntils.modules.map.overlays.objects;
 
+import com.wynntils.core.framework.rendering.ScreenRenderer;
 import com.wynntils.core.framework.rendering.textures.AssetsTexture;
-import com.wynntils.core.framework.rendering.textures.Mappings;
-import com.wynntils.core.framework.rendering.textures.Textures;
 import com.wynntils.modules.map.configs.MapConfig;
-import com.wynntils.modules.map.instances.WaypointProfile;
-import com.wynntils.webapi.WebManager;
-import com.wynntils.webapi.profiles.MapMarkerProfile;
 
-import java.util.ArrayList;
 import java.util.List;
 
-public class MapIconInfo {
+public abstract class MapIconInfo {
+    public static final int ANY_ZOOM = -1000;
 
-    AssetsTexture texture;
+    public abstract AssetsTexture getTexture();
+    public abstract int getPosX();
+    public abstract int getPosZ();
+    public abstract String getName();
+    public abstract int getTexPosX();
+    public abstract int getTexPosZ();
+    public abstract int getTexSizeX();
+    public abstract int getTexSizeZ();
+    public abstract float getSizeX();
+    public abstract float getSizeZ();
+    public abstract int getZoomNeeded();
+    public abstract boolean isEnabled();
 
-    int posX, posZ;
-    String name;
-
-    int texPosX, texPosZ, texSizeX, texSizeZ;
-
-    float sizeX, sizeZ;
-
-    int zoomNeeded;
-
-    protected MapIconInfo(AssetsTexture texture, String name, int posX, int posZ, float size, int texPosX, int texPosZ, int texSizeX, int texSizeZ, int zoomNeeded) {
-        this.texture = texture;
-        this.posX = posX;
-        this.posZ = posZ;
-        this.name = name;
-        this.texPosX = texPosX;
-        this.texPosZ = texPosZ;
-        this.texSizeX = texSizeX;
-        this.texSizeZ = texSizeZ;
-        this.sizeX = (texSizeX - texPosX) / size;
-        this.sizeZ = (texSizeZ - texPosZ) / size;
-        this.zoomNeeded = zoomNeeded;
-    }
-
-    private MapIconInfo(WaypointProfile wp) {
-        texture = Textures.Map.map_icons;
-
-        switch (wp.getType()) {
-            case LOOTCHEST_T1:
-                texPosX = 136; texPosZ = 35;
-                texSizeX = 154; texSizeZ = 53;
-                break;
-            case LOOTCHEST_T2:
-                texPosX = 118; texPosZ = 35;
-                texSizeX = 136; texSizeZ = 53;
-                break;
-            case LOOTCHEST_T3:
-                texPosX = 82; texPosZ = 35;
-                texSizeX = 100; texSizeZ = 53;
-                break;
-            case LOOTCHEST_T4:
-                texPosX = 100; texPosZ = 35;
-                texSizeX = 118; texSizeZ = 53;
-                break;
-            default:
-            case DIAMOND:
-                texPosX = 172; texPosZ = 37;
-                texSizeX = 190; texSizeZ = 55;
-                break;
-            case FLAG:
-                //TODO handle colours
-                texPosX = 154; texPosZ = 36;
-                texSizeX = 172; texSizeZ = 54;
-                break;
-            case SIGN:
-                texPosX = 190; texPosZ = 36;
-                texSizeX = 208; texSizeZ = 54;
-                break;
-            case STAR:
-                texPosX = 208; texPosZ = 36;
-                texSizeX = 226; texSizeZ = 54;
-                break;
-            case TURRET:
-                texPosX = 226; texPosZ = 36;
-                texSizeX = 244; texSizeZ = 54;
-                break;
-        }
-
-        name = wp.getName();
-        posX = (int)wp.getX();
-        posZ = (int)wp.getZ();
-        sizeX = (texSizeX - texPosX) / 2.5f;
-        sizeZ = (texSizeZ - texPosZ) / 2.5f;
-
-        zoomNeeded = wp.getZoomNeeded();
-    }
-
-    public AssetsTexture getTexture() {
-        return texture;
-    }
-
-    public int getPosX() {
-        return posX;
-    }
-
-    public int getPosZ() {
-        return posZ;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public int getTexPosX() {
-        return texPosX;
-    }
-
-    public int getTexPosZ() {
-        return texPosZ;
-    }
-
-    public int getTexSizeX() {
-        return texSizeX;
-    }
-
-    public int getTexSizeZ() {
-        return texSizeZ;
-    }
-
-    public float getSizeX() {
-        return sizeX;
-    }
-
-    public float getSizeZ() {
-        return sizeZ;
-    }
-
-    public int getZoomNeeded() {
-        return zoomNeeded;
-    }
-
-    private static List<MapIconInfo> classicApiMarkers = null;
-    private static List<MapIconInfo> medivalApiMarkers = null;
-    private static List<MapIconInfo> waypoints = null;
-
-    public static void resetApiMarkers() {
-        if (Textures.Map.map_icons == null) return;
-        if (classicApiMarkers == null) {
-            classicApiMarkers = new ArrayList<>();
-        } else {
-            classicApiMarkers.clear();
-        }
-        if (medivalApiMarkers == null) {
-            medivalApiMarkers = new ArrayList<>();
-        } else {
-            medivalApiMarkers.clear();
-        }
-        for (MapMarkerProfile mmp : WebManager.getMapMarkers()) {
-            if (isApiMarkerValid(mmp, MapConfig.IconTexture.Classic)) classicApiMarkers.add(new MapApiIconInfo(mmp, MapConfig.IconTexture.Classic));
-            if (isApiMarkerValid(mmp, MapConfig.IconTexture.Medieval)) medivalApiMarkers.add(new MapApiIconInfo(mmp, MapConfig.IconTexture.Medieval));
-        }
-    }
-
-    public static void resetApiMarkers(MapConfig.IconTexture iconTexture) {
-        if (Textures.Map.map_icons == null) return;
-        List<MapIconInfo> markers;
-        switch (iconTexture) {
-            case Classic:
-                if (classicApiMarkers == null) {
-                    markers = classicApiMarkers = new ArrayList<>();
-                } else {
-                    markers = classicApiMarkers;
-                    markers.clear();
-                }
-                break;
-            case Medieval:
-                if (medivalApiMarkers == null) {
-                    markers = medivalApiMarkers = new ArrayList<>();
-                } else {
-                    markers = medivalApiMarkers;
-                    markers.clear();
-                }
-                break;
-            default:
-                return;
-        }
-        for (MapMarkerProfile mmp : WebManager.getMapMarkers()) {
-            if (isApiMarkerValid(mmp, iconTexture)) markers.add(new MapApiIconInfo(mmp, iconTexture));
-        }
+    public void renderAt(ScreenRenderer renderer, float centreX, float centreZ, float sizeMultiplier) {
+        float sizeX = getSizeX() * sizeMultiplier;
+        float sizeZ = getSizeZ() * sizeMultiplier;
+        renderer.drawRectF(
+                getTexture(),
+                centreX - sizeX, centreZ - sizeZ,
+                centreX + sizeX, centreZ + sizeZ,
+                getTexPosX(), getTexPosZ(), getTexSizeX(), getTexSizeZ()
+        );
     }
 
     public static List<MapIconInfo> getApiMarkers(MapConfig.IconTexture iconTexture) {
-        if (classicApiMarkers == null && medivalApiMarkers == null) resetApiMarkers();
-        switch (iconTexture) {
-            case Classic:
-                if (classicApiMarkers == null) resetApiMarkers(MapConfig.IconTexture.Classic);
-                return classicApiMarkers;
-            case Medieval:
-                if (medivalApiMarkers == null) resetApiMarkers(MapConfig.IconTexture.Medieval);
-                return medivalApiMarkers;
-            default:
-                return null;
-        }
-    }
-
-    private static boolean isApiMarkerValid(MapMarkerProfile mmp, MapConfig.IconTexture iconTexture) {
-        return Mappings.Map.map_icons_mappings.get(iconTexture == MapConfig.IconTexture.Classic ? "CLASSIC" : "MEDIVAL").getAsJsonObject().has(mmp.getIcon());
+        return MapApiIconInfo.getApiMarkers(iconTexture);
     }
 
     public static List<MapIconInfo> getWaypoints() {
-        if (waypoints == null && Textures.Map.map_icons != null) {
-            resetWaypoints();
-        }
-        return waypoints;
+        return MapWaypointIconInfo.getWaypoints();
     }
 
-    public static void resetWaypoints() {
-        if (Textures.Map.map_icons == null) return;
-        if (waypoints == null) {
-            waypoints = new ArrayList<>();
-        } else {
-            waypoints.clear();
-        }
-         MapConfig.Waypoints.INSTANCE.waypoints.forEach(c -> waypoints.add(new MapIconInfo(c)));
-    }
-
-    public static MapCompassIconInfo getCompass() {
-        return MapCompassIconInfo.getInstance();
+    public static MapIconInfo getCompass() {
+        return MapCompassIconInfo.getCompass();
     }
 }

--- a/src/main/java/com/wynntils/modules/map/overlays/objects/MapWaypointIcon.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/objects/MapWaypointIcon.java
@@ -11,7 +11,7 @@ import net.minecraft.client.renderer.GlStateManager;
 import java.util.ArrayList;
 import java.util.List;
 
-public class MapWaypointIconInfo extends MapIconInfo {
+public class MapWaypointIcon extends MapIcon {
     public static final int HIDDEN_ZOOM = -1;
 
     private static int[] sizeMapping = null;
@@ -43,7 +43,7 @@ public class MapWaypointIconInfo extends MapIconInfo {
         setSize(WaypointProfile.WaypointType.LOOTCHEST_T3,  82, 35, 100, 53);
         setSize(WaypointProfile.WaypointType.LOOTCHEST_T4, 100, 35, 118, 53);
         setSize(WaypointProfile.WaypointType.DIAMOND, 172, 37, 190, 55);
-        setSize(WaypointProfile.WaypointType.FLAG, 154, 36, 172, 54);  // TODO: Handle colours
+        setSize(WaypointProfile.WaypointType.FLAG, 154, 36, 172, 54);
         setSize(WaypointProfile.WaypointType.SIGN, 190, 36, 208, 54);
         setSize(WaypointProfile.WaypointType.STAR, 208, 36, 226, 54);
         setSize(WaypointProfile.WaypointType.TURRET, 226, 36, 244, 54);
@@ -51,7 +51,7 @@ public class MapWaypointIconInfo extends MapIconInfo {
 
     private WaypointProfile wp;
 
-    public MapWaypointIconInfo(WaypointProfile wp) {
+    public MapWaypointIcon(WaypointProfile wp) {
         initialise();
 
         assert wp.getType().ordinal() < waypointTypesCount : "Invalid enum value in WaypointProfile.WaypointType: " + wp.getType().ordinal();
@@ -122,10 +122,10 @@ public class MapWaypointIconInfo extends MapIconInfo {
         return wp;
     }
 
-    private static List<MapIconInfo> waypoints = null;
+    private static List<MapIcon> waypoints = null;
 
 
-    public static List<MapIconInfo> getWaypoints() {
+    public static List<MapIcon> getWaypoints() {
         if (waypoints == null) {
             resetWaypoints();
         }
@@ -138,6 +138,6 @@ public class MapWaypointIconInfo extends MapIconInfo {
         } else {
             waypoints.clear();
         }
-        MapConfig.Waypoints.INSTANCE.waypoints.forEach(c -> waypoints.add(new MapWaypointIconInfo(c)));
+        MapConfig.Waypoints.INSTANCE.waypoints.forEach(c -> waypoints.add(new MapWaypointIcon(c)));
     }
 }

--- a/src/main/java/com/wynntils/modules/map/overlays/objects/MapWaypointIconInfo.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/objects/MapWaypointIconInfo.java
@@ -1,0 +1,143 @@
+package com.wynntils.modules.map.overlays.objects;
+
+import com.wynntils.core.framework.rendering.ScreenRenderer;
+import com.wynntils.core.framework.rendering.colors.CustomColor;
+import com.wynntils.core.framework.rendering.textures.AssetsTexture;
+import com.wynntils.core.framework.rendering.textures.Textures;
+import com.wynntils.modules.map.configs.MapConfig;
+import com.wynntils.modules.map.instances.WaypointProfile;
+import net.minecraft.client.renderer.GlStateManager;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MapWaypointIconInfo extends MapIconInfo {
+    public static final int HIDDEN_ZOOM = -1;
+
+    private static int[] sizeMapping = null;
+    private static int waypointTypesCount;
+    private static final int texPosXIndex = 0;
+    private static final int texPosZIndex = 1;
+    private static final int texSizeXIndex = 2;
+    private static final int texSizeZIndex = 3;
+
+    private static void setSize(WaypointProfile.WaypointType type, int texPosX, int texPosZ, int texSizeX, int texSizeZ) {
+        assert type.ordinal() < waypointTypesCount;
+        int i = type.ordinal() * 4;
+        sizeMapping[i + texPosXIndex] = texPosX;
+        sizeMapping[i + texPosZIndex] = texPosZ;
+        sizeMapping[i + texSizeXIndex] = texSizeX;
+        sizeMapping[i + texSizeZIndex] = texSizeZ;
+    }
+
+    private static void initialise() {
+        if (sizeMapping != null) return;
+        waypointTypesCount = WaypointProfile.WaypointType.class.getEnumConstants().length;
+
+        assert waypointTypesCount == 9 : "If you added a new waypoint type, specify the dimensions here";
+
+        sizeMapping = new int[waypointTypesCount * 4];
+
+        setSize(WaypointProfile.WaypointType.LOOTCHEST_T1, 136, 35, 154, 53);
+        setSize(WaypointProfile.WaypointType.LOOTCHEST_T2, 118, 35, 136, 53);
+        setSize(WaypointProfile.WaypointType.LOOTCHEST_T3,  82, 35, 100, 53);
+        setSize(WaypointProfile.WaypointType.LOOTCHEST_T4, 100, 35, 118, 53);
+        setSize(WaypointProfile.WaypointType.DIAMOND, 172, 37, 190, 55);
+        setSize(WaypointProfile.WaypointType.FLAG, 154, 36, 172, 54);  // TODO: Handle colours
+        setSize(WaypointProfile.WaypointType.SIGN, 190, 36, 208, 54);
+        setSize(WaypointProfile.WaypointType.STAR, 208, 36, 226, 54);
+        setSize(WaypointProfile.WaypointType.TURRET, 226, 36, 244, 54);
+    }
+
+    private WaypointProfile wp;
+
+    public MapWaypointIconInfo(WaypointProfile wp) {
+        initialise();
+
+        assert wp.getType().ordinal() < waypointTypesCount : "Invalid enum value in WaypointProfile.WaypointType: " + wp.getType().ordinal();
+
+        this.wp = wp;
+    }
+
+    @Override public AssetsTexture getTexture() {
+        return Textures.Map.map_icons;
+    }
+
+    @Override public int getPosX() {
+        return (int)wp.getX();
+    }
+
+    @Override public int getPosZ() {
+        return (int)wp.getZ();
+    }
+
+    @Override public String getName() {
+        return wp.getName();
+    }
+
+    @Override public int getTexPosX() {
+        return sizeMapping[wp.getType().ordinal() * 4 + texPosXIndex];
+    }
+
+    @Override public int getTexPosZ() {
+        return sizeMapping[wp.getType().ordinal() * 4 + texPosZIndex];
+    }
+
+    @Override public int getTexSizeX() {
+        return sizeMapping[wp.getType().ordinal() * 4 + texSizeXIndex];
+    }
+
+    @Override public int getTexSizeZ() {
+        return sizeMapping[wp.getType().ordinal() * 4 + texSizeZIndex];
+    }
+
+    @Override public float getSizeX() {
+        int i = wp.getType().ordinal() * 4;
+        return (sizeMapping[i + texSizeXIndex] - sizeMapping[i + texPosXIndex]) / 2.5f;
+    }
+
+    @Override public float getSizeZ() {
+        int i = wp.getType().ordinal() * 4;
+        return (sizeMapping[i + texSizeZIndex] - sizeMapping[i + texPosZIndex]) / 2.5f;
+    }
+
+    @Override public int getZoomNeeded() {
+        return wp.getZoomNeeded();
+    }
+
+    @Override public boolean isEnabled() {
+        return wp.getZoomNeeded() != HIDDEN_ZOOM;
+    }
+
+    @Override
+    public void renderAt(ScreenRenderer renderer, float centreX, float centreZ, float sizeMultiplier) {
+        GlStateManager.pushMatrix();
+        CustomColor color = wp.getColor();
+        GlStateManager.color(color.r, color.g, color.b, color.a);
+        super.renderAt(renderer, centreX, centreZ, sizeMultiplier);
+        GlStateManager.popMatrix();
+    }
+
+    public WaypointProfile getWaypointProfile() {
+        return wp;
+    }
+
+    private static List<MapIconInfo> waypoints = null;
+
+
+    public static List<MapIconInfo> getWaypoints() {
+        if (waypoints == null) {
+            resetWaypoints();
+        }
+        return waypoints;
+    }
+
+    public static void resetWaypoints() {
+        if (waypoints == null) {
+            waypoints = new ArrayList<>();
+        } else {
+            waypoints.clear();
+        }
+        MapConfig.Waypoints.INSTANCE.waypoints.forEach(c -> waypoints.add(new MapWaypointIconInfo(c)));
+    }
+}

--- a/src/main/java/com/wynntils/modules/map/overlays/objects/WorldMapIcon.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/objects/WorldMapIcon.java
@@ -12,18 +12,18 @@ import net.minecraft.client.renderer.GlStateManager;
 
 public class WorldMapIcon {
 
-    MapIconInfo info;
+    MapIcon info;
 
     float axisX = 0; float axisZ = 0;
     boolean shouldRender = false;
 
     float alpha = 1;
 
-    public WorldMapIcon(MapIconInfo info) {
+    public WorldMapIcon(MapIcon info) {
         this.info = info;
     }
 
-    public MapIconInfo getInfo() {
+    public MapIcon getInfo() {
         return info;
     }
 
@@ -32,7 +32,7 @@ public class WorldMapIcon {
             shouldRender = false;
             return;
         }
-        if(info.getZoomNeeded() != MapIconInfo.ANY_ZOOM) {
+        if(info.getZoomNeeded() != MapIcon.ANY_ZOOM) {
             alpha = 1 - ((zoom - info.getZoomNeeded()) / 40.0f);
 
             if(alpha <= 0) {

--- a/src/main/java/com/wynntils/modules/map/overlays/objects/WorldMapIcon.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/objects/WorldMapIcon.java
@@ -28,8 +28,12 @@ public class WorldMapIcon {
     }
 
     public void updateAxis(MapProfile mp, int width, int height, float maxX, float minX, float maxZ, float minZ, int zoom) {
-        if(info.zoomNeeded != -1000) {
-            alpha = 1 - ((zoom - info.zoomNeeded) / 40.0f);
+        if (!info.isEnabled()) {
+            shouldRender = false;
+            return;
+        }
+        if(info.getZoomNeeded() != MapIconInfo.ANY_ZOOM) {
+            alpha = 1 - ((zoom - info.getZoomNeeded()) / 40.0f);
 
             if(alpha <= 0) {
                 shouldRender = false;
@@ -50,7 +54,9 @@ public class WorldMapIcon {
     }
 
     public boolean mouseOver(int mouseX, int mouseY) {
-        return mouseX >= (axisX - info.sizeX) && mouseX <= (axisX + info.sizeX) && mouseY >= (axisZ - info.sizeZ) && mouseY <= (axisZ + info.sizeZ);
+        float sizeX = info.getSizeX();
+        float sizeZ = info.getSizeZ();
+        return mouseX >= (axisX - sizeX) && mouseX <= (axisX + sizeX) && mouseY >= (axisZ - sizeZ) && mouseY <= (axisZ + sizeZ);
     }
 
     public void drawScreen(int mouseX, int mouseY, float partialTicks, ScreenRenderer renderer) {
@@ -60,7 +66,9 @@ public class WorldMapIcon {
         GlStateManager.enableBlend();
         GlStateManager.color(1, 1, 1, alpha);
         float multi = mouseOver(mouseX, mouseY) ? 1.3f : 1f;
-        renderer.drawRectF(info.texture, axisX - info.sizeX * multi, axisZ - info.sizeZ * multi, axisX + info.sizeX * multi, axisZ + info.sizeZ * multi, info.texPosX, info.texPosZ, info.texSizeX, info.texSizeZ);
+
+        info.renderAt(renderer, axisX, axisZ, multi);
+
         GlStateManager.color(1,1,1,1);
 
         GlStateManager.popMatrix();
@@ -70,6 +78,6 @@ public class WorldMapIcon {
         if(!shouldRender || !mouseOver(mouseX, mouseY)) return;
 
         GlStateManager.color(1, 1, 1, 1);
-        renderer.drawString(info.name, (int)(axisX), (int)(axisZ)-20, CommonColors.MAGENTA, SmartFontRenderer.TextAlignment.MIDDLE, SmartFontRenderer.TextShadow.OUTLINE);
+        renderer.drawString(info.getName(), (int)(axisX), (int)(axisZ)-20, CommonColors.MAGENTA, SmartFontRenderer.TextAlignment.MIDDLE, SmartFontRenderer.TextShadow.OUTLINE);
     }
 }

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/WaypointCreationMenu.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/WaypointCreationMenu.java
@@ -7,10 +7,9 @@ import com.wynntils.modules.map.instances.WaypointProfile;
 import com.wynntils.modules.map.instances.WaypointProfile.WaypointType;
 import com.wynntils.modules.map.MapModule;
 import com.wynntils.modules.map.configs.MapConfig;
-import com.wynntils.modules.map.overlays.objects.MapWaypointIconInfo;
+import com.wynntils.modules.map.overlays.objects.MapWaypointIcon;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.*;
-import net.minecraft.util.text.TextFormatting;
 
 import java.io.IOException;
 
@@ -40,7 +39,7 @@ public class WaypointCreationMenu extends GuiScreen {
 
     private boolean isUpdatingExisting;
     private WaypointProfile wp;
-    private MapWaypointIconInfo wpIcon;
+    private MapWaypointIcon wpIcon;
     private GuiScreen previousGui;
 
     private int initialX;
@@ -154,7 +153,7 @@ public class WaypointCreationMenu extends GuiScreen {
     }
 
     private void setWpIcon(WaypointType type, int zoomNeeded, CustomColor colour) {
-        wpIcon = new MapWaypointIconInfo(new WaypointProfile("", 0, 0, 0, colour, type, zoomNeeded));
+        wpIcon = new MapWaypointIcon(new WaypointProfile("", 0, 0, 0, colour, type, zoomNeeded));
 
         final int disabledColour = 10526880;
         final int enabledColour = 0;
@@ -164,10 +163,10 @@ public class WaypointCreationMenu extends GuiScreen {
         hiddenButton.packedFGColour = disabledColour;
 
         switch (zoomNeeded) {
-            case MapWaypointIconInfo.ANY_ZOOM:
+            case MapWaypointIcon.ANY_ZOOM:
                 alwaysVisibleButton.packedFGColour = enabledColour;
                 break;
-            case MapWaypointIconInfo.HIDDEN_ZOOM:
+            case MapWaypointIcon.HIDDEN_ZOOM:
                 hiddenButton.packedFGColour = enabledColour;
                 break;
             default:
@@ -271,9 +270,9 @@ public class WaypointCreationMenu extends GuiScreen {
         } else if (button == defaultVisibilityButton) {
             setZoomNeeded(0);
         } else if (button == alwaysVisibleButton) {
-            setZoomNeeded(MapWaypointIconInfo.ANY_ZOOM);
+            setZoomNeeded(MapWaypointIcon.ANY_ZOOM);
         } else if (button == hiddenButton) {
-            setZoomNeeded(MapWaypointIconInfo.HIDDEN_ZOOM);
+            setZoomNeeded(MapWaypointIcon.HIDDEN_ZOOM);
         }
     }
 

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/WaypointCreationMenu.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/WaypointCreationMenu.java
@@ -2,15 +2,15 @@ package com.wynntils.modules.map.overlays.ui;
 
 import com.wynntils.core.framework.rendering.ScreenRenderer;
 import com.wynntils.core.framework.rendering.colors.CommonColors;
-import com.wynntils.core.framework.rendering.textures.Textures;
+import com.wynntils.core.framework.rendering.colors.CustomColor;
 import com.wynntils.modules.map.instances.WaypointProfile;
 import com.wynntils.modules.map.instances.WaypointProfile.WaypointType;
 import com.wynntils.modules.map.MapModule;
 import com.wynntils.modules.map.configs.MapConfig;
+import com.wynntils.modules.map.overlays.objects.MapWaypointIconInfo;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.*;
 import net.minecraft.util.text.TextFormatting;
-import net.minecraftforge.fml.client.config.GuiCheckBox;
 
 import java.io.IOException;
 
@@ -26,15 +26,21 @@ public class WaypointCreationMenu extends GuiScreen {
     private GuiLabel zCoordFieldLabel;
     private GuiTextField zCoordField;
     private GuiLabel coordinatesLabel;
-    private GuiCheckBox alwaysVisible;
+    private GuiButton defaultVisibilityButton;
+    private GuiButton alwaysVisibleButton;
+    private GuiButton hiddenButton;
+    private GuiSlider redSlider;
+    private GuiSlider blueSlider;
+    private GuiSlider greenSlider;
+    private GuiSlider alphaSlider;
     private GuiButton saveButton;
     private GuiButton cancelButton;
     private GuiButton waypointTypeNext;
     private GuiButton waypointTypeBack;
-    private WaypointType waypointType;
 
     private boolean isUpdatingExisting;
     private WaypointProfile wp;
+    private MapWaypointIconInfo wpIcon;
     private GuiScreen previousGui;
 
     private int initialX;
@@ -70,15 +76,58 @@ public class WaypointCreationMenu extends GuiScreen {
         yCoordField = new GuiTextField(3, mc.fontRenderer, this.width/2 + 55, this.height/2 - 30, 25, 20);
         buttonList.add(waypointTypeNext = new GuiButton(97, this.width/2 - 40, this.height/2 + 10, 18, 18, ">"));
         buttonList.add(waypointTypeBack = new GuiButton(98, this.width/2 - 80, this.height/2 + 10, 18, 18, "<"));
-        buttonList.add(alwaysVisible = new GuiCheckBox(99, this.width/2 - 29,this.height/2 + 40,"Always Visible",false));
-        buttonList.add(cancelButton = new GuiButton(100, this.width/2 - 71, this.height - 80, 45, 18, "Cancel"));
-        buttonList.add(saveButton = new GuiButton(101, this.width/2 + 25, this.height - 80, 45, 18, "Save"));
+
+        GuiPageButtonList.GuiResponder sliderResponder = new GuiPageButtonList.GuiResponder() {
+            @Override
+            public void setEntryValue(int id, float value) {
+                CustomColor currentColour = getColor();
+                switch (id) {
+                    case 104:
+                        currentColour.r = value;
+                        break;
+                    case 105:
+                        currentColour.g = value;
+                        break;
+                    case 106:
+                        currentColour.b = value;
+                        break;
+                    case 107:
+                        currentColour.a = value;
+                        break;
+                }
+            }
+
+            @Override public void setEntryValue(int id, boolean value) { }
+            @Override public void setEntryValue(int id, String value) { }
+        };
+
+        GuiSlider.FormatHelper formatter = new GuiSlider.FormatHelper() {
+            @Override
+            public String getText(int id, String name, float value) {
+                return name + ": " + Math.round(value * 100f) + "%";
+            }
+        };
+
+        CustomColor color = wp == null ? CommonColors.WHITE : wp.getColor();
+        buttonList.add(redSlider = new GuiSlider(sliderResponder, 104, this.width / 2, this.height / 2 + 9, "Red", 0, 1, color.r, formatter));
+        buttonList.add(greenSlider = new GuiSlider(sliderResponder, 105, this.width / 2, this.height / 2 + 9 + 21, "Green", 0, 1, color.g, formatter));
+        buttonList.add(blueSlider = new GuiSlider(sliderResponder, 106, this.width / 2, this.height / 2 + 9 + 21 * 2, "Blue", 0, 1, color.b, formatter));
+        buttonList.add(alphaSlider = new GuiSlider(sliderResponder, 107, this.width / 2, this.height / 2 + 9 + 21 * 3, "Alpha", 0, 1, color.a, formatter));
+
+        int visibilityButtonWidth = 100;
+        int visibilityButtonHeight = this.height / 2 + 9 + 21 * 4 + 5;
+        buttonList.add(defaultVisibilityButton = new GuiButton(99, this.width/2 - 3 * visibilityButtonWidth / 2 - 2, visibilityButtonHeight, visibilityButtonWidth, 18, "Default"));
+        buttonList.add(alwaysVisibleButton = new GuiButton(100, this.width/2 - visibilityButtonWidth / 2,visibilityButtonHeight, visibilityButtonWidth, 18, "Always Visible"));
+        buttonList.add(hiddenButton = new GuiButton(101, this.width/2 + visibilityButtonWidth / 2 + 2,visibilityButtonHeight, visibilityButtonWidth, 18, "Hidden"));
+
+        int cancelButtonHeight = this.height / 2 + 45;
+        buttonList.add(cancelButton = new GuiButton(102, this.width/2 - 100, cancelButtonHeight, 45, 18, "Cancel"));
+        buttonList.add(saveButton = new GuiButton(103, this.width/2 - 50, cancelButtonHeight, 45, 18, "Save"));
         saveButton.enabled = false;
 
         xCoordField.setText(Integer.toString(initialX));
         zCoordField.setText(Integer.toString(initialZ));
         yCoordField.setText(Integer.toString(Minecraft.getMinecraft().player.getPosition().getY()));
-        waypointType  = WaypointType.FLAG;
 
         nameFieldLabel = new GuiLabel(mc.fontRenderer,0,this.width/2 - 80,this.height/2 - 81,40,10,0xFFFFFF);
         nameFieldLabel.addLine("Waypoint Name:");
@@ -91,15 +140,63 @@ public class WaypointCreationMenu extends GuiScreen {
         coordinatesLabel = new GuiLabel(mc.fontRenderer,3,this.width/2 - 80,this.height/2 - 41,40,10,0xFFFFFF);
         coordinatesLabel.addLine("Coordinates:");
 
-        if (wp != null) {
+        if (wp == null) {
+            setWpIcon(WaypointType.FLAG, 0, color);
+        } else {
             nameField.setText(wp.getName());
             xCoordField.setText(Integer.toString((int) wp.getX()));
             yCoordField.setText(Integer.toString((int) wp.getY()));
             zCoordField.setText(Integer.toString((int) wp.getZ()));
-            alwaysVisible.setIsChecked(wp.getZoomNeeded() == -1000);
-            if (wp.getType() != null) waypointType = wp.getType();
+
+            setWpIcon(wp.getType(), wp.getZoomNeeded(), color);
             isAllValidInformation();
         }
+    }
+
+    private void setWpIcon(WaypointType type, int zoomNeeded, CustomColor colour) {
+        wpIcon = new MapWaypointIconInfo(new WaypointProfile("", 0, 0, 0, colour, type, zoomNeeded));
+
+        final int disabledColour = 10526880;
+        final int enabledColour = 0;
+
+        defaultVisibilityButton.packedFGColour = disabledColour;
+        alwaysVisibleButton.packedFGColour = disabledColour;
+        hiddenButton.packedFGColour = disabledColour;
+
+        switch (zoomNeeded) {
+            case MapWaypointIconInfo.ANY_ZOOM:
+                alwaysVisibleButton.packedFGColour = enabledColour;
+                break;
+            case MapWaypointIconInfo.HIDDEN_ZOOM:
+                hiddenButton.packedFGColour = enabledColour;
+                break;
+            default:
+                defaultVisibilityButton.packedFGColour = enabledColour;
+        }
+    }
+
+    private int getZoomNeeded() {
+        return wpIcon.getWaypointProfile().getZoomNeeded();
+    }
+
+    private void setZoomNeeded(int zoomNeeded) {
+        setWpIcon(getWaypointType(), zoomNeeded, getColor());
+    }
+
+    private WaypointType getWaypointType() {
+        return wpIcon.getWaypointProfile().getType();
+    }
+
+    private void setWaypointType(WaypointType waypointType) {
+        setWpIcon(waypointType, getZoomNeeded(), getColor());
+    }
+
+    private CustomColor getColor() {
+        return wpIcon.getWaypointProfile().getColor();
+    }
+
+    private void setColor(CustomColor color) {
+        setWpIcon(getWaypointType(), getZoomNeeded(), color);
     }
 
     @Override
@@ -118,52 +215,15 @@ public class WaypointCreationMenu extends GuiScreen {
         zCoordFieldLabel.drawLabel(mc, mouseX, mouseY);
         coordinatesLabel.drawLabel(mc, mouseX, mouseY);
 
-        int tx1 = 0; int tx2 = 0; int ty1 = 0; int ty2 = 0;
-        switch (waypointType) {
-            case LOOTCHEST_T1:
-                tx1 = 136; ty1 = 35;
-                tx2 = 154; ty2 = 53;
-                break;
-            case LOOTCHEST_T2:
-                tx1 = 118; ty1 = 35;
-                tx2 = 136; ty2 = 53;
-                break;
-            case LOOTCHEST_T3:
-                tx1 = 82; ty1 = 35;
-                tx2 = 100; ty2 = 53;
-                break;
-            case LOOTCHEST_T4:
-                tx1 = 100; ty1 = 35;
-                tx2 = 118; ty2 = 53;
-                break;
-            case DIAMOND:
-                tx1 = 172; ty1 = 37;
-                tx2 = 190; ty2 = 55;
-                break;
-            case FLAG:
-                //TODO handle colours
-                tx1 = 154; ty1 = 36;
-                tx2 = 172; ty2 = 54;
-                break;
-            case SIGN:
-                tx1 = 190; ty1 = 36;
-                tx2 = 208; ty2 = 54;
-                break;
-            case STAR:
-                tx1 = 208; ty1 = 36;
-                tx2 = 226; ty2 = 54;
-                break;
-            case TURRET:
-                tx1 = 226; ty1 = 36;
-                tx2 = 244; ty2 = 54;
-                break;
-        }
-
         fontRenderer.drawString("Icon:", this.width/2 - 80,this.height/2,0xFFFFFF, true);
         fontRenderer.drawString("Colour:", this.width/2,this.height/2,0xFFFFFF, true);
-        fontRenderer.drawString( "[" + TextFormatting.GRAY +"In Development"+ TextFormatting.RESET + "]", this.width/2, this.height/2 + 15, 0x808080, true);
         ScreenRenderer.beginGL(0, 0);
-        renderer.drawRect(Textures.Map.map_icons, (this.width/2 - 60), (this.height/2 + 10), (this.width/2 - 60) + 18, (this.height/2 + 10) + 18, tx1, ty1, tx2, ty2);
+
+        float centreX = this.width / 2f - 60 + 9;
+        float centreZ = this.height / 2f + 10 + 9;
+        float multiplier = 9f / Math.max(wpIcon.getSizeX(), wpIcon.getSizeZ());
+        wpIcon.renderAt(renderer, centreX, centreZ, multiplier);
+
         ScreenRenderer.endGL();
     }
 
@@ -190,19 +250,30 @@ public class WaypointCreationMenu extends GuiScreen {
     @Override
     protected void actionPerformed(GuiButton button) {
         if (button == saveButton) {
+            WaypointProfile newWp = new WaypointProfile(
+                    nameField.getText().trim(),
+                    Integer.valueOf(xCoordField.getText().trim()), Integer.valueOf(yCoordField.getText().trim()), Integer.valueOf(zCoordField.getText().trim()),
+                    getColor(), getWaypointType(), getZoomNeeded()
+            );
             if (isUpdatingExisting) {
-                MapConfig.Waypoints.INSTANCE.waypoints.set(MapConfig.Waypoints.INSTANCE.waypoints.indexOf(wp), new WaypointProfile(nameField.getText().trim(), Integer.valueOf(xCoordField.getText().trim()), Integer.valueOf(yCoordField.getText().trim()), Integer.valueOf(zCoordField.getText().trim()), CommonColors.WHITE, waypointType, alwaysVisible.isChecked() ? -1000 : 0));
+                MapConfig.Waypoints.INSTANCE.waypoints.set(MapConfig.Waypoints.INSTANCE.waypoints.indexOf(wp), newWp);
             } else {
-                MapConfig.Waypoints.INSTANCE.waypoints.add(new WaypointProfile(nameField.getText().trim(), Integer.valueOf(xCoordField.getText().trim()), Integer.valueOf(yCoordField.getText().trim()), Integer.valueOf(zCoordField.getText().trim()), CommonColors.WHITE, waypointType, alwaysVisible.isChecked() ? -1000 : 0));
+                MapConfig.Waypoints.INSTANCE.waypoints.add(newWp);
             }
             MapConfig.Waypoints.INSTANCE.saveSettings(MapModule.getModule());
             Minecraft.getMinecraft().displayGuiScreen(previousGui == null ? new WorldMapUI() : previousGui);
         } else if (button == cancelButton) {
             Minecraft.getMinecraft().displayGuiScreen(previousGui == null ? new WorldMapUI() : previousGui);
         } else if (button == waypointTypeNext) {
-            waypointType = WaypointType.values()[(waypointType.ordinal() + 1) % WaypointType.values().length];
+            setWaypointType(WaypointType.values()[(getWaypointType().ordinal() + 1) % WaypointType.values().length]);
         } else if (button == waypointTypeBack) {
-            waypointType = WaypointType.values()[(waypointType.ordinal() + (WaypointType.values().length - 1)) % WaypointType.values().length];
+            setWaypointType(WaypointType.values()[(getWaypointType().ordinal() + (WaypointType.values().length - 1)) % WaypointType.values().length]);
+        } else if (button == defaultVisibilityButton) {
+            setZoomNeeded(0);
+        } else if (button == alwaysVisibleButton) {
+            setZoomNeeded(MapWaypointIconInfo.ANY_ZOOM);
+        } else if (button == hiddenButton) {
+            setZoomNeeded(MapWaypointIconInfo.HIDDEN_ZOOM);
         }
     }
 
@@ -210,7 +281,7 @@ public class WaypointCreationMenu extends GuiScreen {
         if (!xCoordField.getText().trim().matches("(-?(?!0)\\d+)|0")) { xCoordField.setTextColor(0xFF6666); } else { xCoordField.setTextColor(0xFFFFFF); }
         if (!yCoordField.getText().trim().matches("(-?(?!0)\\d+)|0")) { yCoordField.setTextColor(0xFF6666); } else { yCoordField.setTextColor(0xFFFFFF); }
         if (!zCoordField.getText().trim().matches("(-?(?!0)\\d+)|0")) { zCoordField.setTextColor(0xFF6666); } else { zCoordField.setTextColor(0xFFFFFF); }
-        if (xCoordField.getText().trim().matches("(-?(?!0)\\d+)|0") && yCoordField.getText().trim().matches("(-?(?!0)\\d+)|0") && zCoordField.getText().trim().matches("(-?(?!0)\\d+)|0") && !nameField.getText().isEmpty() && waypointType != null){
+        if (xCoordField.getText().trim().matches("(-?(?!0)\\d+)|0") && yCoordField.getText().trim().matches("(-?(?!0)\\d+)|0") && zCoordField.getText().trim().matches("(-?(?!0)\\d+)|0") && !nameField.getText().isEmpty() && getWaypointType() != null){
             saveButton.enabled = true;
         } else {
             saveButton.enabled = false;

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/WaypointCreationMenu.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/WaypointCreationMenu.java
@@ -3,6 +3,8 @@ package com.wynntils.modules.map.overlays.ui;
 import com.wynntils.core.framework.rendering.ScreenRenderer;
 import com.wynntils.core.framework.rendering.colors.CommonColors;
 import com.wynntils.core.framework.rendering.colors.CustomColor;
+import com.wynntils.core.framework.ui.UI;
+import com.wynntils.core.framework.ui.elements.UIEColorWheel;
 import com.wynntils.modules.map.instances.WaypointProfile;
 import com.wynntils.modules.map.instances.WaypointProfile.WaypointType;
 import com.wynntils.modules.map.MapModule;
@@ -13,9 +15,7 @@ import net.minecraft.client.gui.*;
 
 import java.io.IOException;
 
-public class WaypointCreationMenu extends GuiScreen {
-
-    private ScreenRenderer renderer = new ScreenRenderer();
+public class WaypointCreationMenu extends UI {
     private GuiLabel nameFieldLabel;
     private GuiTextField nameField;
     private GuiLabel xCoordFieldLabel;
@@ -28,10 +28,7 @@ public class WaypointCreationMenu extends GuiScreen {
     private GuiButton defaultVisibilityButton;
     private GuiButton alwaysVisibleButton;
     private GuiButton hiddenButton;
-    private GuiSlider redSlider;
-    private GuiSlider blueSlider;
-    private GuiSlider greenSlider;
-    private GuiSlider alphaSlider;
+    private UIEColorWheel colorWheel;
     private GuiButton saveButton;
     private GuiButton cancelButton;
     private GuiButton waypointTypeNext;
@@ -67,8 +64,13 @@ public class WaypointCreationMenu extends GuiScreen {
         isUpdatingExisting = true;
     }
 
-    @Override
-    public void initGui() {
+    @Override public void onInit() { }
+    @Override public void onClose() { }
+    @Override public void onTick() { }
+    @Override public void onWindowUpdate() {
+        buttonList.clear();
+        UIElements.clear();
+
         nameField = new GuiTextField(0, mc.fontRenderer, this.width/2 - 80, this.height/2 - 70, 160, 20);
         xCoordField = new GuiTextField(1, mc.fontRenderer, this.width/2 - 65, this.height/2 - 30, 40, 20);
         zCoordField = new GuiTextField(2, mc.fontRenderer, this.width/2 - 5, this.height/2 - 30, 40, 20);
@@ -76,52 +78,14 @@ public class WaypointCreationMenu extends GuiScreen {
         buttonList.add(waypointTypeNext = new GuiButton(97, this.width/2 - 40, this.height/2 + 10, 18, 18, ">"));
         buttonList.add(waypointTypeBack = new GuiButton(98, this.width/2 - 80, this.height/2 + 10, 18, 18, "<"));
 
-        GuiPageButtonList.GuiResponder sliderResponder = new GuiPageButtonList.GuiResponder() {
-            @Override
-            public void setEntryValue(int id, float value) {
-                CustomColor currentColour = getColor();
-                switch (id) {
-                    case 104:
-                        currentColour.r = value;
-                        break;
-                    case 105:
-                        currentColour.g = value;
-                        break;
-                    case 106:
-                        currentColour.b = value;
-                        break;
-                    case 107:
-                        currentColour.a = value;
-                        break;
-                }
-            }
-
-            @Override public void setEntryValue(int id, boolean value) { }
-            @Override public void setEntryValue(int id, String value) { }
-        };
-
-        GuiSlider.FormatHelper formatter = new GuiSlider.FormatHelper() {
-            @Override
-            public String getText(int id, String name, float value) {
-                return name + ": " + Math.round(value * 100f) + "%";
-            }
-        };
-
-        CustomColor color = wp == null ? CommonColors.WHITE : wp.getColor();
-        buttonList.add(redSlider = new GuiSlider(sliderResponder, 104, this.width / 2, this.height / 2 + 9, "Red", 0, 1, color.r, formatter));
-        buttonList.add(greenSlider = new GuiSlider(sliderResponder, 105, this.width / 2, this.height / 2 + 9 + 21, "Green", 0, 1, color.g, formatter));
-        buttonList.add(blueSlider = new GuiSlider(sliderResponder, 106, this.width / 2, this.height / 2 + 9 + 21 * 2, "Blue", 0, 1, color.b, formatter));
-        buttonList.add(alphaSlider = new GuiSlider(sliderResponder, 107, this.width / 2, this.height / 2 + 9 + 21 * 3, "Alpha", 0, 1, color.a, formatter));
-
         int visibilityButtonWidth = 100;
-        int visibilityButtonHeight = this.height / 2 + 9 + 21 * 4 + 5;
+        int visibilityButtonHeight = this.height/2 + 40;
         buttonList.add(defaultVisibilityButton = new GuiButton(99, this.width/2 - 3 * visibilityButtonWidth / 2 - 2, visibilityButtonHeight, visibilityButtonWidth, 18, "Default"));
         buttonList.add(alwaysVisibleButton = new GuiButton(100, this.width/2 - visibilityButtonWidth / 2,visibilityButtonHeight, visibilityButtonWidth, 18, "Always Visible"));
         buttonList.add(hiddenButton = new GuiButton(101, this.width/2 + visibilityButtonWidth / 2 + 2,visibilityButtonHeight, visibilityButtonWidth, 18, "Hidden"));
 
-        int cancelButtonHeight = this.height / 2 + 45;
-        buttonList.add(cancelButton = new GuiButton(102, this.width/2 - 100, cancelButtonHeight, 45, 18, "Cancel"));
-        buttonList.add(saveButton = new GuiButton(103, this.width/2 - 50, cancelButtonHeight, 45, 18, "Save"));
+        buttonList.add(cancelButton = new GuiButton(102, this.width/2 - 71, this.height - 80, 45, 18, "Cancel"));
+        buttonList.add(saveButton = new GuiButton(103, this.width/2 + 25, this.height - 80, 45, 18, "Save"));
         saveButton.enabled = false;
 
         xCoordField.setText(Integer.toString(initialX));
@@ -138,6 +102,10 @@ public class WaypointCreationMenu extends GuiScreen {
         zCoordFieldLabel.addLine("Z");
         coordinatesLabel = new GuiLabel(mc.fontRenderer,3,this.width/2 - 80,this.height/2 - 41,40,10,0xFFFFFF);
         coordinatesLabel.addLine("Coordinates:");
+
+        UIElements.add(colorWheel = new UIEColorWheel(0, 0, this.width / 2, this.height / 2 + 9, 20, 20, true, this::setColor, this));
+
+        CustomColor color = wp == null ? CommonColors.WHITE : wp.getColor();
 
         if (wp == null) {
             setWpIcon(WaypointType.FLAG, 0, color);
@@ -172,6 +140,8 @@ public class WaypointCreationMenu extends GuiScreen {
             default:
                 defaultVisibilityButton.packedFGColour = enabledColour;
         }
+
+        colorWheel.setColor(colour);
     }
 
     private int getZoomNeeded() {
@@ -198,11 +168,17 @@ public class WaypointCreationMenu extends GuiScreen {
         setWpIcon(getWaypointType(), getZoomNeeded(), color);
     }
 
+    @Override public void onRenderPreUIE(ScreenRenderer renderer) {}
+
     @Override
     public void drawScreen(int mouseX, int mouseY, float partialTicks) {
         drawDefaultBackground();
 
         super.drawScreen(mouseX, mouseY, partialTicks);
+    }
+
+    @Override
+    public void onRenderPostUIE(ScreenRenderer renderer) {
         if (nameField != null) nameField.drawTextBox();
         if (xCoordField != null) xCoordField.drawTextBox();
         if (yCoordField != null) yCoordField.drawTextBox();
@@ -216,14 +192,11 @@ public class WaypointCreationMenu extends GuiScreen {
 
         fontRenderer.drawString("Icon:", this.width/2 - 80,this.height/2,0xFFFFFF, true);
         fontRenderer.drawString("Colour:", this.width/2,this.height/2,0xFFFFFF, true);
-        ScreenRenderer.beginGL(0, 0);
 
         float centreX = this.width / 2f - 60 + 9;
         float centreZ = this.height / 2f + 10 + 9;
         float multiplier = 9f / Math.max(wpIcon.getSizeX(), wpIcon.getSizeZ());
         wpIcon.renderAt(renderer, centreX, centreZ, multiplier);
-
-        ScreenRenderer.endGL();
     }
 
     @Override

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/WaypointOverviewUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/WaypointOverviewUI.java
@@ -1,13 +1,16 @@
 package com.wynntils.modules.map.overlays.ui;
 
 import com.wynntils.core.framework.rendering.ScreenRenderer;
+import com.wynntils.core.framework.rendering.colors.CommonColors;
 import com.wynntils.core.framework.rendering.textures.Textures;
 import com.wynntils.modules.map.MapModule;
 import com.wynntils.modules.map.configs.MapConfig;
 import com.wynntils.modules.map.instances.WaypointProfile;
+import com.wynntils.modules.map.overlays.objects.MapWaypointIconInfo;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.util.text.TextFormatting;
 
 import java.util.ArrayList;
@@ -53,51 +56,26 @@ public class WaypointOverviewUI extends GuiScreen {
             WaypointProfile wp = waypoints.get(page * pageHeight + i);
             if (wp == null || wp.getType() == null) continue;
 
-            int tx1 = 0; int tx2 = 0; int ty1 = 0; int ty2 = 0;
-            switch (wp.getType()) {
-                case LOOTCHEST_T1:
-                    tx1 = 136; ty1 = 35;
-                    tx2 = 154; ty2 = 53;
-                    break;
-                case LOOTCHEST_T2:
-                    tx1 = 118; ty1 = 35;
-                    tx2 = 136; ty2 = 53;
-                    break;
-                case LOOTCHEST_T3:
-                    tx1 = 82; ty1 = 35;
-                    tx2 = 100; ty2 = 53;
-                    break;
-                case LOOTCHEST_T4:
-                    tx1 = 100; ty1 = 35;
-                    tx2 = 118; ty2 = 53;
-                    break;
-                case DIAMOND:
-                    tx1 = 172; ty1 = 37;
-                    tx2 = 190; ty2 = 55;
-                    break;
-                case FLAG:
-                    //TODO handle colours
-                    tx1 = 154; ty1 = 36;
-                    tx2 = 172; ty2 = 54;
-                    break;
-                case SIGN:
-                    tx1 = 190; ty1 = 36;
-                    tx2 = 208; ty2 = 54;
-                    break;
-                case STAR:
-                    tx1 = 208; ty1 = 36;
-                    tx2 = 226; ty2 = 54;
-                    break;
-                case TURRET:
-                    tx1 = 226; ty1 = 36;
-                    tx2 = 244; ty2 = 54;
-                    break;
+            int colour = 0xFFFFFF;
+            boolean hidden = wp.getZoomNeeded() == MapWaypointIconInfo.HIDDEN_ZOOM;
+            if (hidden) {
+                colour = 0x636363;
             }
-            renderer.drawRect(Textures.Map.map_icons, this.width/2 - 180, 51 + 25 * i, this.width/2 - 162,69 + 25 * i, tx1, ty1, tx2, ty2);
-            fontRenderer.drawString(wp.getName(), this.width/2 - 150, 56 + 25 * i, 0xFFFFFF);
-            drawCenteredString(fontRenderer, Integer.toString((int) wp.getX()), this.width/2 - 35, 56 + 25 * i, 0xFFFFFF);
-            drawCenteredString(fontRenderer, Integer.toString((int) wp.getZ()), this.width/2 + 20, 56 + 25 * i, 0xFFFFFF);
-            drawCenteredString(fontRenderer, Integer.toString((int) wp.getY()), this.width/2 + 60, 56 + 25 * i, 0xFFFFFF);
+
+            MapWaypointIconInfo wpIcon = new MapWaypointIconInfo(wp);
+            float centreX = this.width / 2f - 171;
+            float centreZ = 60 + 25 * i;
+            float multiplier = 9f / Math.max(wpIcon.getSizeX(), wpIcon.getSizeZ());
+            wpIcon.renderAt(renderer, centreX, centreZ, multiplier);
+
+            fontRenderer.drawString(wp.getName(), this.width/2 - 150, 56 + 25 * i, colour);
+            drawCenteredString(fontRenderer, Integer.toString((int) wp.getX()), this.width/2 - 35, 56 + 25 * i, colour);
+            drawCenteredString(fontRenderer, Integer.toString((int) wp.getZ()), this.width/2 + 20, 56 + 25 * i, colour);
+            drawCenteredString(fontRenderer, Integer.toString((int) wp.getY()), this.width/2 + 60, 56 + 25 * i, colour);
+
+            if (hidden) {
+                drawHorizontalLine(this.width / 2 - 155, this.width / 2 + 75, (int) centreZ - 1, colour | 0xFF000000);
+            }
         }
         ScreenRenderer.endGL();
     }

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/WaypointOverviewUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/WaypointOverviewUI.java
@@ -1,16 +1,13 @@
 package com.wynntils.modules.map.overlays.ui;
 
 import com.wynntils.core.framework.rendering.ScreenRenderer;
-import com.wynntils.core.framework.rendering.colors.CommonColors;
-import com.wynntils.core.framework.rendering.textures.Textures;
 import com.wynntils.modules.map.MapModule;
 import com.wynntils.modules.map.configs.MapConfig;
 import com.wynntils.modules.map.instances.WaypointProfile;
-import com.wynntils.modules.map.overlays.objects.MapWaypointIconInfo;
+import com.wynntils.modules.map.overlays.objects.MapWaypointIcon;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
-import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.util.text.TextFormatting;
 
 import java.util.ArrayList;
@@ -57,12 +54,12 @@ public class WaypointOverviewUI extends GuiScreen {
             if (wp == null || wp.getType() == null) continue;
 
             int colour = 0xFFFFFF;
-            boolean hidden = wp.getZoomNeeded() == MapWaypointIconInfo.HIDDEN_ZOOM;
+            boolean hidden = wp.getZoomNeeded() == MapWaypointIcon.HIDDEN_ZOOM;
             if (hidden) {
                 colour = 0x636363;
             }
 
-            MapWaypointIconInfo wpIcon = new MapWaypointIconInfo(wp);
+            MapWaypointIcon wpIcon = new MapWaypointIcon(wp);
             float centreX = this.width / 2f - 171;
             float centreZ = 60 + 25 * i;
             float multiplier = 9f / Math.max(wpIcon.getSizeX(), wpIcon.getSizeZ());

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/WorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/WorldMapUI.java
@@ -14,8 +14,7 @@ import com.wynntils.modules.core.managers.CompassManager;
 import com.wynntils.modules.map.MapModule;
 import com.wynntils.modules.map.configs.MapConfig;
 import com.wynntils.modules.map.instances.MapProfile;
-import com.wynntils.modules.map.overlays.objects.MapApiIconInfo;
-import com.wynntils.modules.map.overlays.objects.MapIconInfo;
+import com.wynntils.modules.map.overlays.objects.MapIcon;
 import com.wynntils.modules.map.overlays.objects.MapTerritory;
 import com.wynntils.modules.map.overlays.objects.WorldMapIcon;
 import com.wynntils.modules.utilities.managers.KeyManager;
@@ -66,15 +65,15 @@ public class WorldMapUI extends GuiScreen {
         creationTime = System.currentTimeMillis();
 
         //HeyZeer0: Handles MiniMap markers provided by Wynn API
-        apiMapIcons = MapIconInfo.getApiMarkers(MapConfig.INSTANCE.iconTexture)
+        apiMapIcons = MapIcon.getApiMarkers(MapConfig.INSTANCE.iconTexture)
                 .stream()
                 .map(WorldMapIcon::new)
                 .collect(Collectors.toList());
 
         //HeyZeer0: Handles all waypoints
-        wpMapIcons = MapIconInfo.getWaypoints().stream().map(WorldMapIcon::new).collect(Collectors.toList());
+        wpMapIcons = MapIcon.getWaypoints().stream().map(WorldMapIcon::new).collect(Collectors.toList());
 
-        compassIcon = new WorldMapIcon(MapIconInfo.getCompass());
+        compassIcon = new WorldMapIcon(MapIcon.getCompass());
 
         //HeyZeer0: Handles the territories
         territories = WebManager.getTerritories().values().stream().map(c -> new MapTerritory(c).setRenderer(renderer)).collect(Collectors.toList());

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/WorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/WorldMapUI.java
@@ -68,7 +68,6 @@ public class WorldMapUI extends GuiScreen {
         //HeyZeer0: Handles MiniMap markers provided by Wynn API
         apiMapIcons = MapIconInfo.getApiMarkers(MapConfig.INSTANCE.iconTexture)
                 .stream()
-                .filter(c -> ((MapApiIconInfo) c).isEnabled())
                 .map(WorldMapIcon::new)
                 .collect(Collectors.toList());
 

--- a/src/main/java/com/wynntils/webapi/WebManager.java
+++ b/src/main/java/com/wynntils/webapi/WebManager.java
@@ -12,6 +12,7 @@ import com.wynntils.ModCore;
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.WynnGuildWarEvent;
 import com.wynntils.core.framework.FrameworkManager;
+import com.wynntils.modules.map.overlays.objects.MapApiIconInfo;
 import com.wynntils.webapi.account.WynntilsAccount;
 import com.wynntils.webapi.profiles.*;
 import com.wynntils.webapi.profiles.guild.GuildProfile;
@@ -402,6 +403,7 @@ public class WebManager {
         }.getType();
 
         mapMarkers = gson.fromJson(jsonArray, type);
+        MapApiIconInfo.resetApiMarkers();
     }
 
     /**
@@ -433,6 +435,7 @@ public class WebManager {
         Type type = new TypeToken<ArrayList<MapMarkerProfile>>() {}.getType();
 
         mapMarkers.addAll(gson.fromJson(jsonArray, type));
+        MapApiIconInfo.resetApiMarkers();
     }
 
     /**

--- a/src/main/java/com/wynntils/webapi/WebManager.java
+++ b/src/main/java/com/wynntils/webapi/WebManager.java
@@ -12,7 +12,7 @@ import com.wynntils.ModCore;
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.WynnGuildWarEvent;
 import com.wynntils.core.framework.FrameworkManager;
-import com.wynntils.modules.map.overlays.objects.MapApiIconInfo;
+import com.wynntils.modules.map.overlays.objects.MapApiIcon;
 import com.wynntils.webapi.account.WynntilsAccount;
 import com.wynntils.webapi.profiles.*;
 import com.wynntils.webapi.profiles.guild.GuildProfile;
@@ -403,7 +403,7 @@ public class WebManager {
         }.getType();
 
         mapMarkers = gson.fromJson(jsonArray, type);
-        MapApiIconInfo.resetApiMarkers();
+        MapApiIcon.resetApiMarkers();
     }
 
     /**
@@ -435,7 +435,7 @@ public class WebManager {
         Type type = new TypeToken<ArrayList<MapMarkerProfile>>() {}.getType();
 
         mapMarkers.addAll(gson.fromJson(jsonArray, type));
-        MapApiIconInfo.resetApiMarkers();
+        MapApiIcon.resetApiMarkers();
     }
 
     /**


### PR DESCRIPTION
Added a colour selector in the waypoint creation menu. Currently just calls `GlStateManager.color` and renders the icon as it normally would, and the actual selector itself is not the prettiest (Just 4 rgba sliders).

Also fixed a bug where the enabledMapIcons option wasn't honoured (I just forgot to do it in the minimap icon commit). And I also refactored a bunch of code (`MapIconInfo` -> `MapIcon`, which is now an abstract class, and replaced `drawRectF` drawing the icon with `MapIcon.renderAt`)