### PR TITLE
Add a tooltip to the "+" sign on the map

### DIFF
--- a/src/main/java/com/wynntils/modules/map/overlays/ui/MainWorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/MainWorldMapUI.java
@@ -91,6 +91,9 @@ public class MainWorldMapUI extends WorldMapUI {
 
         super.drawScreen(mouseX, mouseY, partialTicks);
 
+        if (addWaypointBtn.isMouseOver()) {
+            drawHoveringText(TextFormatting.GRAY + "Add waypoint", mouseX, mouseY);
+        }
         if (helpBtn.isMouseOver()) {
             drawHoveringText(Arrays.asList(
                     TextFormatting.UNDERLINE + "Help",


### PR DESCRIPTION
Add a tooltip to the "+" sign on the map, to help the user understand its purpose.