### PR TITLE
Add support for powders on WynnData build lookup.

### DIFF
--- a/src/main/java/com/wynntils/core/framework/enums/Powder.java
+++ b/src/main/java/com/wynntils/core/framework/enums/Powder.java
@@ -1,0 +1,49 @@
+/*
+ *  * Copyright © Wynntils - 2020.
+ */
+
+package com.wynntils.core.framework.enums;
+
+import net.minecraft.util.text.TextFormatting;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public enum Powder {
+
+    EARTH('✤', TextFormatting.DARK_GREEN),
+    THUNDER('✦', TextFormatting.YELLOW),
+    WATER('❉', TextFormatting.AQUA),
+    FIRE('✹', TextFormatting.RED),
+    AIR('❋', TextFormatting.WHITE);
+
+    char symbol;
+    String color;
+
+    Powder(char symbol, TextFormatting color) {
+        this.symbol = symbol;
+        this.color = color.toString();
+    }
+
+    public char getSymbol() {
+        return symbol;
+    }
+
+    public String getLetterRepresentation() {
+        return this.name().substring(0, 1).toLowerCase();
+    }
+
+    public static List<Powder> findPowders(String input) {
+        List<Powder> foundPowders = new LinkedList<>();
+        input.chars().forEach(ch -> {
+            for (Powder powder : values()) {
+                if (ch == powder.getSymbol()) {
+                    foundPowders.add(powder);
+                }
+            }
+        });
+
+        return foundPowders;
+    }
+
+}


### PR DESCRIPTION
Limitations: As has been discussed in Discord, there is no way to get the tier of applied powders from Wynncraft. The solution is to assume tier 1, and redirect the user to the powder setup screen on WynnData, where suitable adjustments in tier can be made. In the end, I think this turned out pretty OK.