### PR TITLE
Bug fixes to speed boost consumable

### DIFF
--- a/src/main/java/com/wynntils/core/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/core/events/ClientEvents.java
@@ -88,6 +88,8 @@ public class ClientEvents {
         }
 
         // by message
+        else if (message.equals("You have died...") && e.getType()==ChatType.SYSTEM)
+            toDispatch = new GameEvent.PlayerDeath();
         else if (message.startsWith("[New Quest Started:"))
             toDispatch = new GameEvent.QuestStarted(message.replace("[New Quest Started: ", "").replace("]", ""));
         else if (message.startsWith("[Mini-Quest Started:"))

--- a/src/main/java/com/wynntils/core/events/custom/GameEvent.java
+++ b/src/main/java/com/wynntils/core/events/custom/GameEvent.java
@@ -16,6 +16,12 @@ import net.minecraftforge.fml.common.eventhandler.Event;
 public class GameEvent extends Event {
 
     /**
+     * Called when the user dies
+     */
+    public static class PlayerDeath extends GameEvent {
+    }
+
+    /**
      * Called when the user Level Up
      */
     public static class LevelUp extends GameEvent {

--- a/src/main/java/com/wynntils/modules/questbook/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/questbook/events/ClientEvents.java
@@ -64,7 +64,7 @@ public class ClientEvents implements Listener {
             position = AnalysePosition.SECRET_DISCOVERIES;
         else if (e instanceof GameEvent.DiscoveryFound)
             position = AnalysePosition.DISCOVERIES;
-        else if (e instanceof GameEvent.ResourceGather) return;
+        else return;
 
         QuestManager.updateAnalysis(position, fullRead, readImmediately && !QuestBookConfig.INSTANCE.updateWhenOpen);
     }

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -167,7 +167,7 @@ public class ClientEvents implements Listener {
         }
 
         if (OverlayConfig.ConsumableTimer.INSTANCE.captureChat) {
-            if (msg.equals("+3 minutes speed boost.")) {
+            if (msg.endsWith("+3 minutes speed boost.")) {
                 ConsumableTimerOverlay.addBasicTimer("Speed boost", 3*60 - 1);
             }
             Matcher matcher = CHEST_COOLDOWN_PATTERN.matcher(msg);

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -167,9 +167,6 @@ public class ClientEvents implements Listener {
         }
 
         if (OverlayConfig.ConsumableTimer.INSTANCE.captureChat) {
-            if (msg.endsWith("+3 minutes speed boost.")) {
-                ConsumableTimerOverlay.addBasicTimer("Speed boost", 3*60 - 1);
-            }
             Matcher matcher = CHEST_COOLDOWN_PATTERN.matcher(msg);
             if (matcher.find()) {
                 int minutes = Integer.parseInt(matcher.group(1));

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -168,12 +168,12 @@ public class ClientEvents implements Listener {
 
         if (OverlayConfig.ConsumableTimer.INSTANCE.captureChat) {
             if (msg.equals("+3 minutes speed boost.")) {
-                ConsumableTimerOverlay.addBasicTimer("Speed boost", 3*60);
+                ConsumableTimerOverlay.addBasicTimer("Speed boost", 3*60 - 1);
             }
             Matcher matcher = CHEST_COOLDOWN_PATTERN.matcher(msg);
             if (matcher.find()) {
                 int minutes = Integer.parseInt(matcher.group(1));
-                ConsumableTimerOverlay.addBasicTimer("Loot cooldown", minutes*60);
+                ConsumableTimerOverlay.addBasicTimer("Loot cooldown", minutes*60 - 1);
             }
         }
     }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/ConsumableTimerOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/ConsumableTimerOverlay.java
@@ -192,7 +192,7 @@ public class ConsumableTimerOverlay extends Overlay {
     public static void addBasicTimer(String name, int timeInSeconds) {
         String formattedName = GRAY + name;
         ConsumableContainer consumable = new ConsumableContainer(formattedName);
-        consumable.setExpirationTime(System.currentTimeMillis() + timeInSeconds*1000);
+        consumable.setExpirationTime(Minecraft.getSystemTime() + timeInSeconds*1000);
         // Clear old consumable with the same name
         activeConsumables.removeIf(c -> c.getName().equals(formattedName));
         activeConsumables.add(consumable);


### PR DESCRIPTION
Fixes:
 * Speed boost replenished before expired will now update timer. 
 * Dying will now clear speed boost (and all other consumables!)

Looking for both chat message and the SPacketEntityEffect is probably overkill, but it's hard to be certain about the server's behavior, and it does not harm to have both.