### PR TITLE
Fix bugs on consumables from chat

### DIFF
--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -167,7 +167,7 @@ public class ClientEvents implements Listener {
         }
 
         if (OverlayConfig.ConsumableTimer.INSTANCE.captureChat) {
-            if (msg.equals("+3 minutes speed boost.")) {
+            if (msg.endsWith("+3 minutes speed boost.")) {
                 ConsumableTimerOverlay.addBasicTimer("Speed boost", 3*60 - 1);
             }
             Matcher matcher = CHEST_COOLDOWN_PATTERN.matcher(msg);

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -168,12 +168,12 @@ public class ClientEvents implements Listener {
 
         if (OverlayConfig.ConsumableTimer.INSTANCE.captureChat) {
             if (msg.equals("+3 minutes speed boost.")) {
-                ConsumableTimerOverlay.addBasicTimer("Speed boost", 3*60);
+                ConsumableTimerOverlay.addBasicTimer("Speed boost", 3*60 - 1);
             }
             Matcher matcher = CHEST_COOLDOWN_PATTERN.matcher(msg);
             if (matcher.find()) {
                 int minutes = Integer.parseInt(matcher.group(1));
-                ConsumableTimerOverlay.addBasicTimer("Loot cooldown", minutes*60);
+                ConsumableTimerOverlay.addBasicTimer("Loot cooldown", minutes*60 - 1);
             }
         }
     }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/ConsumableTimerOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/ConsumableTimerOverlay.java
@@ -192,7 +192,7 @@ public class ConsumableTimerOverlay extends Overlay {
     public static void addBasicTimer(String name, int timeInSeconds) {
         String formattedName = GRAY + name;
         ConsumableContainer consumable = new ConsumableContainer(formattedName);
-        consumable.setExpirationTime(System.currentTimeMillis() + timeInSeconds*1000);
+        consumable.setExpirationTime(Minecraft.getSystemTime() + timeInSeconds*1000);
         // Clear old consumable with the same name
         activeConsumables.removeIf(c -> c.getName().equals(formattedName));
         activeConsumables.add(consumable);


### PR DESCRIPTION
Fix bugs on consumables from chat reported by SirCmt:
 * Use Minecraft.getSystemTime() to avoid time discrepancy on Windows.
 * Subtract a second to better align with actual time set by server.