### PR TITLE
implement a "/s" command to interact with the onlinePlayers API

### DIFF
--- a/src/main/java/com/wynntils/core/framework/FrameworkManager.java
+++ b/src/main/java/com/wynntils/core/framework/FrameworkManager.java
@@ -126,6 +126,7 @@ public class FrameworkManager {
         ClientCommandHandler.instance.registerCommand(new CommandCompass());
         ClientCommandHandler.instance.registerCommand(new CommandTerritory());
         ClientCommandHandler.instance.registerCommand(new CommandExportDiscoveries());
+        ClientCommandHandler.instance.registerCommand(new CommandServer());
     }
 
     public static void disableModules() {

--- a/src/main/java/com/wynntils/modules/core/commands/CommandServer.java
+++ b/src/main/java/com/wynntils/modules/core/commands/CommandServer.java
@@ -127,7 +127,7 @@ public class CommandServer extends CommandBase implements IClientCommand {
         }
     }
 
-    private void serverInfo (MinecraftServer server, ICommandSender sender, String[] args) {
+    private void serverInfo(MinecraftServer server, ICommandSender sender, String[] args) {
         try {
             HashMap<String, ArrayList<String>> onlinePlayers = WebManager.getOnlinePlayers();
             if (args.length >= 1) {
@@ -163,7 +163,7 @@ public class CommandServer extends CommandBase implements IClientCommand {
         }
     }
 
-    private TextComponentString getFilteredServerList (HashMap<String, ArrayList<String>> onlinePlayers,
+    private TextComponentString getFilteredServerList(HashMap<String, ArrayList<String>> onlinePlayers,
                                                        String filter,
                                                        List<String> options) {
         TextComponentString text = new TextComponentString("");

--- a/src/main/java/com/wynntils/modules/core/commands/CommandServer.java
+++ b/src/main/java/com/wynntils/modules/core/commands/CommandServer.java
@@ -1,0 +1,207 @@
+package com.wynntils.modules.core.commands;
+
+import com.google.common.collect.Lists;
+import com.wynntils.Reference;
+import com.wynntils.webapi.WebManager;
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.CommandException;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.text.TextComponentString;
+import net.minecraft.util.text.TextFormatting;
+import net.minecraftforge.client.IClientCommand;
+
+import java.util.*;
+
+
+public class CommandServer extends CommandBase implements IClientCommand {
+    private List<String> serverTypes = Lists.newArrayList("WC", "lobby", "GM", "WAR", "HB");
+
+    @Override
+    public boolean allowUsageWithoutPrefix(ICommandSender sender, String message) {
+        return false;
+    }
+
+    @Override
+    public String getName() {
+        return "s";
+    }
+
+    @Override
+    public String getUsage(ICommandSender sender) {
+        return "/s <command> [options]\n\ncommands:\nl,ls,list | list avaiable servers\ni,info | get info about a server\n\nmore detailed help:\n/s <command> help";
+    }
+
+    @Override
+    public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException {
+        if (Reference.onServer) {
+            if (args.length >= 1) {
+                //String option = args[0];
+                switch (args[0].toLowerCase()) {
+                    case "list":
+                    case "ls":
+                    case "l":
+                        serverList(server, sender, Arrays.copyOfRange(args, 1, args.length));
+                        break;
+                    case "info":
+                    case "i":
+                        serverInfo(server, sender, Arrays.copyOfRange(args, 1, args.length));
+                        break;
+                    default:
+                        throw new CommandException(getUsage(sender));
+                }
+            } else {
+                throw new CommandException(getUsage(sender));
+            }
+        }
+    }
+
+    private void serverList(MinecraftServer server, ICommandSender sender, String[] args) {
+        List<String> options = new ArrayList<>();
+        String selectedType = null;
+
+        for (String arg : args) {
+            argparser:
+            for (String type : serverTypes) {
+                if (arg.equalsIgnoreCase(type)) {
+                    selectedType = type;
+                    break argparser;
+                }
+            }
+            switch(arg.toLowerCase()) {
+                case "group":
+                case "g":
+                    options.add("group");
+                    break;
+                case "sort":
+                case "s":
+                    options.add("sort");
+                    options.add("group");
+                    break;
+                case "count":
+                case "c":
+                    options.add("count");
+                    break;
+                case "help":
+                case "h":
+                    options.add("help");
+                    break;
+            }
+        }
+
+        TextComponentString text;
+        if (options.contains("help")) {
+            text = new TextComponentString(
+                    "Usage: /s list [type] [options]\n order of types and options does not matter\nDefault: print all servers oldest to new\n\ntypes:\n");
+            for (String type : serverTypes) {
+                text.appendText(String.format("  %s\n", type));
+            }
+            text.appendText("options:\n");
+            text.appendText("  g, group : group servers by type\n");
+            text.appendText("  s, sort : sort servers alphabetically, sets group flag\n");
+            text.appendText("  c, count : print amount of online servers\n");
+            text.appendText("  h, help : this help\n");
+            sender.sendMessage(text);
+            return;
+        }
+
+        try {
+            HashMap<String, ArrayList<String>> onlinePlayers = WebManager.getOnlinePlayers();
+            if (selectedType != null) {
+                sender.sendMessage(getFilteredServerList(onlinePlayers, selectedType, options));
+            } else if (options.contains("group")) {
+                text = new TextComponentString("Available servers" +
+                        (options.contains("count") ? String.format(" (%d)", onlinePlayers.size()): "") + ":\n");
+
+                for (String type : serverTypes.subList(0, serverTypes.size() - 1)) {
+                    text.appendSibling(getFilteredServerList(onlinePlayers, type, options));
+                    text.appendText("\n");
+                }
+                text.appendSibling(getFilteredServerList(onlinePlayers, serverTypes.get(serverTypes.size() - 1), options));
+                sender.sendMessage(text);
+            } else { //args.length == 0
+                sender.sendMessage(getFilteredServerList(onlinePlayers, "", options));
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void serverInfo (MinecraftServer server, ICommandSender sender, String[] args) {
+        try {
+            HashMap<String, ArrayList<String>> onlinePlayers = WebManager.getOnlinePlayers();
+            if (args.length >= 1) {
+                for (String serverName : onlinePlayers.keySet()) {
+                    if (args[0].equalsIgnoreCase(serverName)) {
+                        TextComponentString text = new TextComponentString(String.format("%s: ", serverName));
+                        TextComponentString playerText = new TextComponentString("");
+
+                        ArrayList<String> players = onlinePlayers.get(serverName);
+
+                        for (String player : players.subList(0, players.size() - 1)) {
+                            playerText.appendText(String.format("%s, ", player));
+                        }
+                        playerText.appendText(players.get(players.size() - 1));
+                        playerText.getStyle().setColor(TextFormatting.GRAY);
+                        text.appendSibling(playerText);
+
+                        text.appendText("\nTotal online players: ");
+                        TextComponentString playerCountText = new TextComponentString(String.valueOf(players.size()));
+                        playerCountText.getStyle().setColor(TextFormatting.GRAY);
+                        text.appendSibling(playerCountText);
+
+                        sender.sendMessage(text);
+                        return;
+                    }
+                }
+                sender.sendMessage(new TextComponentString(String.format("Unknown server ID: %s", args[0])));
+            } else { //args.length == 0
+                sender.sendMessage(new TextComponentString("Usage: /s info <serverID>"));
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private TextComponentString getFilteredServerList (HashMap<String, ArrayList<String>> onlinePlayers,
+                                                       String filter,
+                                                       List<String> options) {
+        TextComponentString text = new TextComponentString("");
+        TextComponentString serverListText = new TextComponentString("");
+
+        int serverCount = 0;
+        for (String serverName : options.contains("sort") ? new TreeSet<>(onlinePlayers.keySet()) : onlinePlayers.keySet()) {
+            if (serverName.toLowerCase().contains(filter.toLowerCase())) {
+                TextComponentString serverText = new TextComponentString(String.format("%s ", serverName));
+                if (onlinePlayers.get(serverName).size() >= 48) {serverText.getStyle().setColor(TextFormatting.RED);}
+                else {serverText.getStyle().setColor(TextFormatting.GREEN);}
+                serverListText.appendSibling(serverText);
+                serverCount++;
+            }
+        }
+
+        if (filter.equals("")) {
+            text.appendText("Available servers" +
+                    (options.contains("count") ? String.format(" (%d)", onlinePlayers.size()): "") + ":\n");
+        } else if (options.contains("count")) {
+            text.appendText(String.format("%s (%d):\n", filter, serverCount));
+        } else {
+            text.appendText(String.format("%s:\n", filter));
+        }
+
+        if(serverCount == 0) {
+            serverListText.appendText("none");
+            serverListText.getStyle().setColor(TextFormatting.DARK_GRAY);
+            text.getStyle().setColor(TextFormatting.GRAY);
+        }
+
+        text.appendSibling(serverListText);
+
+        return text;
+    }
+
+    @Override
+    public int getRequiredPermissionLevel() {
+        return 0;
+    }
+}

--- a/src/main/java/com/wynntils/webapi/WebManager.java
+++ b/src/main/java/com/wynntils/webapi/WebManager.java
@@ -41,6 +41,7 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.UUID;
 
@@ -354,7 +355,7 @@ public class WebManager {
         JsonObject main = new JsonParser().parse(IOUtils.toString(st.getInputStream(), StandardCharsets.UTF_8)).getAsJsonObject();
         main.remove("request");
 
-        Type type = new TypeToken<HashMap<String, ArrayList<String>>>() {
+        Type type = new TypeToken<LinkedHashMap<String, ArrayList<String>>>() {
         }.getType();
 
         return gson.fromJson(main, type);


### PR DESCRIPTION
The command has two main functions, 
1. /s list
this will list the available servers, by default sorted from oldest to newest (largest to smallest uptime). 
server colors will be based on the amount of online players, it follows the same colors as in the compass menu
it accepts options to
    - group the results by server type e.g. lobby servers and wc game servers
    - filter by server type
    - sort by alphabet
    - count the amount of online servers
2. /s info <serverID>
this will give information about the server, currently it is only able to show the player list and the player count. 
Online time would be nice but I can only get the relative online time from the api. Real online time can only be determined by constantly polling (by a third party, not the client)

The main reason to add this is to be able to quickly poll the newest server when you get the notice that your server is going to restart. It is not possible to derive this from the compass menu, and the compass menu is also not available from the game servers.

On the info command I did not implement the feature to poll the rank of each member, this because a full server will trigger 50 api calls for the ranks. This will get you quickly to the API call limit.

the command also supports short versions of the keywords to more easily type the command. This is supported on the [i]nfo [l]ist commands and also all options from the list command (first letter of the word)