### PR TITLE
Improvements for "consumables" countdown timers

### DIFF
--- a/src/main/java/com/wynntils/modules/utilities/configs/OverlayConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/OverlayConfig.java
@@ -496,8 +496,14 @@ public class OverlayConfig extends SettingsClass {
         @Setting(displayName = "Show Effects", description = "Should the effects be displayed in the overlay?")
         public boolean showEffects = true;
 
-        @Setting(displayName = "Capture Chat Events", description = "Should events from the chat, such as loot chest cooldown, be displayed?")
-        public boolean captureChat = true;
+        @Setting(displayName = "Show Cool Down", description = "Should loot chest cool down be displayed as a timer?")
+        public boolean showCooldown = true;
+
+        @Setting(displayName = "Show Spell Effects", description = "Should spell effects such as speed boost be displayed?")
+        public boolean showSpellEffects = true;
+
+        @Setting(displayName = "Show Server Restart", description = "Should server restart countdown be displayed?")
+        public boolean showServerRestart = false;
     }
 
 }

--- a/src/main/java/com/wynntils/modules/utilities/configs/OverlayConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/OverlayConfig.java
@@ -326,6 +326,9 @@ public class OverlayConfig extends SettingsClass {
 
             @Setting(displayName = "Redirect Soul Point Messages", description = "Should messages about regaining soul points be redirected to the game-update-ticker?")
             public boolean redirectSoulPoint = true;
+
+            @Setting(displayName = "Redirect Cooldown", description = "Should messages about needing to wait be redirected to the game-update-ticker?")
+            public boolean redirectCooldown = true;
         }
 
         @SettingsInfo(name = "game_update_territory_settings", displayPath = "Utilities/Overlays/Update Ticker/Territory Change")

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -10,6 +10,7 @@ import com.wynntils.core.events.custom.ChatEvent;
 import com.wynntils.core.events.custom.GuiOverlapEvent;
 import com.wynntils.core.events.custom.PacketEvent;
 import com.wynntils.core.events.custom.WynnClassChangeEvent;
+import com.wynntils.core.events.custom.WynnWorldEvent;
 import com.wynntils.core.framework.enums.wynntils.WynntilsSound;
 import com.wynntils.core.framework.instances.PlayerInfo;
 import com.wynntils.core.framework.interfaces.Listener;
@@ -166,11 +167,11 @@ public class ClientEvents implements Listener {
             DailyReminderManager.openedDaily();
         }
 
-        if (OverlayConfig.ConsumableTimer.INSTANCE.captureChat) {
+        if (OverlayConfig.ConsumableTimer.INSTANCE.showCooldown) {
             Matcher matcher = CHEST_COOLDOWN_PATTERN.matcher(msg);
             if (matcher.find()) {
                 int minutes = Integer.parseInt(matcher.group(1));
-                ConsumableTimerOverlay.addBasicTimer("Loot cooldown", minutes*60 - 1);
+                ConsumableTimerOverlay.addBasicTimer("Loot cooldown", minutes*60 - 1, true);
             }
         }
     }
