### PR TITLE
Fix Fabled item highlight

### DIFF
--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -203,7 +203,7 @@ public class UtilitiesConfig extends SettingsClass {
         public CustomColor mythicHighlightColor = new CustomColor(0.3f, 0, 0.3f);
 
         @Setting(displayName = "Fabled Item Highlight Colour", description = "What colour should the highlight for fabled items be?\n\n§aClick the coloured box to open the colour wheel.", order = 52)
-        public CustomColor fabledHighlightColor = new CustomColor(1, .58f, .49f);
+        public CustomColor fabledHighlightColor = new CustomColor(1, 1/3f, 1/3f);
 
         @Setting(displayName = "Rare Item Highlight Colour", description = "What colour should the highlight for rare items be?\n\n§aClick the coloured box to open the colour wheel.", order = 53)
         public CustomColor rareHighlightColor = new CustomColor(1, 0, 1);

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/HotbarOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/HotbarOverlay.java
@@ -61,6 +61,7 @@ public class HotbarOverlay extends Overlay {
                 if (description.contains(TextFormatting.YELLOW + "Unique")) color = UtilitiesConfig.Items.INSTANCE.uniqueHighlightColor;
                 else if (description.contains(TextFormatting.LIGHT_PURPLE + "Rare")) color = UtilitiesConfig.Items.INSTANCE.rareHighlightColor;
                 else if (description.contains(TextFormatting.AQUA + "Legendary")) color = UtilitiesConfig.Items.INSTANCE.lengendaryHighlightColor;
+                else if (description.contains(TextFormatting.RED + "Fabled")) color = UtilitiesConfig.Items.INSTANCE.fabledHighlightColor;
                 else if (description.contains(TextFormatting.GREEN + "Set")) color = UtilitiesConfig.Items.INSTANCE.setHighlightColor;
                 else if (description.contains(TextFormatting.DARK_PURPLE + "Mythic")) color = UtilitiesConfig.Items.INSTANCE.mythicHighlightColor;
 


### PR DESCRIPTION
Fabled item highlight colour changed from #ff8c8c to #ff5555 to match the text colour and to make it more visible.
Old vs New
![image](https://user-images.githubusercontent.com/10358674/71321965-2de1fc00-24ca-11ea-8b81-da4a60b4b5cf.png)

Also fixed Fabled items not being highlighted on the hotbar.
