### PR TITLE
Add labels to map

### DIFF
--- a/scripts/update-labels-json.sh
+++ b/scripts/update-labels-json.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+# This script will retrieve the labels.js file from map.wynncraft.com, parse
+# the locations and coordinates that are present in it, and convert it to a
+# json file.
+MYDIR=$(cd $(dirname "$0") && pwd)
+TARGET="$MYDIR/../src/main/resources/assets/wynntils/labels.json"
+
+command -v curl > /dev/null 2>&1
+if test $? -ne 0; then
+  echo curl is required
+  exit 1
+fi
+
+command -v gawk > /dev/null 2>&1
+if test $? -ne 0; then
+  echo gawk is required
+  exit 1
+fi
+
+command -v jq > /dev/null 2>&1
+if test $? -ne 0; then
+  echo jq is required
+  exit 1
+fi
+
+curl -s https://map.wynncraft.com/js/labels.js | gawk '
+function jsonval(v)
+{
+  return "\""v"\": " SYMTAB[v]
+}
+
+function jsonvalquote(v)
+{
+  return "\""v"\": \"" SYMTAB[v] "\""
+}
+
+match($0, /fromWorldToLatLng\( *([0-9-]*), *[0-9-]*, *([0-9-]*), *ovconf/, a) {
+  x = a[1];
+  z = a[2];
+}
+match($0, /labelHtml\('"'"'(.*) *<div class="level">\[Lv. ([0-9+ -]*)\]<\/div>'"'"', '"'"'([0-9]*)'"'"'/, b) {
+  name = b[1];
+  gsub(/[ \t]+$/, "", name);
+  gsub("\\\\", "", name);
+
+  level = b[2]
+  gsub(" ", "", level);
+
+  switch (b[3]) {
+case 25:
+    layer=1; break
+case 16:
+    layer=2; break
+case 14:
+    layer=3; break
+  }
+  print "{ " jsonval("x") ", " jsonval("z") ", " jsonvalquote("name") ", " jsonval("layer") ", " jsonvalquote("level") " }"
+}
+
+match($0, /labelHtml\('"'"'([^[]*)'"'"', '"'"'([0-9]*)'"'"'/, b) {
+  name = b[1];
+  gsub(/[ \t]+$/, "", name);
+  gsub("\\\\", "", name);
+
+  switch (b[2]) {
+case 25:
+    layer=1; break
+case 16:
+    layer=2; break
+case 14:
+    layer=3; break
+  }
+  print "{ " jsonval("x") ", " jsonval("z") ", " jsonvalquote("name") ", " jsonval("layer") " }"
+}
+' | jq -s '{labels: .}' > "$TARGET"
+
+echo Finished updating "$TARGET"

--- a/src/main/java/com/wynntils/modules/map/configs/MapConfig.java
+++ b/src/main/java/com/wynntils/modules/map/configs/MapConfig.java
@@ -102,6 +102,9 @@ public class MapConfig extends SettingsClass {
 
         @Setting(displayName = "Show Friends on Map", description = "Should online friends in your world be displayed on your map?")
         public boolean showFriends = true;
+
+        @Setting(displayName = "Show Labels", description = "Should place labels be displayed on your map?")
+        public boolean showLabels = true;
     }
 
     @SettingsInfo(name = "map_textures", displayPath = "Map/Textures")

--- a/src/main/java/com/wynntils/modules/map/overlays/objects/MapIcon.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/objects/MapIcon.java
@@ -78,6 +78,10 @@ public abstract class MapIcon {
         return MapApiIcon.getApiMarkers(iconTexture);
     }
 
+    public static List<MapIcon> getLabels() {
+        return MapLabel.getLabels();
+    }
+
     public static List<MapIcon> getWaypoints() {
         return MapWaypointIcon.getWaypoints();
     }

--- a/src/main/java/com/wynntils/modules/map/overlays/objects/MapLabel.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/objects/MapLabel.java
@@ -49,13 +49,7 @@ public class MapLabel extends MapIcon {
     }
 
     @Override public int getZoomNeeded() {
-        if (mlp.getLayer() == 3) {
-            return 110;
-        } else if (mlp.getLayer() == 2) {
-            return 270;
-        } else {
-            return 400;
-        }
+        throw new UnsupportedOperationException("Not valid for MapLabel");
     }
 
     @Override public boolean isEnabled(boolean forMinimap) {
@@ -72,25 +66,9 @@ public class MapLabel extends MapIcon {
         return false;
     }
 
-    public CustomColor getColorFromLayer(float alpha) {
-        CustomColor color;
-        if (getLayer() == 1) {
-            color = new CustomColor(1.0f, 0, 0, 0.7f * alpha);
-        } else if (getLayer() == 2) {
-            color = new CustomColor(1.0f, 1.0f, 0, 0.85f * alpha);
-        } else {
-            color = new CustomColor(1.0f, 1.0f, 1.0f, 0.7f * alpha);
-        }
-        return color;
-    }
-
-    public void renderAt(ScreenRenderer renderer, float centreX, float centreZ, float sizeMultiplier, float blockScale, float alpha) {
-        renderer.drawString(getName(), centreX - getSizeX(), centreZ - getSizeZ(), getColorFromLayer(alpha));
-    }
-
     @Override
     public void renderAt(ScreenRenderer renderer, float centreX, float centreZ, float sizeMultiplier, float blockScale) {
-        renderAt(renderer, centreX, centreZ, sizeMultiplier, blockScale, 1.0f);
+        throw new UnsupportedOperationException("Not valid for MapLabel");
     }
 
     private static List<MapIcon> labels = null;

--- a/src/main/java/com/wynntils/modules/map/overlays/objects/MapLabel.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/objects/MapLabel.java
@@ -5,7 +5,8 @@
 package com.wynntils.modules.map.overlays.objects;
 
 import com.wynntils.core.framework.rendering.ScreenRenderer;
-import com.wynntils.core.framework.rendering.colors.CommonColors;
+import com.wynntils.core.framework.rendering.colors.CustomColor;
+import com.wynntils.modules.map.configs.MapConfig;
 import com.wynntils.webapi.WebManager;
 import com.wynntils.webapi.profiles.MapLabelProfile;
 
@@ -31,20 +32,34 @@ public class MapLabel extends MapIcon {
         return mlp.getName();
     }
 
+    public String getLevel() {
+        return mlp.getLevel();
+    }
+
+    public int getLayer() {
+        return mlp.getLayer();
+    }
+
     @Override public float getSizeX() {
-        return 8;
+        return ScreenRenderer.fontRenderer.getStringWidth(getName()) / 2;
     }
 
     @Override public float getSizeZ() {
-        return 8;
+        return 4;
     }
 
     @Override public int getZoomNeeded() {
-        return -1000;
+        if (mlp.getLayer() == 3) {
+            return 110;
+        } else if (mlp.getLayer() == 2) {
+            return 270;
+        } else {
+            return 400;
+        }
     }
 
     @Override public boolean isEnabled(boolean forMinimap) {
-        return !forMinimap;
+        return !forMinimap && MapConfig.WorldMap.INSTANCE.showLabels;
     }
 
     @Override
@@ -57,11 +72,25 @@ public class MapLabel extends MapIcon {
         return false;
     }
 
+    public CustomColor getColorFromLayer(float alpha) {
+        CustomColor color;
+        if (getLayer() == 1) {
+            color = new CustomColor(1.0f, 0, 0, 0.7f * alpha);
+        } else if (getLayer() == 2) {
+            color = new CustomColor(1.0f, 1.0f, 0, 0.85f * alpha);
+        } else {
+            color = new CustomColor(1.0f, 1.0f, 1.0f, 0.7f * alpha);
+        }
+        return color;
+    }
+
+    public void renderAt(ScreenRenderer renderer, float centreX, float centreZ, float sizeMultiplier, float blockScale, float alpha) {
+        renderer.drawString(getName(), centreX - getSizeX(), centreZ - getSizeZ(), getColorFromLayer(alpha));
+    }
+
     @Override
     public void renderAt(ScreenRenderer renderer, float centreX, float centreZ, float sizeMultiplier, float blockScale) {
-        float sizeX = getSizeX() * sizeMultiplier;
-        float sizeZ = getSizeZ() * sizeMultiplier;
-        renderer.drawCenteredString(mlp.getName(), centreX - sizeX, centreZ - sizeZ, CommonColors.YELLOW);
+        renderAt(renderer, centreX, centreZ, sizeMultiplier, blockScale, 1.0f);
     }
 
     private static List<MapIcon> labels = null;

--- a/src/main/java/com/wynntils/modules/map/overlays/objects/MapLabel.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/objects/MapLabel.java
@@ -1,0 +1,86 @@
+/*
+ *  * Copyright © Wynntils - 2020.
+ */
+
+package com.wynntils.modules.map.overlays.objects;
+
+import com.wynntils.core.framework.rendering.ScreenRenderer;
+import com.wynntils.core.framework.rendering.colors.CommonColors;
+import com.wynntils.webapi.WebManager;
+import com.wynntils.webapi.profiles.MapLabelProfile;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MapLabel extends MapIcon {
+    MapLabelProfile mlp;
+
+    public MapLabel(MapLabelProfile mlp) {
+        this.mlp = mlp;
+    }
+
+    @Override public int getPosX() {
+        return mlp.getX();
+    }
+
+    @Override public int getPosZ() {
+        return mlp.getZ();
+    }
+
+    @Override public String getName() {
+        return mlp.getName();
+    }
+
+    @Override public float getSizeX() {
+        return 8;
+    }
+
+    @Override public float getSizeZ() {
+        return 8;
+    }
+
+    @Override public int getZoomNeeded() {
+        return -1000;
+    }
+
+    @Override public boolean isEnabled(boolean forMinimap) {
+        return !forMinimap;
+    }
+
+    @Override
+    public boolean followRotation() {
+        return false;
+    }
+
+    @Override
+    public boolean hasDynamicLocation() {
+        return false;
+    }
+
+    @Override
+    public void renderAt(ScreenRenderer renderer, float centreX, float centreZ, float sizeMultiplier, float blockScale) {
+        float sizeX = getSizeX() * sizeMultiplier;
+        float sizeZ = getSizeZ() * sizeMultiplier;
+        renderer.drawCenteredString(mlp.getName(), centreX - sizeX, centreZ - sizeZ, CommonColors.YELLOW);
+    }
+
+    private static List<MapIcon> labels = null;
+
+    public static List<MapIcon> getLabels() {
+        if (labels == null) {
+            resetLabels();
+        }
+        return labels;
+    }
+
+    public static void resetLabels() {
+        if (labels == null) {
+            labels = new ArrayList<>();
+        } else {
+            labels.clear();
+        }
+        for (MapLabelProfile mmp : WebManager.getMapLabels()) {
+            labels.add(new MapLabel(mmp));
+        }
+    }
+}

--- a/src/main/java/com/wynntils/modules/map/overlays/objects/WorldMapIcon.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/objects/WorldMapIcon.java
@@ -34,6 +34,16 @@ public class WorldMapIcon {
         }
         if (info.getZoomNeeded() != MapIcon.ANY_ZOOM) {
             alpha = 1 - ((zoom - info.getZoomNeeded()) / 40.0f);
+            if (alpha > 1.0) alpha = 1.0f;
+
+            if (info instanceof MapLabel) {
+                MapLabel label = (MapLabel) info;
+
+                if (label.getLayer() == 1) {
+                    alpha = ((zoom - 80) / 60.0f);
+                    if (alpha > 1.0) alpha = 1.0f;
+                }
+            }
 
             if (alpha <= 0) {
                 shouldRender = false;
@@ -73,8 +83,12 @@ public class WorldMapIcon {
 
         GlStateManager.color(1, 1, 1, alpha);
         float multi = mouseOver(mouseX, mouseY) ? 1.3f : 1f;
-
-        info.renderAt(renderer, axisX, axisZ, multi, blockScale);
+        if (info instanceof MapLabel) {
+            MapLabel label = (MapLabel) info;
+            label.renderAt(renderer, axisX, axisZ, multi, blockScale, alpha);
+        } else {
+            info.renderAt(renderer, axisX, axisZ, multi, blockScale);
+        }
 
         GlStateManager.color(1, 1, 1, 1);
     }
@@ -83,9 +97,21 @@ public class WorldMapIcon {
         if (!shouldRender || !mouseOver(mouseX, mouseY)) return;
 
         GlStateManager.color(1, 1, 1, 1);
-        String name = info.getName();
-        if (name != null) {
-            renderer.drawString(name, (int) (axisX), (int) (axisZ) - 20, CommonColors.MAGENTA, SmartFontRenderer.TextAlignment.MIDDLE, SmartFontRenderer.TextShadow.OUTLINE);
+        if (info instanceof MapLabel) {
+            MapLabel label = (MapLabel) info;
+            String level = label.getLevel();
+            if (level != null) {
+                String lvStr = "[Lv. " + level + "]";
+                renderer.drawString(lvStr,  (int) (axisX), (int) (axisZ) + 8, CommonColors.MAGENTA, SmartFontRenderer.TextAlignment.MIDDLE, SmartFontRenderer.TextShadow.OUTLINE);
+            }
+            // Force opaque rendering by artificially high alpha
+            renderer.drawString(label.getName(), axisX - label.getSizeX(), axisZ - label.getSizeZ(), label.getColorFromLayer(100f));
+
+        } else {
+            String name = info.getName();
+            if (name != null) {
+                renderer.drawString(name, (int) (axisX), (int) (axisZ) - 20, CommonColors.MAGENTA, SmartFontRenderer.TextAlignment.MIDDLE, SmartFontRenderer.TextShadow.OUTLINE);
+            }
         }
     }
 }

--- a/src/main/java/com/wynntils/modules/map/overlays/objects/WorldMapIcon.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/objects/WorldMapIcon.java
@@ -27,28 +27,25 @@ public class WorldMapIcon {
         return info;
     }
 
+    protected void updateAlphaForZoom(int zoom) {
+        if (info.getZoomNeeded() != MapIcon.ANY_ZOOM) {
+            alpha = 1 - ((zoom - info.getZoomNeeded()) / 40.0f);
+            if (alpha > 1.0) {
+                alpha = 1.0f;
+            }
+        }
+    }
+
     public void updateAxis(MapProfile mp, int width, int height, float maxX, float minX, float maxZ, float minZ, int zoom) {
         if (!info.isEnabled(false)) {
             shouldRender = false;
             return;
         }
-        if (info.getZoomNeeded() != MapIcon.ANY_ZOOM) {
-            alpha = 1 - ((zoom - info.getZoomNeeded()) / 40.0f);
-            if (alpha > 1.0) alpha = 1.0f;
 
-            if (info instanceof MapLabel) {
-                MapLabel label = (MapLabel) info;
-
-                if (label.getLayer() == 1) {
-                    alpha = ((zoom - 80) / 60.0f);
-                    if (alpha > 1.0) alpha = 1.0f;
-                }
-            }
-
-            if (alpha <= 0) {
-                shouldRender = false;
-                return;
-            }
+        updateAlphaForZoom(zoom);
+        if (alpha <= 0) {
+            shouldRender = false;
+            return;
         }
 
         float axisX = ((mp.getTextureXPosition(info.getPosX()) - minX) / (maxX - minX));
@@ -83,12 +80,8 @@ public class WorldMapIcon {
 
         GlStateManager.color(1, 1, 1, alpha);
         float multi = mouseOver(mouseX, mouseY) ? 1.3f : 1f;
-        if (info instanceof MapLabel) {
-            MapLabel label = (MapLabel) info;
-            label.renderAt(renderer, axisX, axisZ, multi, blockScale, alpha);
-        } else {
-            info.renderAt(renderer, axisX, axisZ, multi, blockScale);
-        }
+
+        info.renderAt(renderer, axisX, axisZ, multi, blockScale);
 
         GlStateManager.color(1, 1, 1, 1);
     }
@@ -97,21 +90,9 @@ public class WorldMapIcon {
         if (!shouldRender || !mouseOver(mouseX, mouseY)) return;
 
         GlStateManager.color(1, 1, 1, 1);
-        if (info instanceof MapLabel) {
-            MapLabel label = (MapLabel) info;
-            String level = label.getLevel();
-            if (level != null) {
-                String lvStr = "[Lv. " + level + "]";
-                renderer.drawString(lvStr,  (int) (axisX), (int) (axisZ) + 8, CommonColors.MAGENTA, SmartFontRenderer.TextAlignment.MIDDLE, SmartFontRenderer.TextShadow.OUTLINE);
-            }
-            // Force opaque rendering by artificially high alpha
-            renderer.drawString(label.getName(), axisX - label.getSizeX(), axisZ - label.getSizeZ(), label.getColorFromLayer(100f));
-
-        } else {
-            String name = info.getName();
-            if (name != null) {
-                renderer.drawString(name, (int) (axisX), (int) (axisZ) - 20, CommonColors.MAGENTA, SmartFontRenderer.TextAlignment.MIDDLE, SmartFontRenderer.TextShadow.OUTLINE);
-            }
+        String name = info.getName();
+        if (name != null) {
+            renderer.drawString(name, (int) (axisX), (int) (axisZ) - 20, CommonColors.MAGENTA, SmartFontRenderer.TextAlignment.MIDDLE, SmartFontRenderer.TextShadow.OUTLINE);
         }
     }
 }

--- a/src/main/java/com/wynntils/modules/map/overlays/objects/WorldMapLabel.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/objects/WorldMapLabel.java
@@ -37,7 +37,7 @@ public class WorldMapLabel extends WorldMapIcon {
     private CustomColor getColorFromLayer() {
         CustomColor color;
         if (label.getLayer() == 1) {
-            color = new CustomColor(1.0f, 0, 0);
+            color = new CustomColor(1.0f, 0.2f, 0.2f);
         } else if (label.getLayer() == 2) {
             color = new CustomColor(1.0f, 1.0f, 0);
         } else {

--- a/src/main/java/com/wynntils/modules/map/overlays/objects/WorldMapLabel.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/objects/WorldMapLabel.java
@@ -1,0 +1,70 @@
+/*
+ *  * Copyright © Wynntils - 2018 - 2020.
+ */
+
+package com.wynntils.modules.map.overlays.objects;
+
+import com.wynntils.core.framework.rendering.ScreenRenderer;
+import com.wynntils.core.framework.rendering.SmartFontRenderer;
+import com.wynntils.core.framework.rendering.colors.CommonColors;
+import com.wynntils.core.framework.rendering.colors.CustomColor;
+import com.wynntils.modules.map.instances.MapProfile;
+import net.minecraft.client.renderer.GlStateManager;
+
+public class WorldMapLabel extends WorldMapIcon {
+
+    MapLabel label;
+
+    public WorldMapLabel(MapLabel label) {
+        super(label);
+        this.label = label;
+    }
+
+    protected void updateAlphaForZoom(int zoom) {
+        if (label.getLayer() == 1) {
+            alpha = ((zoom - 80) / 60.0f);
+        } else if (label.getLayer() == 2) {
+            alpha =  1 - ((zoom - 270) / 40.0f);
+        } else {
+            alpha =  1 - ((zoom - 110) / 40.0f);
+        }
+
+        if (alpha > 1.0) {
+            alpha = 1.0f;
+        }
+    }
+
+    private CustomColor getColorFromLayer() {
+        CustomColor color;
+        if (label.getLayer() == 1) {
+            color = new CustomColor(1.0f, 0, 0);
+        } else if (label.getLayer() == 2) {
+            color = new CustomColor(1.0f, 1.0f, 0);
+        } else {
+            color = new CustomColor(1.0f, 1.0f, 1.0f);
+        }
+        return color;
+    }
+
+    private CustomColor getDimmedColorFromLayer(float alpha) {
+        CustomColor color = getColorFromLayer();
+        color.setA(0.75f * alpha);
+        return color;
+    }
+
+    public void drawScreen(int mouseX, int mouseY, float partialTicks, float blockScale, ScreenRenderer renderer) {
+        if (!shouldRender || renderer == null) return;
+
+        renderer.drawString(label.getName(), axisX - label.getSizeX(), axisZ - label.getSizeZ(), getDimmedColorFromLayer(alpha));
+    }
+
+    public void drawHovering(int mouseX, int mouseY, float partialTicks, ScreenRenderer renderer) {
+        if (!shouldRender || !mouseOver(mouseX, mouseY)) return;
+
+        String level = label.getLevel();
+        if (level != null) {
+            String lvStr = "[Lv. " + level + "]";
+            renderer.drawString(lvStr,  (int) (axisX), (int) (axisZ) + 8, CommonColors.MAGENTA, SmartFontRenderer.TextAlignment.MIDDLE, SmartFontRenderer.TextShadow.OUTLINE);
+        }
+        renderer.drawString(label.getName(), axisX - label.getSizeX(), axisZ - label.getSizeZ(), getColorFromLayer()); }
+}

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/WorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/WorldMapUI.java
@@ -17,8 +17,10 @@ import com.wynntils.modules.map.MapModule;
 import com.wynntils.modules.map.configs.MapConfig;
 import com.wynntils.modules.map.instances.MapProfile;
 import com.wynntils.modules.map.overlays.objects.MapIcon;
+import com.wynntils.modules.map.overlays.objects.MapLabel;
 import com.wynntils.modules.map.overlays.objects.MapTerritory;
 import com.wynntils.modules.map.overlays.objects.WorldMapIcon;
+import com.wynntils.modules.map.overlays.objects.WorldMapLabel;
 import com.wynntils.modules.questbook.managers.QuestManager;
 import com.wynntils.modules.utilities.managers.KeyManager;
 import com.wynntils.webapi.WebManager;
@@ -95,7 +97,13 @@ public class WorldMapUI extends GuiMovementScreen {
             friendsIcons
         )) {
             if (i.isEnabled(false)) {
-                icons.add(new WorldMapIcon(i));
+                WorldMapIcon icon;
+                if (i instanceof MapLabel) {
+                    icon = new WorldMapLabel((MapLabel) i);
+                } else {
+                    icon = new WorldMapIcon(i);
+                }
+                icons.add(icon);
             }
         }
     }

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/WorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/WorldMapUI.java
@@ -45,6 +45,7 @@ public class WorldMapUI extends GuiMovementScreen {
 
     protected float centerPositionX = Float.NaN;
     protected float centerPositionZ = Float.NaN;
+    // Zoom goes from 300 (whole world) to -10 (max details)
     protected int zoom = 0;
 
     protected List<WorldMapIcon> icons = new ArrayList<>();
@@ -88,9 +89,9 @@ public class WorldMapUI extends GuiMovementScreen {
 
         for (MapIcon i : Iterables.concat(
             apiMapIcons,
-            mapLabels,
             wpMapIcons,
             pathWpMapIcons,
+            mapLabels,
             friendsIcons
         )) {
             if (i.isEnabled(false)) {

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/WorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/WorldMapUI.java
@@ -74,6 +74,8 @@ public class WorldMapUI extends GuiMovementScreen {
     protected void createIcons() {
         // HeyZeer0: Handles MiniMap markers provided by Wynn API
         List<MapIcon> apiMapIcons = MapIcon.getApiMarkers(MapConfig.INSTANCE.iconTexture);
+        // Handles map labels from map.wynncraft.com
+        List<MapIcon> mapLabels = MapIcon.getLabels();
         // HeyZeer0: Handles all waypoints
         List<MapIcon> wpMapIcons = MapIcon.getWaypoints();
         List<MapIcon> pathWpMapIcons = MapIcon.getPathWaypoints();
@@ -86,6 +88,7 @@ public class WorldMapUI extends GuiMovementScreen {
 
         for (MapIcon i : Iterables.concat(
             apiMapIcons,
+            mapLabels,
             wpMapIcons,
             pathWpMapIcons,
             friendsIcons

--- a/src/main/java/com/wynntils/webapi/WebManager.java
+++ b/src/main/java/com/wynntils/webapi/WebManager.java
@@ -25,6 +25,8 @@ import com.wynntils.webapi.profiles.item.objects.IdentificationContainer;
 import com.wynntils.webapi.profiles.player.PlayerStatsProfile;
 import com.wynntils.webapi.request.Request;
 import com.wynntils.webapi.request.RequestHandler;
+import net.minecraft.client.Minecraft;
+import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.common.ProgressManager;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -399,8 +401,9 @@ public class WebManager {
         );
          */
         try {
-            FileInputStream jsonFile = new FileInputStream("/Users/ihse/hacking/Wynntils/src/main/resources/assets/wynntils/labels.json");
-            String content = IOUtils.toString(jsonFile, StandardCharsets.UTF_8);
+            ResourceLocation rl = new ResourceLocation(Reference.MOD_ID + ":labels.json");
+            InputStream stream = Minecraft.getMinecraft().getResourceManager().getResource(rl).getInputStream();
+            String content = IOUtils.toString(stream, StandardCharsets.UTF_8);
             JsonObject main = new JsonParser().parse(content).getAsJsonObject();
             JsonArray jsonArray = main.getAsJsonArray("labels");
             Type type = new TypeToken<ArrayList<MapLabelProfile>>() {

--- a/src/main/java/com/wynntils/webapi/WebManager.java
+++ b/src/main/java/com/wynntils/webapi/WebManager.java
@@ -57,6 +57,7 @@ public class WebManager {
     private static HashMap<String, ItemGuessProfile> itemGuesses = new HashMap<>();
 
     private static ArrayList<MapMarkerProfile> mapMarkers = new ArrayList<>();
+    private static ArrayList<MapLabelProfile> mapLabels = new ArrayList<>();
 
     private static PlayerStatsProfile playerProfile;
     private static HashMap<String, GuildProfile> guilds = new HashMap<>();
@@ -99,6 +100,7 @@ public class WebManager {
         updateTerritories(handler);
         updateItemList(handler);
         updateMapMarkers(handler);
+        updateMapLabels(handler);
         updateItemGuesses(handler);
         updatePlayerProfile(handler);
         updateDiscoveries(handler);
@@ -161,6 +163,10 @@ public class WebManager {
 
     public static ArrayList<MapMarkerProfile> getMapMarkers() {
         return mapMarkers;
+    }
+
+    public static ArrayList<MapLabelProfile> getMapLabels() {
+        return mapLabels;
     }
 
     public static Iterable<MapMarkerProfile> getApiMarkers() {
@@ -370,6 +376,42 @@ public class WebManager {
                 return true;
             })
         );
+    }
+
+    /**
+     * Update all Wynn MapLabels on the {@link HashMap} mapLabels
+     */
+    public static void updateMapLabels(RequestHandler handler) {
+        /*
+        // Use this when/if the map_labels.json file is added to Athena.
+        String url = apiUrls == null ? null : apiUrls.get("Athena") + "/cache/get/mapLabels";
+        handler.addRequest(new Request(url, "map_labels")
+                .cacheTo(new File(API_CACHE_ROOT, "map_labels.json"))
+                .cacheMD5Validator(() -> getAccount().getMD5Verification("mapLabels"))
+                .handleJsonObject(main -> {
+                    JsonArray jsonArray = main.getAsJsonArray("labels");
+                    Type type = new TypeToken<ArrayList<MapLabelProfile>>() {
+                    }.getType();
+
+                    mapLabels = gson.fromJson(jsonArray, type);
+                    return true;
+                })
+        );
+         */
+        try {
+            FileInputStream jsonFile = new FileInputStream("/Users/ihse/hacking/Wynntils/src/main/resources/assets/wynntils/labels.json");
+            String content = IOUtils.toString(jsonFile, StandardCharsets.UTF_8);
+            JsonObject main = new JsonParser().parse(content).getAsJsonObject();
+            JsonArray jsonArray = main.getAsJsonArray("labels");
+            Type type = new TypeToken<ArrayList<MapLabelProfile>>() {
+            }.getType();
+
+            mapLabels = gson.fromJson(jsonArray, type);
+        } catch (java.io.FileNotFoundException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
 
     /**

--- a/src/main/java/com/wynntils/webapi/profiles/MapLabelProfile.java
+++ b/src/main/java/com/wynntils/webapi/profiles/MapLabelProfile.java
@@ -1,0 +1,48 @@
+/*
+ *  * Copyright © Wynntils - 2020.
+ */
+
+package com.wynntils.webapi.profiles;
+
+public class MapLabelProfile {
+
+    String name;
+    int x;
+    int y;
+    int z;
+    String level;
+    int layer;
+
+    public MapLabelProfile(String name, int x, int y, int z, int layer, String level) {
+        this.name = name;
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.layer = layer;
+        this.level = level;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getX() {
+        return x;
+    }
+
+    public int getY() {
+        return y;
+    }
+
+    public int getZ() {
+        return z;
+    }
+
+    public int getLayer() {
+        return layer;
+    }
+
+    public String getLevel() {
+        return level;
+    }
+}

--- a/src/main/java/com/wynntils/webapi/profiles/MapLabelProfile.java
+++ b/src/main/java/com/wynntils/webapi/profiles/MapLabelProfile.java
@@ -14,7 +14,11 @@ public class MapLabelProfile {
     int layer;
 
     public MapLabelProfile(String name, int x, int y, int z, int layer, String level) {
-        this.name = name;
+        if (layer == 1) {
+            this.name = name.toUpperCase();
+        } else {
+            this.name = name;
+        }
         this.x = x;
         this.y = y;
         this.z = z;

--- a/src/main/resources/assets/wynntils/labels.json
+++ b/src/main/resources/assets/wynntils/labels.json
@@ -32,112 +32,112 @@
       "x": -539,
       "z": -1926,
       "name": "Maltic",
-      "layer": 2,
+      "layer": 3,
       "level": "10"
     },
     {
       "x": 828,
       "z": -1610,
       "name": "Ternaves",
-      "layer": 2,
+      "layer": 3,
       "level": "15"
     },
     {
       "x": 305,
       "z": -2053,
       "name": "Saint's Row",
-      "layer": 2,
+      "layer": 3,
       "level": "25"
     },
     {
       "x": 206,
       "z": -1884,
       "name": "Ancient Nemract",
-      "layer": 2,
+      "layer": 3,
       "level": "20"
     },
     {
       "x": -603,
       "z": -1611,
       "name": "Emerald Trail",
-      "layer": 2,
+      "layer": 3,
       "level": "1"
     },
     {
       "x": -459,
       "z": -1254,
       "name": "Time Valley",
-      "layer": 2,
+      "layer": 3,
       "level": "15"
     },
     {
       "x": -680,
       "z": -1384,
       "name": "Pigmen's Ravines",
-      "layer": 2,
+      "layer": 3,
       "level": "15"
     },
     {
       "x": -198,
       "z": -1536,
       "name": "Nivla Woods",
-      "layer": 2,
+      "layer": 3,
       "level": "5"
     },
     {
       "x": 117,
       "z": -817,
       "name": "Nesaak",
-      "layer": 2,
+      "layer": 3,
       "level": "40"
     },
     {
       "x": 10,
       "z": -1227,
       "name": "Elkurn",
-      "layer": 2,
+      "layer": 3,
       "level": "5"
     },
     {
       "x": 705,
       "z": -2096,
       "name": "Bremminglar",
-      "layer": 2,
+      "layer": 3,
       "level": "30"
     },
     {
       "x": 280,
       "z": -1586,
       "name": "Detlas Suburb",
-      "layer": 2,
+      "layer": 3,
       "level": "10"
     },
     {
       "x": 1362,
       "z": -539,
       "name": "Path to Darkness",
-      "layer": 2,
+      "layer": 3,
       "level": "110"
     },
     {
       "x": 873,
       "z": -2844,
       "name": "Mage Island",
-      "layer": 2,
+      "layer": 3,
       "level": "30"
     },
     {
       "x": 667,
       "z": -1519,
       "name": "Black Road",
-      "layer": 2,
+      "layer": 3,
       "level": "12"
     },
     {
       "x": 480,
       "z": -2058,
       "name": "Pirate Bay",
-      "layer": 2,
+      "layer": 3,
       "level": "20"
     },
     {
@@ -151,28 +151,28 @@
       "x": 410,
       "z": -1128,
       "name": "Corrupted Village",
-      "layer": 2,
+      "layer": 3,
       "level": "25"
     },
     {
       "x": -691,
       "z": -1022,
       "name": "Temple of Legends",
-      "layer": 2,
+      "layer": 3,
       "level": "70"
     },
     {
       "x": 999,
       "z": -2580,
       "name": "Half Moon Island",
-      "layer": 2,
+      "layer": 3,
       "level": "30"
     },
     {
       "x": 437,
       "z": -2880,
       "name": "Durum Isles",
-      "layer": 2,
+      "layer": 3,
       "level": "20"
     },
     {
@@ -200,49 +200,49 @@
       "x": -1668,
       "z": -2366,
       "name": "Relos",
-      "layer": 2,
+      "layer": 3,
       "level": "85"
     },
     {
       "x": -1822,
       "z": -3176,
       "name": "Avos Territory",
-      "layer": 2,
+      "layer": 3,
       "level": "90"
     },
     {
       "x": 718,
       "z": -3741,
       "name": "Ghost Ship",
-      "layer": 2,
+      "layer": 3,
       "level": "45"
     },
     {
       "x": -106,
       "z": -2476,
       "name": "Rooster Island",
-      "layer": 2,
+      "layer": 3,
       "level": "20"
     },
     {
       "x": 376,
       "z": -3485,
       "name": "Skiens Island",
-      "layer": 2,
+      "layer": 3,
       "level": "55"
     },
     {
       "x": 791,
       "z": -3340,
       "name": "Nodguj Nation",
-      "layer": 2,
+      "layer": 3,
       "level": "45"
     },
     {
       "x": 977,
       "z": -3468,
       "name": "Dujgon Nation",
-      "layer": 2,
+      "layer": 3,
       "level": "45"
     },
     {
@@ -256,175 +256,175 @@
       "x": 173,
       "z": -3947,
       "name": "Maro Peaks",
-      "layer": 2,
+      "layer": 3,
       "level": "60"
     },
     {
       "x": -373,
       "z": -2456,
       "name": "The Bear Zoo",
-      "layer": 2,
+      "layer": 3,
       "level": "15"
     },
     {
       "x": 79,
       "z": -2646,
       "name": "Underwater Route",
-      "layer": 2,
+      "layer": 3,
       "level": "20"
     },
     {
       "x": -290,
       "z": -2127,
       "name": "Coastal Trail",
-      "layer": 2,
+      "layer": 3,
       "level": "5"
     },
     {
       "x": -800,
       "z": -1907,
       "name": "Katoa Ranch",
-      "layer": 2,
+      "layer": 3,
       "level": "5"
     },
     {
       "x": 124,
       "z": -1227,
       "name": "The Tower of Amnesia",
-      "layer": 2,
+      "layer": 3,
       "level": "25"
     },
     {
       "x": -751,
       "z": -751,
       "name": "Jungle Village",
-      "layer": 2,
+      "layer": 3,
       "level": "50"
     },
     {
       "x": 221,
       "z": -814,
       "name": "Underground Squid Village",
-      "layer": 2,
+      "layer": 3,
       "level": "40"
     },
     {
       "x": -365,
       "z": -770,
       "name": "The Great Bridge",
-      "layer": 2,
+      "layer": 3,
       "level": "50"
     },
     {
       "x": 1090,
       "z": -2329,
       "name": "Mummy's Tomb",
-      "layer": 2,
+      "layer": 3,
       "level": "35"
     },
     {
       "x": 122,
       "z": -369,
       "name": "House of Twain",
-      "layer": 2,
+      "layer": 3,
       "level": "45"
     },
     {
       "x": -695,
       "z": -3132,
       "name": "Pirate Town",
-      "layer": 2,
+      "layer": 3,
       "level": "60"
     },
     {
       "x": -500,
       "z": -2831,
       "name": "Zhight Island",
-      "layer": 2,
+      "layer": 3,
       "level": "50"
     },
     {
       "x": -98,
       "z": -2010,
       "name": "Mt. Wynn",
-      "layer": 2,
+      "layer": 3,
       "level": "20"
     },
     {
       "x": -992,
       "z": -3672,
       "name": "Volcanic Isles",
-      "layer": 2,
+      "layer": 3,
       "level": "55"
     },
     {
       "x": -182,
       "z": -352,
       "name": "Lusuco",
-      "layer": 2,
+      "layer": 3,
       "level": "45"
     },
     {
       "x": 300,
       "z": -3186,
       "name": "Seavale Reefs",
-      "layer": 2,
+      "layer": 3,
       "level": "25"
     },
     {
       "x": 1291,
       "z": -4082,
       "name": "Jofash Dock",
-      "layer": 2,
+      "layer": 3,
       "level": "90"
     },
     {
       "x": 872,
       "z": -3923,
       "name": "Dead Island",
-      "layer": 2,
+      "layer": 3,
       "level": "75"
     },
     {
       "x": 806,
       "z": -2253,
       "name": "Lion Lair",
-      "layer": 2,
+      "layer": 3,
       "level": "25"
     },
     {
       "x": 1250,
       "z": -1334,
       "name": "Rymek",
-      "layer": 2,
+      "layer": 3,
       "level": "35"
     },
     {
       "x": 1380,
       "z": -2247,
       "name": "Invaded Barracks",
-      "layer": 2,
+      "layer": 3,
       "level": "30"
     },
     {
       "x": -549,
       "z": -1214,
       "name": "Door of Time",
-      "layer": 2,
+      "layer": 3,
       "level": "15"
     },
     {
       "x": 762,
       "z": -1251,
       "name": "Abandoned Mines",
-      "layer": 2,
+      "layer": 3,
       "level": "25"
     },
     {
       "x": 232,
       "z": -1291,
       "name": "Roots of Corruption",
-      "layer": 2
+      "layer": 3
     },
     {
       "x": 103,
@@ -478,98 +478,98 @@
       "x": -479,
       "z": -4546,
       "name": "Aldorei",
-      "layer": 2,
+      "layer": 3,
       "level": "75"
     },
     {
       "x": 134,
       "z": -5241,
       "name": "Thanos",
-      "layer": 2,
+      "layer": 3,
       "level": "80"
     },
     {
       "x": -608,
       "z": -5442,
       "name": "Lexdale",
-      "layer": 2,
+      "layer": 3,
       "level": "70"
     },
     {
       "x": 941,
       "z": -5506,
       "name": "Eltom",
-      "layer": 2,
+      "layer": 3,
       "level": "85"
     },
     {
       "x": 1486,
       "z": -5292,
       "name": "Maex",
-      "layer": 2,
+      "layer": 3,
       "level": "90"
     },
     {
       "x": 757,
       "z": -4466,
       "name": "Kandon-Beda",
-      "layer": 2,
+      "layer": 3,
       "level": "95"
     },
     {
       "x": -1617,
       "z": -4470,
       "name": "Karoc Quarry",
-      "layer": 2,
+      "layer": 3,
       "level": "45"
     },
     {
       "x": -950,
       "z": -4913,
       "name": "Light Forest",
-      "layer": 2,
+      "layer": 3,
       "level": "70"
     },
     {
       "x": -1162,
       "z": -5341,
       "name": "Dark Forest",
-      "layer": 2,
+      "layer": 3,
       "level": "60"
     },
     {
       "x": 1495,
       "z": -5492,
       "name": "Molten Heights",
-      "layer": 2,
+      "layer": 3,
       "level": "90"
     },
     {
       "x": -1493,
       "z": -4818,
       "name": "Pre-Light Forest",
-      "layer": 2,
+      "layer": 3,
       "level": "65"
     },
     {
       "x": 629,
       "z": -5224,
       "name": "Canyon of the Lost",
-      "layer": 2,
+      "layer": 3,
       "level": "85"
     },
     {
       "x": -1066,
       "z": -5007,
       "name": "Efilim",
-      "layer": 2,
+      "layer": 3,
       "level": "70"
     },
     {
       "x": 1266,
       "z": -4697,
       "name": "Sky Islands",
-      "layer": 2,
+      "layer": 3,
       "level": "95"
     },
     {
@@ -583,93 +583,93 @@
       "x": -779,
       "z": -435,
       "name": "Dernel Jungle",
-      "layer": 2,
+      "layer": 3,
       "level": "60-70"
     },
     {
       "x": -46,
       "z": -5539,
       "name": "Gert Camp",
-      "layer": 2,
+      "layer": 3,
       "level": "75"
     },
     {
       "x": -1608,
       "z": -4969,
       "name": "Bucie",
-      "layer": 2,
+      "layer": 3,
       "level": "40"
     },
     {
       "x": -164,
       "z": -5238,
       "name": "Lake Gylia",
-      "layer": 2,
+      "layer": 3,
       "level": "75"
     },
     {
       "x": -805,
       "z": -5312,
       "name": "Kander Forest",
-      "layer": 2,
+      "layer": 3,
       "level": "70"
     },
     {
       "x": -1926,
       "z": -5299,
       "name": "Swamp",
-      "layer": 2,
+      "layer": 3,
       "level": "50"
     },
     {
       "x": 606,
       "z": -4873,
       "name": "Bantisu Air Temple",
-      "layer": 2,
+      "layer": 3,
       "level": "85"
     },
     {
       "x": -189,
       "z": -4917,
       "name": "Letvus Airbase",
-      "layer": 2
+      "layer": 3
     },
     {
       "x": -310,
       "z": -4933,
       "name": "Guild Hall",
-      "layer": 2
+      "layer": 3
     },
     {
       "x": 395,
       "z": -5573,
       "name": "The Hive",
-      "layer": 2
+      "layer": 3
     },
     {
       "x": -1041,
       "z": -4480,
       "name": "Light's Secret",
-      "layer": 2
+      "layer": 3
     },
     {
       "x": -310,
       "z": -430,
       "name": "Tower of Ascension",
-      "layer": 2
+      "layer": 3
     },
     {
       "x": -847,
       "z": -4911,
       "name": "The Forgery",
-      "layer": 2,
+      "layer": 3,
       "level": "70"
     },
     {
       "x": 256,
       "z": -5288,
       "name": "Ozoth's Spire",
-      "layer": 2
+      "layer": 3
     },
     {
       "x": -110,
@@ -700,14 +700,14 @@
       "x": 603,
       "z": -543,
       "name": "Ruined Olmic City",
-      "layer": 2,
+      "layer": 3,
       "level": "100"
     },
     {
       "x": 1350,
       "z": -904,
       "name": "The Eldritch Outlook",
-      "layer": 2,
+      "layer": 3,
       "level": "100+"
     }
   ]

--- a/src/main/resources/assets/wynntils/labels.json
+++ b/src/main/resources/assets/wynntils/labels.json
@@ -1,0 +1,714 @@
+{
+  "labels": [
+    {
+      "x": -819,
+      "z": -1581,
+      "name": "Ragni",
+      "layer": 2,
+      "level": "1"
+    },
+    {
+      "x": 970,
+      "z": -1983,
+      "name": "Almuj",
+      "layer": 2,
+      "level": "30"
+    },
+    {
+      "x": 477,
+      "z": -1590,
+      "name": "Detlas",
+      "layer": 2,
+      "level": "10"
+    },
+    {
+      "x": 119,
+      "z": -2206,
+      "name": "Nemract",
+      "layer": 2,
+      "level": "20"
+    },
+    {
+      "x": -539,
+      "z": -1926,
+      "name": "Maltic",
+      "layer": 2,
+      "level": "10"
+    },
+    {
+      "x": 828,
+      "z": -1610,
+      "name": "Ternaves",
+      "layer": 2,
+      "level": "15"
+    },
+    {
+      "x": 305,
+      "z": -2053,
+      "name": "Saint's Row",
+      "layer": 2,
+      "level": "25"
+    },
+    {
+      "x": 206,
+      "z": -1884,
+      "name": "Ancient Nemract",
+      "layer": 2,
+      "level": "20"
+    },
+    {
+      "x": -603,
+      "z": -1611,
+      "name": "Emerald Trail",
+      "layer": 2,
+      "level": "1"
+    },
+    {
+      "x": -459,
+      "z": -1254,
+      "name": "Time Valley",
+      "layer": 2,
+      "level": "15"
+    },
+    {
+      "x": -680,
+      "z": -1384,
+      "name": "Pigmen's Ravines",
+      "layer": 2,
+      "level": "15"
+    },
+    {
+      "x": -198,
+      "z": -1536,
+      "name": "Nivla Woods",
+      "layer": 2,
+      "level": "5"
+    },
+    {
+      "x": 117,
+      "z": -817,
+      "name": "Nesaak",
+      "layer": 2,
+      "level": "40"
+    },
+    {
+      "x": 10,
+      "z": -1227,
+      "name": "Elkurn",
+      "layer": 2,
+      "level": "5"
+    },
+    {
+      "x": 705,
+      "z": -2096,
+      "name": "Bremminglar",
+      "layer": 2,
+      "level": "30"
+    },
+    {
+      "x": 280,
+      "z": -1586,
+      "name": "Detlas Suburb",
+      "layer": 2,
+      "level": "10"
+    },
+    {
+      "x": 1362,
+      "z": -539,
+      "name": "Path to Darkness",
+      "layer": 2,
+      "level": "110"
+    },
+    {
+      "x": 873,
+      "z": -2844,
+      "name": "Mage Island",
+      "layer": 2,
+      "level": "30"
+    },
+    {
+      "x": 667,
+      "z": -1519,
+      "name": "Black Road",
+      "layer": 2,
+      "level": "12"
+    },
+    {
+      "x": 480,
+      "z": -2058,
+      "name": "Pirate Bay",
+      "layer": 2,
+      "level": "20"
+    },
+    {
+      "x": -793,
+      "z": -963,
+      "name": "Troms",
+      "layer": 2,
+      "level": "55"
+    },
+    {
+      "x": 410,
+      "z": -1128,
+      "name": "Corrupted Village",
+      "layer": 2,
+      "level": "25"
+    },
+    {
+      "x": -691,
+      "z": -1022,
+      "name": "Temple of Legends",
+      "layer": 2,
+      "level": "70"
+    },
+    {
+      "x": 999,
+      "z": -2580,
+      "name": "Half Moon Island",
+      "layer": 2,
+      "level": "30"
+    },
+    {
+      "x": 437,
+      "z": -2880,
+      "name": "Durum Isles",
+      "layer": 2,
+      "level": "20"
+    },
+    {
+      "x": 92,
+      "z": -3183,
+      "name": "Selchar",
+      "layer": 2,
+      "level": "25"
+    },
+    {
+      "x": -1632,
+      "z": -2930,
+      "name": "Corkus City",
+      "layer": 2,
+      "level": "85"
+    },
+    {
+      "x": -1112,
+      "z": -2430,
+      "name": "Legendary Island",
+      "layer": 2,
+      "level": "90+"
+    },
+    {
+      "x": -1668,
+      "z": -2366,
+      "name": "Relos",
+      "layer": 2,
+      "level": "85"
+    },
+    {
+      "x": -1822,
+      "z": -3176,
+      "name": "Avos Territory",
+      "layer": 2,
+      "level": "90"
+    },
+    {
+      "x": 718,
+      "z": -3741,
+      "name": "Ghost Ship",
+      "layer": 2,
+      "level": "45"
+    },
+    {
+      "x": -106,
+      "z": -2476,
+      "name": "Rooster Island",
+      "layer": 2,
+      "level": "20"
+    },
+    {
+      "x": 376,
+      "z": -3485,
+      "name": "Skiens Island",
+      "layer": 2,
+      "level": "55"
+    },
+    {
+      "x": 791,
+      "z": -3340,
+      "name": "Nodguj Nation",
+      "layer": 2,
+      "level": "45"
+    },
+    {
+      "x": 977,
+      "z": -3468,
+      "name": "Dujgon Nation",
+      "layer": 2,
+      "level": "45"
+    },
+    {
+      "x": 909,
+      "z": -3339,
+      "name": "Ice Islands",
+      "layer": 2,
+      "level": "45"
+    },
+    {
+      "x": 173,
+      "z": -3947,
+      "name": "Maro Peaks",
+      "layer": 2,
+      "level": "60"
+    },
+    {
+      "x": -373,
+      "z": -2456,
+      "name": "The Bear Zoo",
+      "layer": 2,
+      "level": "15"
+    },
+    {
+      "x": 79,
+      "z": -2646,
+      "name": "Underwater Route",
+      "layer": 2,
+      "level": "20"
+    },
+    {
+      "x": -290,
+      "z": -2127,
+      "name": "Coastal Trail",
+      "layer": 2,
+      "level": "5"
+    },
+    {
+      "x": -800,
+      "z": -1907,
+      "name": "Katoa Ranch",
+      "layer": 2,
+      "level": "5"
+    },
+    {
+      "x": 124,
+      "z": -1227,
+      "name": "The Tower of Amnesia",
+      "layer": 2,
+      "level": "25"
+    },
+    {
+      "x": -751,
+      "z": -751,
+      "name": "Jungle Village",
+      "layer": 2,
+      "level": "50"
+    },
+    {
+      "x": 221,
+      "z": -814,
+      "name": "Underground Squid Village",
+      "layer": 2,
+      "level": "40"
+    },
+    {
+      "x": -365,
+      "z": -770,
+      "name": "The Great Bridge",
+      "layer": 2,
+      "level": "50"
+    },
+    {
+      "x": 1090,
+      "z": -2329,
+      "name": "Mummy's Tomb",
+      "layer": 2,
+      "level": "35"
+    },
+    {
+      "x": 122,
+      "z": -369,
+      "name": "House of Twain",
+      "layer": 2,
+      "level": "45"
+    },
+    {
+      "x": -695,
+      "z": -3132,
+      "name": "Pirate Town",
+      "layer": 2,
+      "level": "60"
+    },
+    {
+      "x": -500,
+      "z": -2831,
+      "name": "Zhight Island",
+      "layer": 2,
+      "level": "50"
+    },
+    {
+      "x": -98,
+      "z": -2010,
+      "name": "Mt. Wynn",
+      "layer": 2,
+      "level": "20"
+    },
+    {
+      "x": -992,
+      "z": -3672,
+      "name": "Volcanic Isles",
+      "layer": 2,
+      "level": "55"
+    },
+    {
+      "x": -182,
+      "z": -352,
+      "name": "Lusuco",
+      "layer": 2,
+      "level": "45"
+    },
+    {
+      "x": 300,
+      "z": -3186,
+      "name": "Seavale Reefs",
+      "layer": 2,
+      "level": "25"
+    },
+    {
+      "x": 1291,
+      "z": -4082,
+      "name": "Jofash Dock",
+      "layer": 2,
+      "level": "90"
+    },
+    {
+      "x": 872,
+      "z": -3923,
+      "name": "Dead Island",
+      "layer": 2,
+      "level": "75"
+    },
+    {
+      "x": 806,
+      "z": -2253,
+      "name": "Lion Lair",
+      "layer": 2,
+      "level": "25"
+    },
+    {
+      "x": 1250,
+      "z": -1334,
+      "name": "Rymek",
+      "layer": 2,
+      "level": "35"
+    },
+    {
+      "x": 1380,
+      "z": -2247,
+      "name": "Invaded Barracks",
+      "layer": 2,
+      "level": "30"
+    },
+    {
+      "x": -549,
+      "z": -1214,
+      "name": "Door of Time",
+      "layer": 2,
+      "level": "15"
+    },
+    {
+      "x": 762,
+      "z": -1251,
+      "name": "Abandoned Mines",
+      "layer": 2,
+      "level": "25"
+    },
+    {
+      "x": 232,
+      "z": -1291,
+      "name": "Roots of Corruption",
+      "layer": 2
+    },
+    {
+      "x": 103,
+      "z": -1726,
+      "name": "The Province of Wynn",
+      "layer": 1
+    },
+    {
+      "x": -1989,
+      "z": -4533,
+      "name": "Llevigar",
+      "layer": 2,
+      "level": "40"
+    },
+    {
+      "x": -1727,
+      "z": -5532,
+      "name": "Olux",
+      "layer": 2,
+      "level": "50"
+    },
+    {
+      "x": -455,
+      "z": -4928,
+      "name": "Cinfras",
+      "layer": 2,
+      "level": "75"
+    },
+    {
+      "x": 770,
+      "z": -5043,
+      "name": "Thesead",
+      "layer": 2,
+      "level": "85"
+    },
+    {
+      "x": 1101,
+      "z": -5136,
+      "name": "Rodoroc",
+      "layer": 2,
+      "level": "90"
+    },
+    {
+      "x": 1010,
+      "z": -4554,
+      "name": "Ahmsord",
+      "layer": 2,
+      "level": "100"
+    },
+    {
+      "x": -479,
+      "z": -4546,
+      "name": "Aldorei",
+      "layer": 2,
+      "level": "75"
+    },
+    {
+      "x": 134,
+      "z": -5241,
+      "name": "Thanos",
+      "layer": 2,
+      "level": "80"
+    },
+    {
+      "x": -608,
+      "z": -5442,
+      "name": "Lexdale",
+      "layer": 2,
+      "level": "70"
+    },
+    {
+      "x": 941,
+      "z": -5506,
+      "name": "Eltom",
+      "layer": 2,
+      "level": "85"
+    },
+    {
+      "x": 1486,
+      "z": -5292,
+      "name": "Maex",
+      "layer": 2,
+      "level": "90"
+    },
+    {
+      "x": 757,
+      "z": -4466,
+      "name": "Kandon-Beda",
+      "layer": 2,
+      "level": "95"
+    },
+    {
+      "x": -1617,
+      "z": -4470,
+      "name": "Karoc Quarry",
+      "layer": 2,
+      "level": "45"
+    },
+    {
+      "x": -950,
+      "z": -4913,
+      "name": "Light Forest",
+      "layer": 2,
+      "level": "70"
+    },
+    {
+      "x": -1162,
+      "z": -5341,
+      "name": "Dark Forest",
+      "layer": 2,
+      "level": "60"
+    },
+    {
+      "x": 1495,
+      "z": -5492,
+      "name": "Molten Heights",
+      "layer": 2,
+      "level": "90"
+    },
+    {
+      "x": -1493,
+      "z": -4818,
+      "name": "Pre-Light Forest",
+      "layer": 2,
+      "level": "65"
+    },
+    {
+      "x": 629,
+      "z": -5224,
+      "name": "Canyon of the Lost",
+      "layer": 2,
+      "level": "85"
+    },
+    {
+      "x": -1066,
+      "z": -5007,
+      "name": "Efilim",
+      "layer": 2,
+      "level": "70"
+    },
+    {
+      "x": 1266,
+      "z": -4697,
+      "name": "Sky Islands",
+      "layer": 2,
+      "level": "95"
+    },
+    {
+      "x": -1004,
+      "z": -5300,
+      "name": "Gelibord",
+      "layer": 2,
+      "level": "60"
+    },
+    {
+      "x": -779,
+      "z": -435,
+      "name": "Dernel Jungle",
+      "layer": 2,
+      "level": "60-70"
+    },
+    {
+      "x": -46,
+      "z": -5539,
+      "name": "Gert Camp",
+      "layer": 2,
+      "level": "75"
+    },
+    {
+      "x": -1608,
+      "z": -4969,
+      "name": "Bucie",
+      "layer": 2,
+      "level": "40"
+    },
+    {
+      "x": -164,
+      "z": -5238,
+      "name": "Lake Gylia",
+      "layer": 2,
+      "level": "75"
+    },
+    {
+      "x": -805,
+      "z": -5312,
+      "name": "Kander Forest",
+      "layer": 2,
+      "level": "70"
+    },
+    {
+      "x": -1926,
+      "z": -5299,
+      "name": "Swamp",
+      "layer": 2,
+      "level": "50"
+    },
+    {
+      "x": 606,
+      "z": -4873,
+      "name": "Bantisu Air Temple",
+      "layer": 2,
+      "level": "85"
+    },
+    {
+      "x": -189,
+      "z": -4917,
+      "name": "Letvus Airbase",
+      "layer": 2
+    },
+    {
+      "x": -310,
+      "z": -4933,
+      "name": "Guild Hall",
+      "layer": 2
+    },
+    {
+      "x": 395,
+      "z": -5573,
+      "name": "The Hive",
+      "layer": 2
+    },
+    {
+      "x": -1041,
+      "z": -4480,
+      "name": "Light's Secret",
+      "layer": 2
+    },
+    {
+      "x": -310,
+      "z": -430,
+      "name": "Tower of Ascension",
+      "layer": 2
+    },
+    {
+      "x": -847,
+      "z": -4911,
+      "name": "The Forgery",
+      "layer": 2,
+      "level": "70"
+    },
+    {
+      "x": 256,
+      "z": -5288,
+      "name": "Ozoth's Spire",
+      "layer": 2
+    },
+    {
+      "x": -110,
+      "z": -5049,
+      "name": "The Province of Gavel",
+      "layer": 1
+    },
+    {
+      "x": 1144,
+      "z": -845,
+      "name": "The Silent Expanse",
+      "layer": 1
+    },
+    {
+      "x": -1522,
+      "z": -2752,
+      "name": "Corkus Island",
+      "layer": 1
+    },
+    {
+      "x": 979,
+      "z": -675,
+      "name": "Lutho",
+      "layer": 2,
+      "level": "105"
+    },
+    {
+      "x": 603,
+      "z": -543,
+      "name": "Ruined Olmic City",
+      "layer": 2,
+      "level": "100"
+    },
+    {
+      "x": 1350,
+      "z": -904,
+      "name": "The Eldritch Outlook",
+      "layer": 2,
+      "level": "100+"
+    }
+  ]
+}


### PR DESCRIPTION
This patch will add text labels (names of places) to the in-game map, just as found on map.wynncraft.com.

The labels are pulled from map.wynncraft.com, and processed into a json format by a simple script. The script is currently inside the `script` directory. You may want to put the json file on your Athena service eventually, instead of bundling it with the plugin. (I've written some non-tested, commented-out code to achieve this, based on other methods in the WebManager class.)

I am pleasantly surprised at how good this looks. It really fills a need I've had for a long time with the Wynntils map. (While I'm not as much of a Wynncraft noob anymore, I still suck at remembering names and places, and I was forced to swap out Wynncraft to map.wynncraft.com to check those.)
