### PR TITLE
Remove empty "filler" tooltip

### DIFF
--- a/src/main/java/com/wynntils/core/events/custom/GuiOverlapEvent.java
+++ b/src/main/java/com/wynntils/core/events/custom/GuiOverlapEvent.java
@@ -15,6 +15,7 @@ import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.inventory.ClickType;
 import net.minecraft.inventory.Slot;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
 import net.minecraftforge.fml.common.eventhandler.Event;
 
 import java.util.List;
@@ -396,6 +397,7 @@ public class GuiOverlapEvent<T extends Gui> extends Event {
                 return y;
             }
 
+            @Cancelable
             public static class Pre extends HoveredToolTip {
 
                 public Pre(ChestReplacer guiInventory, int x, int y) {

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -542,4 +542,14 @@ public class ClientEvents implements Listener {
         } catch (NoClassDefFoundError e) { /* ignore */ }
     }
 
+    @SubscribeEvent
+    public void clearEmptyTooltip(GuiOverlapEvent.ChestOverlap.HoveredToolTip.Pre e) {
+        if (e.getGui().getSlotUnderMouse() == null || e.getGui().getSlotUnderMouse().getStack().isEmpty()) return;
+
+        ItemStack stack = e.getGui().getSlotUnderMouse().getStack();
+        if (stack.getDisplayName().equals(" ")) {
+            e.setCanceled(true);
+        }
+    }
+
 }


### PR DESCRIPTION
Remove the ugly empty black square tooltip for "filler" items in chest UIs, like the lobby server selection.