### PR TITLE
Print the coordinates of where the loot run start when loading it

### DIFF
--- a/src/main/java/com/wynntils/modules/map/commands/CommandLootRun.java
+++ b/src/main/java/com/wynntils/modules/map/commands/CommandLootRun.java
@@ -69,8 +69,10 @@ public class CommandLootRun extends CommandBase implements IClientCommand {
 
                 if (!LootRunManager.getActivePath().getPoints().isEmpty()) {
                     Location start = LootRunManager.getActivePath().getPoints().get(0);
-                    sender.sendMessage(new TextComponentString("Loot run starts at [" +
-                            (int) start.getX() + ", " + (int) start.getZ() + "]"));
+                    ITextComponent startingPointMsg = new TextComponentString("Loot run starts at [" +
+                            (int) start.getX() + ", " + (int) start.getZ() + "]");
+                    startingPointMsg.getStyle().setColor(GRAY);
+                    sender.sendMessage(startingPointMsg);
                 }
 
                 return;

--- a/src/main/java/com/wynntils/modules/map/commands/CommandLootRun.java
+++ b/src/main/java/com/wynntils/modules/map/commands/CommandLootRun.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.map.commands;
 
+import com.wynntils.core.utils.objects.Location;
 import com.wynntils.modules.map.managers.LootRunManager;
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.CommandException;
@@ -65,6 +66,13 @@ public class CommandLootRun extends CommandBase implements IClientCommand {
                 else message = RED + "The specified loot run doesn't exist!";
 
                 sender.sendMessage(new TextComponentString(message));
+
+                if (!LootRunManager.getActivePath().getPoints().isEmpty()) {
+                    Location start = LootRunManager.getActivePath().getPoints().get(0);
+                    sender.sendMessage(new TextComponentString("Loot run starts at [" +
+                            (int) start.getX() + ", " + (int) start.getZ() + "]"));
+                }
+
                 return;
             }
             case "save": {


### PR DESCRIPTION
Print the coordinates of where the loot run start when loading it. (Which are clickable, so you can set your beacon there easily.)