### PR TITLE
Avoid NPE stack trace if CoreDBConfig singleton is not instantiated

### DIFF
--- a/src/main/java/com/wynntils/core/framework/settings/SettingsContainer.java
+++ b/src/main/java/com/wynntils/core/framework/settings/SettingsContainer.java
@@ -63,8 +63,10 @@ public class SettingsContainer {
         }
 
         try {
-            if (CoreDBConfig.INSTANCE.enableCloudSync) {
-                fromCloud = SettingsManager.getCloudSettings(m, holder);
+            if (CoreDBConfig.INSTANCE != null) {
+                if (CoreDBConfig.INSTANCE.enableCloudSync) {
+                    fromCloud = SettingsManager.getCloudSettings(m, holder);
+                }
             }
         } catch (Exception ex) { ex.printStackTrace(); }
 


### PR DESCRIPTION
At startup, CoreDBConfig singleton might not be instantiated. Check for null to avoid printing a NPE stack trace.

I got annoyed at this always appearing when I was debugging my other branch.