### PR TITLE
Added Wynncraft Content Team Nametag

### DIFF
--- a/src/main/java/com/wynntils/modules/utilities/managers/NametagManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/NametagManager.java
@@ -60,7 +60,7 @@ public class NametagManager {
     private static final NametagLabel guildLabel = new NametagLabel(MinecraftChatColors.AQUA, "Guild Member", 0.7f);
     private static final NametagLabel moderatorLabel = new NametagLabel(MinecraftChatColors.GOLD, "Wynncraft Moderator", 0.7f);
     private static final NametagLabel adminLabel = new NametagLabel(MinecraftChatColors.DARK_RED, "Wynncraft Admin", 0.7f);
-    private static final NametagLabel wynnContentTeamLabel = new NametagLabel(MinecraftChatColors.DARK_AQUA, "Wynncraft Content Team", 0.7f);
+    private static final NametagLabel wynnContentTeamLabel = new NametagLabel(MinecraftChatColors.DARK_AQUA, "Wynncraft CT", 0.7f);
     private static final NametagLabel developerLabel = new NametagLabel(null, TextFormatting.GOLD + (TextFormatting.BOLD + "Wynntils Developer"), 0.7f);
     private static final NametagLabel helperLabel = new NametagLabel(CommonColors.LIGHT_GREEN, "Wynntils Helper", 0.7f);
     private static final NametagLabel contentTeamLabel = new NametagLabel(CommonColors.RAINBOW, "Wynntils CT", 0.7f);

--- a/src/main/java/com/wynntils/modules/utilities/managers/NametagManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/NametagManager.java
@@ -60,7 +60,7 @@ public class NametagManager {
     private static final NametagLabel guildLabel = new NametagLabel(MinecraftChatColors.AQUA, "Guild Member", 0.7f);
     private static final NametagLabel moderatorLabel = new NametagLabel(MinecraftChatColors.GOLD, "Wynncraft Moderator", 0.7f);
     private static final NametagLabel adminLabel = new NametagLabel(MinecraftChatColors.DARK_RED, "Wynncraft Admin", 0.7f);
-    private static final NametagLabel wynnContentTeamLabel = new Nametaglabel(MinecraftChatColors.BLUE, "Wynncraft Content Team", 0.7f);
+    private static final NametagLabel wynnContentTeamLabel = new NametagLabel(MinecraftChatColors.DARK_AQUA, "Wynncraft Content Team", 0.7f);
     private static final NametagLabel developerLabel = new NametagLabel(null, TextFormatting.GOLD + (TextFormatting.BOLD + "Wynntils Developer"), 0.7f);
     private static final NametagLabel helperLabel = new NametagLabel(CommonColors.LIGHT_GREEN, "Wynntils Helper", 0.7f);
     private static final NametagLabel contentTeamLabel = new NametagLabel(CommonColors.RAINBOW, "Wynntils CT", 0.7f);
@@ -86,7 +86,7 @@ public class NametagManager {
 
             if(entity.getDisplayName().getUnformattedText().startsWith(TextFormatting.GOLD.toString())) customLabels.add(moderatorLabel); //moderator
             if(entity.getDisplayName().getUnformattedText().startsWith(TextFormatting.DARK_RED.toString())) customLabels.add(adminLabel); //admin
-            if(entity.getDisplayName().getUnformattedText().startsWith(TextFormatting.BLUE.toString())) customLabels.add(wynnContentTeamLabel); //Wynn CT
+            if(entity.getDisplayName().getUnformattedText().startsWith(TextFormatting.DARK_AQUA.toString())) customLabels.add(wynnContentTeamLabel); //Wynn CT
             if(WebManager.isModerator(entity.getUniqueID())) customLabels.add(developerLabel); //developer
             if(WebManager.isHelper(entity.getUniqueID())) customLabels.add(helperLabel); //helper
             if(WebManager.isContentTeam(entity.getUniqueID())) customLabels.add(contentTeamLabel); //contentTeam

--- a/src/main/java/com/wynntils/modules/utilities/managers/NametagManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/NametagManager.java
@@ -60,6 +60,7 @@ public class NametagManager {
     private static final NametagLabel guildLabel = new NametagLabel(MinecraftChatColors.AQUA, "Guild Member", 0.7f);
     private static final NametagLabel moderatorLabel = new NametagLabel(MinecraftChatColors.GOLD, "Wynncraft Moderator", 0.7f);
     private static final NametagLabel adminLabel = new NametagLabel(MinecraftChatColors.DARK_RED, "Wynncraft Admin", 0.7f);
+    private static final NametagLabel wynnContentTeamLabel = new Nametaglabel(MinecraftChatColors.BLUE, "Wynncraft Content Team", 0.7f);
     private static final NametagLabel developerLabel = new NametagLabel(null, TextFormatting.GOLD + (TextFormatting.BOLD + "Wynntils Developer"), 0.7f);
     private static final NametagLabel helperLabel = new NametagLabel(CommonColors.LIGHT_GREEN, "Wynntils Helper", 0.7f);
     private static final NametagLabel contentTeamLabel = new NametagLabel(CommonColors.RAINBOW, "Wynntils CT", 0.7f);
@@ -85,6 +86,7 @@ public class NametagManager {
 
             if(entity.getDisplayName().getUnformattedText().startsWith(TextFormatting.GOLD.toString())) customLabels.add(moderatorLabel); //moderator
             if(entity.getDisplayName().getUnformattedText().startsWith(TextFormatting.DARK_RED.toString())) customLabels.add(adminLabel); //admin
+            if(entity.getDisplayName().getUnformattedText().startsWith(TextFormatting.BLUE.toString())) customLabels.add(wynnContentTeamLabel); //Wynn CT
             if(WebManager.isModerator(entity.getUniqueID())) customLabels.add(developerLabel); //developer
             if(WebManager.isHelper(entity.getUniqueID())) customLabels.add(helperLabel); //helper
             if(WebManager.isContentTeam(entity.getUniqueID())) customLabels.add(contentTeamLabel); //contentTeam


### PR DESCRIPTION
Adds the "Wynncraft Content Team" label in a similar fashion to that of "Wynncraft Admin" and "Wynncraft Moderator".