### PR TITLE
Add a /locate command

### DIFF
--- a/src/main/java/com/wynntils/modules/map/MapModule.java
+++ b/src/main/java/com/wynntils/modules/map/MapModule.java
@@ -10,6 +10,7 @@ import com.wynntils.core.framework.instances.KeyHolder;
 import com.wynntils.core.framework.instances.Module;
 import com.wynntils.core.framework.interfaces.annotations.ModuleInfo;
 import com.wynntils.core.utils.Utils;
+import com.wynntils.modules.map.commands.CommandLocate;
 import com.wynntils.modules.map.commands.CommandLootRun;
 import com.wynntils.modules.map.configs.MapConfig;
 import com.wynntils.modules.map.events.ClientEvents;
@@ -49,6 +50,7 @@ public class MapModule extends Module {
         registerOverlay(new MiniMapOverlay(), Priority.LOWEST);
 
         registerCommand(new CommandLootRun());
+        registerCommand(new CommandLocate());
 
         registerKeyBinding("New Waypoint", Keyboard.KEY_B, "Wynntils", true, () -> {
             if (Reference.onWorld)

--- a/src/main/java/com/wynntils/modules/map/commands/CommandLocate.java
+++ b/src/main/java/com/wynntils/modules/map/commands/CommandLocate.java
@@ -1,0 +1,110 @@
+/*
+ *  * Copyright © Wynntils - 2020.
+ */
+
+package com.wynntils.modules.map.commands;
+
+import com.wynntils.core.utils.objects.Location;
+import com.wynntils.webapi.WebManager;
+import com.wynntils.webapi.profiles.MapMarkerProfile;
+import net.minecraft.client.Minecraft;
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.CommandException;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.command.WrongUsageException;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.TextComponentString;
+import net.minecraftforge.client.IClientCommand;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import static net.minecraft.util.text.TextFormatting.GRAY;
+
+public class CommandLocate extends CommandBase implements IClientCommand {
+    Map<String, List<MapMarkerProfile>> mapFeatures = new HashMap<>();
+
+    public CommandLocate() {
+        for (MapMarkerProfile mmp : WebManager.getNonIgnoredApiMarkers()) {
+            registerFeature(mmp);
+        }
+    }
+
+    private String getFeatureKey(MapMarkerProfile mmp) {
+        return mmp.getTranslatedName().replace(" ", "_");
+    }
+
+    private void registerFeature(MapMarkerProfile mmp) {
+        String featureKey = getFeatureKey(mmp);
+        List<MapMarkerProfile> knownProfiles = mapFeatures.get(featureKey);
+        if (knownProfiles == null) {
+            knownProfiles = new LinkedList<>();
+        }
+        knownProfiles.add(mmp);
+        mapFeatures.put(featureKey, knownProfiles);
+    }
+
+    @Override
+    public boolean allowUsageWithoutPrefix(ICommandSender sender, String message) {
+        return false;
+    }
+
+    @Override
+    public String getName() {
+        return "locate";
+    }
+
+    @Override
+    public String getUsage(ICommandSender sender) {
+        return "locate <map feature>";
+    }
+
+    @Override
+    public int getRequiredPermissionLevel() {
+        return 0;
+    }
+
+    @Override
+    public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException {
+        if (args.length == 0) {
+            throw new WrongUsageException("/" + getUsage(sender));
+        }
+
+        List<MapMarkerProfile> knownProfiles = mapFeatures.get(args[0]);
+        if (knownProfiles == null) {
+            throw new WrongUsageException("Unknown map feature: " + args[0]);
+        }
+
+        TreeMap<Double, MapMarkerProfile> distanceToLocations = new TreeMap<>();
+        Location currentLocation = new Location(Minecraft.getMinecraft().player);
+
+        for (MapMarkerProfile mmp : knownProfiles) {
+            Location location = new Location(mmp.getX(), currentLocation.getY(), mmp.getZ());
+            double distance = location.distance(currentLocation);
+            distanceToLocations.put(distance, mmp);
+        }
+
+        int numPrinted = 0;
+        for (Map.Entry<Double, MapMarkerProfile> entry : distanceToLocations.entrySet()) {
+            double distance = entry.getKey();
+            MapMarkerProfile mmp = entry.getValue();
+
+            ITextComponent startingPointMsg = new TextComponentString(mmp.getTranslatedName() + " at [" +
+                    mmp.getX() + ", " + mmp.getZ() + "] (" + (int) distance + " blocks)");
+            startingPointMsg.getStyle().setColor(GRAY);
+            sender.sendMessage(startingPointMsg);
+            numPrinted++;
+            if (numPrinted >= 3) break;
+        }
+    }
+
+    @Override
+    public List<String> getTabCompletions(MinecraftServer server, ICommandSender sender, String[] args, BlockPos targetPos) {
+        return getListOfStringsMatchingLastWord(args, mapFeatures.keySet());
+    }
+}

--- a/src/main/java/com/wynntils/modules/map/configs/MapConfig.java
+++ b/src/main/java/com/wynntils/modules/map/configs/MapConfig.java
@@ -16,9 +16,9 @@ import com.wynntils.modules.map.instances.PathWaypointProfile;
 import com.wynntils.modules.map.instances.WaypointProfile;
 import com.wynntils.modules.map.managers.LootRunManager;
 import com.wynntils.modules.map.overlays.MiniMapOverlay;
-import com.wynntils.modules.map.overlays.objects.MapApiIcon;
 import com.wynntils.modules.map.overlays.objects.MapPathWaypointIcon;
 import com.wynntils.modules.map.overlays.objects.MapWaypointIcon;
+import com.wynntils.webapi.profiles.MapMarkerProfile;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -268,17 +268,10 @@ public class MapConfig extends SettingsClass {
             enabledIcons.put(icon, false);
         }
 
-        // Warn if we are either missing some icons in the options
-        // or have options that do not have an icon
         if (Reference.developmentEnvironment) {
-            for (String icon : MapApiIcon.MAPMARKERNAME_TRANSLATION.values()) {
-                if (MapApiIcon.IGNORED_MARKERS.contains(icon)) continue;
-                if (!enabledIcons.containsKey(icon)) Reference.LOGGER.warn("Missing option for icon \"" + icon + "\"");
-            }
-            for (String icon : enabledIcons.keySet()) {
-                if (MapApiIcon.IGNORED_MARKERS.contains(icon)) continue;
-                if (!MapApiIcon.MAPMARKERNAME_REVERSE_TRANSLATION.containsKey(icon)) Reference.LOGGER.warn("Missing translation for \"" + icon + "\"");
-            }
+            // Warn if we are either missing some icons in the options
+            // or have options that do not have an icon
+            MapMarkerProfile.validateIcons(enabledIcons);
         }
 
         return enabledIcons;

--- a/src/main/java/com/wynntils/webapi/WebManager.java
+++ b/src/main/java/com/wynntils/webapi/WebManager.java
@@ -168,8 +168,8 @@ public class WebManager {
         return mapLabels;
     }
 
-    public static Iterable<MapMarkerProfile> getApiMarkers() {
-        return Iterables.concat(mapMarkers);
+    public static Iterable<MapMarkerProfile> getNonIgnoredApiMarkers() {
+        return Iterables.filter(mapMarkers, o -> !o.isIgnored());
     }
 
     public static UpdateProfile getUpdate() {
@@ -320,9 +320,9 @@ public class WebManager {
         JsonObject main = new JsonParser().parse(IOUtils.toString(st.getInputStream(), StandardCharsets.UTF_8)).getAsJsonObject();
         if (!main.has("message")) {
             main.remove("request");
-    
+
             Type type = new TypeToken<LinkedHashMap<String, ArrayList<String>>>() {}.getType();
-    
+
             return gson.fromJson(main, type);
         } else {
             return new HashMap<>();

--- a/src/main/java/com/wynntils/webapi/profiles/MapMarkerProfile.java
+++ b/src/main/java/com/wynntils/webapi/profiles/MapMarkerProfile.java
@@ -4,9 +4,81 @@
 
 package com.wynntils.webapi.profiles;
 
+import com.wynntils.Reference;
 import com.wynntils.core.utils.StringUtils;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
 public class MapMarkerProfile {
+
+    private static final Map<String, String> MAPMARKERNAME_TRANSLATION = Collections.unmodifiableMap(new HashMap<String, String>() {{
+        put("Content_Dungeon", "Dungeons");
+        put("Content_CorruptedDungeon", "Corrupted Dungeons");
+        put("Content_BossAltar", "Boss Altar");
+        put("Merchant_Accessory", "Accessory Merchant");
+        put("Merchant_Armour", "Armour Merchant");
+        put("Merchant_Dungeon", "Dungeon Merchant");
+        put("Merchant_Horse", "Horse Merchant");
+        put("Merchant_KeyForge", "Key Forge Merchant");
+        put("Merchant_Liquid", "LE Merchant");
+        put("Merchant_Potion", "Potion Merchant");
+        put("Merchant_Powder", "Powder Merchant");
+        put("Merchant_Scroll", "Scroll Merchant");
+        put("Merchant_Seasail", "Seasail Merchant");
+        put("Merchant_Weapon", "Weapon Merchant");
+        put("NPC_Blacksmith", "Blacksmith");
+        put("NPC_GuildMaster", "Guild Master");
+        put("NPC_ItemIdentifier", "Item Identifier");
+        put("NPC_PowderMaster", "Powder Master");
+        put("Special_FastTravel", "Fast Travel");
+        put("tnt", "TNT Merchant");
+        put("painting", "Art Merchant");
+        put("Ore_Refinery", "Ore Refinery");
+        put("Fish_Refinery", "Fish Refinery");
+        put("Wood_Refinery", "Wood Refinery");
+        put("Crop_Refinery", "Crop Refinery");
+        put("NPC_TradeMarket", "Marketplace");
+        put("Content_Quest", "Quests");
+        put("Content_Miniquest", "Mini-Quests");
+        put("Special_Rune", "Runes");
+        put("Special_RootsOfCorruption", "Nether Portal");
+        put("Content_UltimateDiscovery", "Ultimate Discovery");
+        put("Content_Cave", "Caves");
+        put("Content_GrindSpot", "Grind Spots");
+        put("Merchant_Other", "Other Merchants");
+        put("Special_LightRealm", "Light's Secret");
+        put("Merchant_Emerald", "Emerald Merchant");
+        put("Profession_Weaponsmithing", "Weaponsmithing Station");
+        put("Profession_Armouring", "Armouring Station");
+        put("Profession_Alchemism", "Alchemism Station");
+        put("Profession_Jeweling", "Jeweling Station");
+        put("Profession_Tailoring", "Tailoring Station");
+        put("Profession_Scribing", "Scribing Station");
+        put("Profession_Cooking", "Cooking Station");
+        put("Profession_Woodworking", "Woodworking Station");
+        put("Merchant_Tool", "Tool Merchant");
+    }});
+
+    private static final Map<String, String> MAPMARKERNAME_REVERSE_TRANSLATION = Collections.unmodifiableMap(new HashMap<String, String>(MAPMARKERNAME_TRANSLATION.size()) {{
+        for (Entry<String, String> entry : MAPMARKERNAME_TRANSLATION.entrySet()) {
+            this.put(entry.getValue(), entry.getKey());
+        }
+    }});
+
+    private static final Set<String> IGNORED_MARKERS = Collections.unmodifiableSet(new HashSet<String>() {{
+        for (String ignored : new String[]{
+            "Content_CorruptedDungeon"
+        }) {
+            add(ignored);
+            String translated = MAPMARKERNAME_TRANSLATION.get(ignored);
+            assert translated != null;
+            add(translated);
+        }
+    }});
 
     String name;
     int x;
@@ -21,6 +93,10 @@ public class MapMarkerProfile {
         this.z = z;
         this.icon = icon;
         ensureNormalized();
+    }
+
+    public boolean isIgnored() {
+        return IGNORED_MARKERS.contains(this.name);
     }
 
     public String getName() {
@@ -48,4 +124,29 @@ public class MapMarkerProfile {
         icon = icon.replace(".png", "");
     }
 
+    public String getTranslatedName() {
+        return MAPMARKERNAME_TRANSLATION.get(icon);
+    }
+
+    public static String getReverseTranslation(String icon) {
+        String reverse = MAPMARKERNAME_REVERSE_TRANSLATION.getOrDefault(icon, icon);
+        if (!MAPMARKERNAME_TRANSLATION.containsKey(reverse)) {
+            throw new RuntimeException("getReverseTranslation(\"" + icon + "\"): invalid name");
+        }
+        return reverse;
+    }
+
+    /*
+     * Debug function run in developmentEnvironment to verify consistency
+     */
+    public static void validateIcons(HashMap<String, Boolean> enabledIcons) {
+        for (String icon : MAPMARKERNAME_TRANSLATION.values()) {
+            if (IGNORED_MARKERS.contains(icon)) continue;
+            if (!enabledIcons.containsKey(icon)) Reference.LOGGER.warn("Missing option for icon \"" + icon + "\"");
+        }
+        for (String icon : enabledIcons.keySet()) {
+            if (IGNORED_MARKERS.contains(icon)) continue;
+            if (!MAPMARKERNAME_REVERSE_TRANSLATION.containsKey(icon)) Reference.LOGGER.warn("Missing translation for \"" + icon + "\"");
+        }
+    }
 }


### PR DESCRIPTION
Typing "/locate <map feature>" will display the up to three nearest of a specific feature, e.g. Item Identifier.

The available features can be tab completed.

I also refactored how metadata regarding locations names are handled, so they moved from MapApiIcon (which it did not make sense that CommandLocate should access) to MapMarkerProfile.