### PR TITLE
Menu button improvements

### DIFF
--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -20,6 +20,11 @@ import java.util.HashSet;
 public class UtilitiesConfig extends SettingsClass {
     public static UtilitiesConfig INSTANCE;
 
+    @Setting(displayName = "Add Class & Hub Buttons to Menu", description = "Should 'Class selection' and 'Back to Hub' buttons be displayed on the in-game menu?", order = 1)
+    public boolean addClassHubButtons = true;
+
+    @Setting(displayName = "Add Options & Profile Buttons to Menu", description = "Should 'Wynntils Option' and 'User Profile'  buttons be displayed on the in-game menu?", order = 2)
+    public boolean addOptionsProfileButtons = true;
 
     @Setting(displayName = "Daily Chest Reminder", description = "Should a message notifying that you can claim your daily chest be sent upon joining a world?")
     public boolean dailyReminder = true;
@@ -29,12 +34,6 @@ public class UtilitiesConfig extends SettingsClass {
 
     @Setting(displayName = "Hide Vanilla Active Potions Indicators", description = "Should the indicator for active potion effects (black squares) be hidden?")
     public boolean hidePotionGui = true;
-
-    @Setting(displayName = "Add Class & Server Button to Menu", description = "Should a class and server button be displayed on the in-game menu?")
-    public boolean addClassServer = true;
-
-    @Setting(displayName = "Add Change Options Button to Menu", description = "Should a button to show the Wynntils Option menu be displayed on the in-game menu when in the hub?")
-    public boolean addChangeOptions = true;
 
     @Setting(displayName = "Hide Nametags Through Walls", description = "Should nametags be hidden when behind opaque blocks?")
     public boolean hideNametags = true;

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/MenuButtonsOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/MenuButtonsOverlay.java
@@ -9,6 +9,7 @@ import com.wynntils.core.events.custom.GuiOverlapEvent;
 import com.wynntils.core.framework.interfaces.Listener;
 import com.wynntils.core.framework.settings.ui.SettingsUI;
 import com.wynntils.modules.core.overlays.inventories.IngameMenuReplacer;
+import com.wynntils.modules.questbook.enums.QuestBookPages;
 import com.wynntils.modules.utilities.configs.UtilitiesConfig;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiButton;
@@ -22,14 +23,53 @@ public class MenuButtonsOverlay implements Listener {
     @SubscribeEvent
     public void initGui(GuiOverlapEvent.IngameMenuOverlap.InitGui e) {
         if (!Reference.onServer) return;
-        if (Reference.onWorld) {
-            if (UtilitiesConfig.INSTANCE.addClassServer) {
-                initClassServerGui(e.getButtonList(), e.getGui());
-            }
-            return;
+
+        int numButtonRows = 0;
+        if (Reference.onWorld && UtilitiesConfig.INSTANCE.addClassHubButtons) {
+            numButtonRows++;
         }
-        if (UtilitiesConfig.INSTANCE.addChangeOptions) {
-            initChangeServer(e.getButtonList(), e.getGui());
+        if (UtilitiesConfig.INSTANCE.addOptionsProfileButtons) {
+            numButtonRows++;
+        }
+        if (numButtonRows == 0) return;
+
+        List<GuiButton> buttonList = e.getButtonList();
+        IngameMenuReplacer gui = e.getGui();
+        removeDefaultButtons(buttonList);
+
+        int yOffset;
+        if (numButtonRows == 2) {
+            yOffset = 48;
+        } else {
+            yOffset = 72;
+            moveTopButtonDown(buttonList, gui);
+        }
+
+        if (Reference.onWorld && UtilitiesConfig.INSTANCE.addClassHubButtons) {
+            addButtonPair(buttonList, gui, yOffset, 753, "Class selection",
+                    754, "Back to Hub");
+            yOffset = 72;
+        }
+
+        if (UtilitiesConfig.INSTANCE.addOptionsProfileButtons) {
+            addButtonPair(buttonList, gui, yOffset, 755, "Wynntils Options",
+                    756, "User Profile");
+        }
+    }
+
+    private static void addButtonPair(List<GuiButton> buttonList, IngameMenuReplacer gui, int yOffset, int buttonId1, String buttonText1, int buttonId2, String buttonText2) {
+        buttonList.add(new GuiButton(buttonId1, gui.width / 2 - 100, gui.height / 4 + yOffset + -16, 98, 20, buttonText1));
+        buttonList.add(new GuiButton(buttonId2, gui.width / 2 + 2, gui.height / 4 + yOffset + -16, 98, 20, buttonText2));
+    }
+
+    /**
+     * Move the top "Back to Game" button down to avoid a gap
+     */
+    private static void moveTopButtonDown(List<GuiButton> buttonList, IngameMenuReplacer gui) {
+        for (GuiButton button : buttonList) {
+            if (button.id == 4) {
+                button.y = gui.height / 4 + 48 - 16;
+            }
         }
     }
 
@@ -49,24 +89,6 @@ public class MenuButtonsOverlay implements Listener {
         });
     }
 
-    private void initClassServerGui(List<GuiButton> buttonList, IngameMenuReplacer gui) {
-        removeDefaultButtons(buttonList);
-
-        buttonList.add(new GuiButton(753, gui.width / 2 - 100, gui.height / 4 + 48 + -16, "Class selection"));
-        buttonList.add(new GuiButton(754, gui.width / 2 - 100, gui.height / 4 + 72 + -16, "Back to Hub"));
-    }
-
-    private void initChangeServer(List<GuiButton> buttonList, IngameMenuReplacer gui) {
-        removeDefaultButtons(buttonList);
-
-        for (GuiButton button : buttonList) {
-            if (button.id == 4) {
-                button.y = gui.height / 4 + 48 - 16;
-            }
-        }
-        buttonList.add(new GuiButton(755, gui.width / 2 - 100, gui.height / 4 + 72 - 16, "Wynntils Options"));
-    }
-
     @SubscribeEvent
     public void actionPerformed(GuiOverlapEvent.IngameMenuOverlap.ActionPerformed e) {
         int id = e.getButton().id;
@@ -79,6 +101,9 @@ public class MenuButtonsOverlay implements Listener {
                 break;
             case 755:
                 Minecraft.getMinecraft().displayGuiScreen(SettingsUI.getInstance(Minecraft.getMinecraft().currentScreen));
+                break;
+            case 756:
+                QuestBookPages.MAIN.getPage().open(true);
                 break;
             default:
                 return;


### PR DESCRIPTION
* Allow Wynntils Options to show even when on a world. 
* Add User Profile as main menu button.
* Rephrase options texts for menu buttons for consistency and clarity.

"Class selection" and "Back to hub" are now half-length buttons which share a row. So is "Wynntils Options" and the new "User Profile" button.