### PR TITLE
Implement item lookup on WynnData

### DIFF
--- a/src/main/java/com/wynntils/core/utils/Utils.java
+++ b/src/main/java/com/wynntils/core/utils/Utils.java
@@ -6,6 +6,7 @@ package com.wynntils.core.utils;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.wynntils.ModCore;
+import com.wynntils.core.utils.reflections.ReflectionMethods;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.GuiTextField;
@@ -22,6 +23,7 @@ import net.minecraft.util.text.TextFormatting;
 import net.minecraft.util.text.event.ClickEvent;
 import net.minecraftforge.client.event.GuiOpenEvent;
 import net.minecraftforge.common.MinecraftForge;
+import org.lwjgl.opengl.Display;
 
 import java.awt.Desktop;
 import java.awt.Toolkit;
@@ -270,6 +272,11 @@ public class Utils {
         if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
             try {
                 Desktop.getDesktop().browse(new URI(url));
+                // If we switch windows so Minecraft loses focus, make sure we forget
+                // about any pressed keys.
+                if (!Display.isActive()) {
+                    ReflectionMethods.Keyboard_reset.invoke(null);
+                }
                 return;
             } catch (Exception ignored) {
                 ignored.printStackTrace();

--- a/src/main/java/com/wynntils/core/utils/Utils.java
+++ b/src/main/java/com/wynntils/core/utils/Utils.java
@@ -10,6 +10,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.GuiTextField;
 import net.minecraft.client.gui.ScaledResolution;
+import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.scoreboard.ScorePlayerTeam;
@@ -126,6 +127,13 @@ public class Utils {
         healthBar = healthBar.substring(0, 5 + Math.min(health, 15)) + TextFormatting.DARK_GRAY + healthBar.substring(5 + Math.min(health, 15));
         if (health < 8) { healthBar = healthBar.replace(TextFormatting.RED.toString(), TextFormatting.GOLD.toString()); }
         return healthBar;
+    }
+
+    /**
+     * Return true if the GuiScreen is the character information page (selected from the compass)
+     */
+    public static boolean isCharacterInfoPage(GuiScreen gui) {
+        return (gui instanceof GuiContainer && ((GuiContainer)gui).inventorySlots.getSlot(0).inventory.getName().contains("skill points remaining"));
     }
 
     /**

--- a/src/main/java/com/wynntils/core/utils/Utils.java
+++ b/src/main/java/com/wynntils/core/utils/Utils.java
@@ -243,10 +243,15 @@ public class Utils {
      */
     public static String encodeItemNameForUrl(ItemStack stack) {
         final Pattern PERCENTAGE_PATTERN = Pattern.compile(" +\\[[0-9]+%\\]");
+        final Pattern INGREDIENT_PATTERN = Pattern.compile(" +\\[✫+\\]");
 
         String name = stack.getDisplayName();
         name = TextFormatting.getTextWithoutFormattingCodes(name);
         name = PERCENTAGE_PATTERN.matcher(name).replaceAll("");
+        name = INGREDIENT_PATTERN.matcher(name).replaceAll("");
+        if (name.startsWith("Perfect ")) {
+            name = name.substring(8);
+        }
         name = com.wynntils.core.utils.StringUtils.normalizeBadString(name);
         try {
             name = URLEncoder.encode(name, "UTF-8");
@@ -270,7 +275,7 @@ public class Utils {
                 ignored.printStackTrace();
             }
         }
-        
+
         Utils.copyToClipboard(url);
         TextComponentString text = new TextComponentString("Error opening link, it has been copied to your clipboard\n");
         text.getStyle().setColor(TextFormatting.DARK_RED);

--- a/src/main/java/com/wynntils/core/utils/Utils.java
+++ b/src/main/java/com/wynntils/core/utils/Utils.java
@@ -272,11 +272,12 @@ public class Utils {
         if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
             try {
                 Desktop.getDesktop().browse(new URI(url));
+                
                 // If we switch windows so Minecraft loses focus, make sure we forget
                 // about any pressed keys.
-                if (!Display.isActive()) {
+                if (!Display.isActive())
                     ReflectionMethods.Keyboard_reset.invoke(null);
-                }
+                
                 return;
             } catch (Exception ignored) {
                 ignored.printStackTrace();

--- a/src/main/java/com/wynntils/core/utils/reflections/ReflectionMethods.java
+++ b/src/main/java/com/wynntils/core/utils/reflections/ReflectionMethods.java
@@ -15,8 +15,7 @@ public enum ReflectionMethods {
 
     Minecraft$setWindowIcon(Minecraft.class, "setWindowIcon", "func_175594_ao"),
     SPacketPlayerListItem$AddPlayerData_getProfile(ReflectionClasses.SPacketPlayerListItem$AddPlayerData.clazz, "getProfile", "func_179962_a"),
-    SPacketPlayerListItem$AddPlayerData_getDisplayName(ReflectionClasses.SPacketPlayerListItem$AddPlayerData.clazz, "getDisplayName", "func_179961_d"),
-    Keyboard_reset(Keyboard.class, "reset", null);
+    SPacketPlayerListItem$AddPlayerData_getDisplayName(ReflectionClasses.SPacketPlayerListItem$AddPlayerData.clazz, "getDisplayName", "func_179961_d");
 
     final Method method;
 

--- a/src/main/java/com/wynntils/core/utils/reflections/ReflectionMethods.java
+++ b/src/main/java/com/wynntils/core/utils/reflections/ReflectionMethods.java
@@ -16,7 +16,7 @@ public enum ReflectionMethods {
     Minecraft$setWindowIcon(Minecraft.class, "setWindowIcon", "func_175594_ao"),
     SPacketPlayerListItem$AddPlayerData_getProfile(ReflectionClasses.SPacketPlayerListItem$AddPlayerData.clazz, "getProfile", "func_179962_a"),
     SPacketPlayerListItem$AddPlayerData_getDisplayName(ReflectionClasses.SPacketPlayerListItem$AddPlayerData.clazz, "getDisplayName", "func_179961_d"),
-    Keyboard_reset(Keyboard.class, "reset", "reset");
+    Keyboard_reset(Keyboard.class, "reset", null);
 
     final Method method;
 

--- a/src/main/java/com/wynntils/core/utils/reflections/ReflectionMethods.java
+++ b/src/main/java/com/wynntils/core/utils/reflections/ReflectionMethods.java
@@ -6,6 +6,7 @@ package com.wynntils.core.utils.reflections;
 
 import net.minecraft.client.Minecraft;
 import net.minecraftforge.fml.relauncher.ReflectionHelper;
+import org.lwjgl.input.Keyboard;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -14,7 +15,8 @@ public enum ReflectionMethods {
 
     Minecraft$setWindowIcon(Minecraft.class, "setWindowIcon", "func_175594_ao"),
     SPacketPlayerListItem$AddPlayerData_getProfile(ReflectionClasses.SPacketPlayerListItem$AddPlayerData.clazz, "getProfile", "func_179962_a"),
-    SPacketPlayerListItem$AddPlayerData_getDisplayName(ReflectionClasses.SPacketPlayerListItem$AddPlayerData.clazz, "getDisplayName", "func_179961_d");
+    SPacketPlayerListItem$AddPlayerData_getDisplayName(ReflectionClasses.SPacketPlayerListItem$AddPlayerData.clazz, "getDisplayName", "func_179961_d"),
+    Keyboard_reset(Keyboard.class, "reset", "reset");
 
     final Method method;
 

--- a/src/main/java/com/wynntils/modules/utilities/managers/DailyReminderManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/DailyReminderManager.java
@@ -6,6 +6,7 @@ package com.wynntils.modules.utilities.managers;
 
 import com.wynntils.ModCore;
 import com.wynntils.Reference;
+import com.wynntils.core.utils.Utils;
 import com.wynntils.modules.utilities.UtilitiesModule;
 import com.wynntils.modules.utilities.configs.UtilitiesConfig;
 import net.minecraft.client.audio.PositionedSoundRecord;
@@ -59,7 +60,7 @@ public class DailyReminderManager {
     public static void openedDailyInventory(GuiScreenEvent.InitGuiEvent.Post e) {
         if (!UtilitiesConfig.INSTANCE.dailyReminder || !Reference.onWorld) return;
 
-        if (e.getGui() instanceof GuiContainer && ((GuiContainer)e.getGui()).inventorySlots.getSlot(0).inventory.getName().contains("skill points remaining")) {
+        if (Utils.isCharacterInfoPage(e.getGui())) {
             if (!((GuiContainer) e.getGui()).inventorySlots.getSlot(22).getHasStack()) {
                 UtilitiesConfig.Data.INSTANCE.dailyReminder = System.currentTimeMillis() + 86400000;
                 UtilitiesConfig.Data.INSTANCE.saveSettings(UtilitiesModule.getModule());

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/WynnDataOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/WynnDataOverlay.java
@@ -14,6 +14,7 @@ import net.minecraft.client.audio.PositionedSoundRecord;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.SoundEvents;
+import net.minecraft.inventory.Slot;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.NonNullList;
@@ -65,10 +66,12 @@ public class WynnDataOverlay implements Listener {
     @SubscribeEvent
     public void clickOnChest(GuiOverlapEvent.ChestOverlap.HandleMouseClick e) {
         if (!Utils.isCharacterInfoPage(e.getGui()) || !WynnDataOverlay.itemLookupMode ||
-                e.getMouseButton() != 1 || e.getGui().getSlotUnderMouse() == null ||
-                e.getGui().getSlotUnderMouse().inventory == null) return;
+                e.getMouseButton() != 1) return;
 
-        ItemStack stack = e.getGui().getSlotUnderMouse().getStack();
+        Slot slot = e.getGui().getSlotUnderMouse();
+        if (slot == null || slot.inventory == null || !slot.getHasStack()) return;
+
+        ItemStack stack = slot.getStack();
         Utils.openUrl("https://www.wynndata.tk/i/" + Utils.encodeItemNameForUrl(stack));
         e.setCanceled(true);
     }
@@ -97,7 +100,7 @@ public class WynnDataOverlay implements Listener {
             Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
 
             Map<String, String> itemNames = new HashMap<>();
-            
+
             NonNullList<ItemStack> armorInventory = Minecraft.getMinecraft().player.inventory.armorInventory;
             getItemNameFromInventory(itemNames, "helmet", armorInventory, 3);
             getItemNameFromInventory(itemNames, "chestplate", armorInventory, 2);
@@ -124,5 +127,5 @@ public class WynnDataOverlay implements Listener {
             Utils.openUrl(urlBuilder.toString());
         });
     }
-    
+
 }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/WynnDataOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/WynnDataOverlay.java
@@ -7,7 +7,6 @@ package com.wynntils.modules.utilities.overlays.inventories;
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.GuiOverlapEvent;
 import com.wynntils.core.framework.interfaces.Listener;
-import com.wynntils.core.framework.rendering.colors.CommonColors;
 import com.wynntils.core.utils.Utils;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.audio.PositionedSoundRecord;
@@ -18,55 +17,43 @@ import net.minecraft.inventory.Slot;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.NonNullList;
-import net.minecraftforge.client.event.GuiScreenEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import org.lwjgl.input.Keyboard;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
 public class WynnDataOverlay implements Listener {
-    GuiButton button;
-    public static boolean itemLookupMode = false;
 
     @SubscribeEvent
     public void initGui(GuiOverlapEvent.ChestOverlap.InitGui e) {
         if (!Reference.onWorld || !Utils.isCharacterInfoPage(e.getGui())) return;
 
-        button = new GuiButton(12,
+        e.getButtonList().add(
+                new GuiButton(12,
                         (e.getGui().width - e.getGui().getXSize()) / 2 - 20,
                         (e.getGui().height - e.getGui().getYSize()) / 2 + 40,
                         18, 18,
                         "➦"
-                );
-        e.getButtonList().add(button);
+                )
+        );
     }
 
     @SubscribeEvent
     public void drawScreen(GuiOverlapEvent.ChestOverlap.DrawScreen e) {
         e.getButtonList().forEach(gb -> {
             if (gb.id == 12 && gb.isMouseOver()) {
-                if (itemLookupMode) {
-                    e.getGui().drawHoveringText( Arrays.asList("Right click on item", "to open on WynnData"),  e.getMouseX(), e.getMouseY());
-                } else {
-                    e.getGui().drawHoveringText(Arrays.asList("Left click: Open Build on WynnData", "Right click: Toggle item lookup mode"), e.getMouseX(), e.getMouseY());
-                }
+                e.getGui().drawHoveringText(Arrays.asList("Left click: Open Build on WynnData", "Shift + Right click on item: Open Item on WynnData"), e.getMouseX(), e.getMouseY());
             }
         });
     }
 
     @SubscribeEvent
-    public void characterInfoPageOpened(GuiScreenEvent.InitGuiEvent.Post e) {
-        if (Utils.isCharacterInfoPage(e.getGui())) {
-            // Reset lookup mode when re-opening character info page
-            itemLookupMode = false;
-        }
-    }
-
-    @SubscribeEvent
     public void clickOnChest(GuiOverlapEvent.ChestOverlap.HandleMouseClick e) {
-        if (!Utils.isCharacterInfoPage(e.getGui()) || !WynnDataOverlay.itemLookupMode ||
-                e.getMouseButton() != 1) return;
+        if (!Utils.isCharacterInfoPage(e.getGui()) || e.getMouseButton() != 1) return;
+
+        if (!(Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT))) return;
 
         Slot slot = e.getGui().getSlotUnderMouse();
         if (slot == null || slot.inventory == null || !slot.getHasStack()) return;
@@ -86,16 +73,7 @@ public class WynnDataOverlay implements Listener {
     @SubscribeEvent
     public void mouseClicked(GuiOverlapEvent.ChestOverlap.MouseClicked e) {
         e.getButtonList().forEach(gb -> {
-            if (gb.id != 12 || !gb.isMouseOver()) return;
-
-            if (e.getMouseButton() == 1) {
-                // Toggle item lookup mode with right click
-                itemLookupMode = !itemLookupMode;
-                button.packedFGColour = itemLookupMode ? CommonColors.ORANGE.toInt() : 0;
-                return;
-            }
-
-            if (e.getMouseButton() != 0) return;
+            if (gb.id != 12 || !gb.isMouseOver() || e.getMouseButton() != 0) return;
 
             Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
 


### PR DESCRIPTION
This PR adds the functionality to do item lookups on WynnData. To enter item lookup mode, right click on the WynnData share button. You can then right click on any item to open it in WynnData's item database. You can exit the item lookup mode by leaving the character information page, or by right clicking again on the WynnData share button.

The rationale for the item identification mode is to avoid accidental right clicks which opens the browser unexpectedly.

This PR also fixes a bug with the WynnData share button. I only intended for it to appear on the character info page, but it appeared on all chests (!). 