### PR TITLE
Prevent hotkey with press enabled from firing multiple times on keydown

### DIFF
--- a/src/main/java/com/wynntils/core/framework/instances/KeyHolder.java
+++ b/src/main/java/com/wynntils/core/framework/instances/KeyHolder.java
@@ -12,6 +12,7 @@ public class KeyHolder {
     private Runnable onAction;
     private boolean press;
     private KeyBinding keyBinding;
+    public boolean wasPressed;
 
     public KeyHolder(String name, int key, String tab, boolean press, Runnable onAction) {
         this.onAction = onAction;

--- a/src/main/java/com/wynntils/core/framework/instances/containers/ModuleContainer.java
+++ b/src/main/java/com/wynntils/core/framework/instances/containers/ModuleContainer.java
@@ -51,11 +51,14 @@ public class ModuleContainer {
             return;
         }
         keyHolders.forEach(k -> {
-            if(k.isPress() && k.getKeyBinding().isPressed()) {
-                k.getOnAction().run();
-            }else if(!k.isPress() && k.getKeyBinding().isKeyDown()) {
+            if (!k.getKeyBinding().isKeyDown()) k.wasPressed = false;
+
+            if (k.isPress() && k.getKeyBinding().isKeyDown() && !k.wasPressed) {
+                k.wasPressed = true;
                 k.getOnAction().run();
             }
+
+            if (!k.isPress() && k.getKeyBinding().isKeyDown()) k.getOnAction().run();
         });
     }
 


### PR DESCRIPTION
Prevented use of the KeyBinding.isPressed() function which isn't meant for continuous querying according to function description. This should fix the bug where a hotkey action in press mode is fired multiple times during one key press.