@@ -506,7 +507,12 @@ public class ClientEvents implements Listener {
 
     @SubscribeEvent
     public void onClassChange(WynnClassChangeEvent e) {
-        ConsumableTimerOverlay.clearConsumables(); // clear consumable list
+        ConsumableTimerOverlay.clearConsumables(false); // clear consumable list
+    }
+
+    @SubscribeEvent
+    public void onWorldLeave(WynnWorldEvent.Leave e) {
+        ConsumableTimerOverlay.clearConsumables(true); // clear consumable list
     }
 
     // tooltip scroller

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -20,7 +20,6 @@ import com.wynntils.core.utils.reflections.ReflectionFields;
 import com.wynntils.modules.chat.overlays.gui.ChatGUI;
 import com.wynntils.modules.core.overlays.inventories.ChestReplacer;
 import com.wynntils.modules.utilities.UtilitiesModule;
-import com.wynntils.modules.utilities.configs.OverlayConfig;
 import com.wynntils.modules.utilities.configs.SoundEffectsConfig;
 import com.wynntils.modules.utilities.configs.UtilitiesConfig;
 import com.wynntils.modules.utilities.managers.*;
@@ -60,13 +59,10 @@ import org.lwjgl.opengl.Display;
 
 import java.util.HashSet;
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class ClientEvents implements Listener {
     private static GuiScreen scheduledGuiScreen = null;
     private static boolean firstNullOccurred = false;
-    private static final Pattern CHEST_COOLDOWN_PATTERN = Pattern.compile("Please wait an additional ([0-9]+) minutes? before opening this chest.");
 
     boolean isAfk = false;
     int lastPosition = 0;
@@ -165,14 +161,6 @@ public class ClientEvents implements Listener {
         String msg = e.getMessage().getUnformattedText();
         if (msg.startsWith("[Daily Rewards:")) {
             DailyReminderManager.openedDaily();
-        }
-
-        if (OverlayConfig.ConsumableTimer.INSTANCE.showCooldown) {
-            Matcher matcher = CHEST_COOLDOWN_PATTERN.matcher(msg);
-            if (matcher.find()) {
-                int minutes = Integer.parseInt(matcher.group(1));
-                ConsumableTimerOverlay.addBasicTimer("Loot cooldown", minutes*60 - 1, true);
-            }
         }
     }
 

--- a/src/main/java/com/wynntils/modules/utilities/instances/ConsumableContainer.java
+++ b/src/main/java/com/wynntils/modules/utilities/instances/ConsumableContainer.java
@@ -11,13 +11,19 @@ import java.util.HashMap;
 
 public class ConsumableContainer {
 
-    String name;
-    long expirationTime = 0;
+    private String name;
+    private long expirationTime = 0;
+    private boolean persistent = false;
 
     HashMap<String, IdentificationHolder> effects = new HashMap<>();
 
     public ConsumableContainer(String name) {
         this.name = name;
+    }
+
+    public ConsumableContainer(String name, boolean persistent) {
+        this.name = name;
+        this.persistent = persistent;
     }
 
     /**
@@ -91,4 +97,7 @@ public class ConsumableContainer {
         return Minecraft.getSystemTime() >= expirationTime;
     }
 
+    public boolean isPersistent() {
+        return persistent;
+    }
 }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
@@ -258,14 +258,14 @@ public class OverlayEvents implements Listener {
             // ARCHER
             } else if (messageText.equals("+3 minutes speed boost.")) {
                 GameUpdateOverlay.queueMessage(TextFormatting.AQUA + "+3 minutes " + TextFormatting.GRAY + "speed boost");
-                if (OverlayConfig.ConsumableTimer.INSTANCE.captureChat) {
+                if (OverlayConfig.ConsumableTimer.INSTANCE.showSpellEffects) {
                     ConsumableTimerOverlay.addBasicTimer("Speed boost", 3 * 60 - 1);
                 }
                 e.setCanceled(true);
                 return;
             } else if (messageText.matches("[a-zA-Z0-9_]{1,16} gave you \\+3 minutes speed boost\\.")) {
                 GameUpdateOverlay.queueMessage(TextFormatting.AQUA + "+3 minutes " + TextFormatting.GRAY + "speed boost (" + formattedText.split(" ")[0].replace(TextFormatting.RESET.toString(), "") + TextFormatting.GRAY + ")");
-                if (OverlayConfig.ConsumableTimer.INSTANCE.captureChat) {
+                if (OverlayConfig.ConsumableTimer.INSTANCE.showSpellEffects) {
                     ConsumableTimerOverlay.addBasicTimer("Speed boost", 3 * 60 - 1);
                 }
                 e.setCanceled(true);
@@ -274,16 +274,25 @@ public class OverlayEvents implements Listener {
             // WARRIOR
             else if (messageText.matches("[a-zA-Z0-9_]{1,16} has given you 10% resistance\\.")) {
                 GameUpdateOverlay.queueMessage(TextFormatting.AQUA + "+10% resistance " + TextFormatting.GRAY + "(" + formattedText.split(" ")[0].replace(TextFormatting.RESET.toString(), "") + TextFormatting.GRAY + ")");
+                if (OverlayConfig.ConsumableTimer.INSTANCE.showSpellEffects) {
+                    ConsumableTimerOverlay.addBasicTimer("War Scream I", 2 * 60 - 1);
+                }
                 e.setCanceled(true);
                 return;
             }
             else if (messageText.matches("[a-zA-Z0-9_]{1,16} has given you 15% resistance\\.")) {
                 GameUpdateOverlay.queueMessage(TextFormatting.AQUA + "+15% resistance " + TextFormatting.GRAY + "(" + formattedText.split(" ")[0].replace(TextFormatting.RESET.toString(), "") + TextFormatting.GRAY + ")");
+                if (OverlayConfig.ConsumableTimer.INSTANCE.showSpellEffects) {
+                    ConsumableTimerOverlay.addBasicTimer("War Scream II", 3 * 60 - 1);
+                }
                 e.setCanceled(true);
                 return;
             }
             else if (messageText.matches("[a-zA-Z0-9_]{1,16} has given you 20% resistance and 10% strength\\.")) {
                 GameUpdateOverlay.queueMessage(TextFormatting.AQUA + "+20% resistance " + TextFormatting.GRAY + "& " + TextFormatting.AQUA + "+10% strength " + TextFormatting.GRAY + "(" + formattedText.split(" ")[0].replace(TextFormatting.RESET.toString(), "") + TextFormatting.GRAY + ")");
+                if (OverlayConfig.ConsumableTimer.INSTANCE.showSpellEffects) {
+                    ConsumableTimerOverlay.addBasicTimer("War Scream III", 4 * 60 - 1);
+                }
                 e.setCanceled(true);
                 return;
             }
@@ -350,6 +359,19 @@ public class OverlayEvents implements Listener {
                 String[] res = messageText.split(" ");
                 GameUpdateOverlay.queueMessage(TextFormatting.DARK_RED + res[5] + " " + res[6].replace(".", "") + " until server restart");
                 e.setCanceled(true);
+
+                if (OverlayConfig.ConsumableTimer.INSTANCE.showServerRestart) {
+                    try {
+                        int seconds = Integer.parseInt(res[5]);
+                        if (res[6].startsWith("minute")) {
+                            seconds = seconds * 60;
+                        }
+                        ConsumableTimerOverlay.addBasicTimer("Server restart", seconds);
+                    } catch (NumberFormatException ignored) {
+                        // ignore
+                    }
+                }
+
                 return;
             }
         }
@@ -582,12 +604,12 @@ public class OverlayEvents implements Listener {
 
     @SubscribeEvent
     public void onPlayerDeath(GameEvent.PlayerDeath e) {
-        ConsumableTimerOverlay.clearConsumables();
+        ConsumableTimerOverlay.clearConsumables(false);
     }
 
     @SubscribeEvent
     public void onEffectApplied(PacketEvent<SPacketEntityEffect> e) {
-        if (OverlayConfig.ConsumableTimer.INSTANCE.captureChat) {
+        if (OverlayConfig.ConsumableTimer.INSTANCE.showSpellEffects) {
             SPacketEntityEffect effect = e.getPacket();
             Potion potion = Potion.getPotionById(effect.getEffectId());
             if (potion.getName().equals("effect.moveSpeed")) {

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/ConsumableTimerOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/ConsumableTimerOverlay.java
@@ -37,7 +37,7 @@ public class ConsumableTimerOverlay extends Overlay {
     transient private static HashMap<String, IdentificationHolder> activeEffects = new HashMap<>();
 
     public ConsumableTimerOverlay() {
-        super("Consumable Timer", 100, 60, true, 1, 0.2f, 0, 0, OverlayGrowFrom.TOP_RIGHT, RenderGameOverlayEvent.ElementType.ALL);
+        super("Consumable Timer", 125, 60, true, 1, 0.2f, 0, 0, OverlayGrowFrom.TOP_RIGHT, RenderGameOverlayEvent.ElementType.ALL);
     }
 
     public static void clearConsumables(boolean clearPersistant) {
@@ -201,10 +201,18 @@ public class ConsumableTimerOverlay extends Overlay {
      */
     public static void addBasicTimer(String name, int timeInSeconds, boolean persistent) {
         String formattedName = GRAY + name;
+        // setExpirationTime adds an extra 1000 so compensate for that here
+        long expirationTime = Minecraft.getSystemTime() + timeInSeconds*1000 - 1000;
+
+        for (ConsumableContainer c : activeConsumables) {
+            if (c.getName().equals(formattedName)) {
+                c.setExpirationTime(expirationTime);
+                return;
+            }
+        }
+
         ConsumableContainer consumable = new ConsumableContainer(formattedName, persistent);
-        consumable.setExpirationTime(Minecraft.getSystemTime() + timeInSeconds*1000);
-        // Clear old consumable with the same name
-        activeConsumables.removeIf(c -> c.getName().equals(formattedName));
+        consumable.setExpirationTime(expirationTime);
         activeConsumables.add(consumable);
     }
 

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/ConsumableTimerOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/ConsumableTimerOverlay.java
@@ -40,9 +40,15 @@ public class ConsumableTimerOverlay extends Overlay {
         super("Consumable Timer", 100, 60, true, 1, 0.2f, 0, 0, OverlayGrowFrom.TOP_RIGHT, RenderGameOverlayEvent.ElementType.ALL);
     }
 
-    public static void clearConsumables() {
-        // assigns a new object to avoid CME
-        activeConsumables = new ArrayList<>();
+    public static void clearConsumables(boolean clearPersistant) {
+        if (clearPersistant) {
+            // assigns a new object to avoid CME
+            activeConsumables = new ArrayList<>();
+        } else {
+            ArrayList<ConsumableContainer> persistant = new ArrayList<>(activeConsumables);
+            persistant.removeIf(c -> !c.isPersistent());
+            activeConsumables = persistant;
+        }
         activeEffects = new HashMap<>();
     }
 
@@ -189,13 +195,21 @@ public class ConsumableTimerOverlay extends Overlay {
         }
     }
 
-    public static void addBasicTimer(String name, int timeInSeconds) {
+    /**
+     * Create a new generic timer.
+     * @param persistent If this timer should persist over class change or player death
+     */
+    public static void addBasicTimer(String name, int timeInSeconds, boolean persistent) {
         String formattedName = GRAY + name;
-        ConsumableContainer consumable = new ConsumableContainer(formattedName);
+        ConsumableContainer consumable = new ConsumableContainer(formattedName, persistent);
         consumable.setExpirationTime(Minecraft.getSystemTime() + timeInSeconds*1000);
         // Clear old consumable with the same name
         activeConsumables.removeIf(c -> c.getName().equals(formattedName));
         activeConsumables.add(consumable);
+    }
+
+    public static void addBasicTimer(String name, int timeInSeconds) {
+        addBasicTimer(name, timeInSeconds, false);
     }
 
     @Override


### PR DESCRIPTION
* Add timer for War Scream (not tested) 
* Add timer for server restart 
* Keep loot cooldown and server restart timers over class change and player death. 
* Remove all timers on leaving world
* Make individual selections for cooldown, spell effects and server restart as consumables in options.
* Adjust Consumables overlay width to fit new messages better
* Add redirect of cooldown messages to game ticker
* Bug fix for Speed boost incorrectly triggering when going back to hub.