### PR TITLE
Improve wynncraft team nametags

### DIFF
--- a/src/main/java/com/wynntils/modules/utilities/managers/NametagManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/NametagManager.java
@@ -67,9 +67,10 @@ public class NametagManager {
             if(PlayerInfo.getPlayerInfo().getFriendList().contains(entity.getName())) customLabels.add(friendLabel); //friend
             else if(PlayerInfo.getPlayerInfo().getGuildList().contains(entity.getName())) customLabels.add(guildLabel); //guild
 
-            if(entity.getDisplayName().getUnformattedText().startsWith(TextFormatting.GOLD.toString())) customLabels.add(moderatorLabel); //moderator
-            if(entity.getDisplayName().getUnformattedText().startsWith(TextFormatting.DARK_RED.toString())) customLabels.add(adminLabel); //admin
-            if(entity.getDisplayName().getUnformattedText().startsWith(TextFormatting.DARK_AQUA.toString())) customLabels.add(wynnContentTeamLabel); //Wynn CT
+            //wynncraft teams (Admin, Moderator, GM, Builder, etc.)
+            if (entity.getTeam() != null && !(entity.getTeam().getName().equalsIgnoreCase("all") || entity.getTeam().getName().equalsIgnoreCase("afk"))) {
+                customLabels.add(new NametagLabel(null, entity.getTeam().getColor() + "Wynncraft " + entity.getTeam().getName(), 0.7f));
+            }
             if(WebManager.isModerator(entity.getUniqueID())) customLabels.add(developerLabel); //developer
             if(WebManager.isHelper(entity.getUniqueID())) customLabels.add(helperLabel); //helper
             if(WebManager.isContentTeam(entity.getUniqueID())) customLabels.add(contentTeamLabel); //contentTeam

--- a/src/main/java/com/wynntils/modules/utilities/managers/NametagManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/NametagManager.java
@@ -32,6 +32,7 @@ import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.client.event.RenderLivingEvent;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -48,6 +49,7 @@ public class NametagManager {
     private static final NametagLabel helperLabel = new NametagLabel(CommonColors.LIGHT_GREEN, "Wynntils Helper", 0.7f);
     private static final NametagLabel contentTeamLabel = new NametagLabel(CommonColors.RAINBOW, "Wynntils CT", 0.7f);
     private static final NametagLabel donatorLabel = new NametagLabel(CommonColors.RAINBOW, "Wynntils Donator", 0.7f);
+    private static final HashMap<String, NametagLabel> wynncraftTeamLabels = new HashMap<>();
 
     public static final Pattern MOB_LEVEL = Pattern.compile("(" + TextFormatting.GOLD + " \\[Lv\\. (.*?)\\])");
     private static final ScreenRenderer renderer = new ScreenRenderer();
@@ -69,7 +71,7 @@ public class NametagManager {
 
             //wynncraft teams (Admin, Moderator, GM, Builder, etc.)
             if (entity.getTeam() != null && !(entity.getTeam().getName().equalsIgnoreCase("all") || entity.getTeam().getName().equalsIgnoreCase("afk"))) {
-                customLabels.add(new NametagLabel(null, entity.getTeam().getColor() + "Wynncraft " + entity.getTeam().getName(), 0.7f));
+                customLabels.add(getWynncraftTeamLabel(entity.getTeam()));
             }
             if(WebManager.isModerator(entity.getUniqueID())) customLabels.add(developerLabel); //developer
             if(WebManager.isHelper(entity.getUniqueID())) customLabels.add(helperLabel); //helper
@@ -262,6 +264,13 @@ public class NametagManager {
         }
 
         return labels;
+    }
+
+    private static NametagLabel getWynncraftTeamLabel(Team team) {
+        if (!wynncraftTeamLabels.containsKey(team.getName())) {
+            wynncraftTeamLabels.put(team.getName(), new NametagLabel(null, team.getColor() + "Wynncraft " + team.getName(), 0.7f));
+        }
+        return wynncraftTeamLabels.get(team.getName());
     }
 
 }


### PR DESCRIPTION
This makes the nametags for the wynncraft teams (such as Moderator, Admin, GM) based on the name of the scoreboard team the player has assigned by wynncraft. 

For Moderators and Admins I don't think anything changes in appearance. People that originally had "Wynncraft CT" will now get their specific rank such as GM or Builder. 

This might also fix [Issue#144](https://github.com/Wynntils/Wynntils/issues/144) but my guess is that [Issue#144](https://github.com/Wynntils/Wynntils/issues/144) is happening because the specific player with the art rank doesn't have a scoreboard team or the art rank in general doesn't have a scoreboard team.