### PR TITLE
Automatic translation of chat and NPC messages

### DIFF
--- a/src/main/java/com/wynntils/modules/chat/ChatModule.java
+++ b/src/main/java/com/wynntils/modules/chat/ChatModule.java
@@ -19,6 +19,7 @@ public class ChatModule extends Module {
         module = this;
 
         registerSettings(ChatConfig.class);
+        registerSettings(ChatConfig.ChatTranslation.class);
         registerEvents(new ClientEvents());
 
         TabManager.startTabs();

--- a/src/main/java/com/wynntils/modules/chat/configs/ChatConfig.java
+++ b/src/main/java/com/wynntils/modules/chat/configs/ChatConfig.java
@@ -10,6 +10,7 @@ import com.wynntils.core.framework.settings.instances.SettingsClass;
 import com.wynntils.modules.chat.instances.ChatTab;
 import com.wynntils.modules.chat.managers.ChatManager;
 import com.wynntils.modules.chat.managers.TabManager;
+import com.wynntils.webapi.services.TranslationManager;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -63,7 +64,7 @@ public class ChatConfig extends SettingsClass {
     @Setting(displayName = "Clickable Duel Message", description = "Should the duel message become clickable?")
     public boolean clickableDuelMessage = true;
 
-    @Setting(displayName = "Translate Into Chat", description = "Should the wynnic translator replace the wynnic instead of translating it into a hover?")
+    @Setting(displayName = "Translate Wynnic into Chat", description = "Should the wynnic translator replace the wynnic instead of translating it into a hover?")
     public boolean translateIntoChat = false;
 
     public enum Presets {
@@ -84,6 +85,20 @@ public class ChatConfig extends SettingsClass {
         } else if (name.equals("preset")) {
             TabManager.registerPresets();
         }
+    }
+
+    @SettingsInfo(name = "chat_translation", displayPath = "Chat/Translation")
+    public static class ChatTranslation extends SettingsClass {
+        public static ChatTranslation INSTANCE;
+
+        @Setting(displayName = "Enable Chat Translation", description = "Should chat messages by automatically translated to a foreign language?")
+        public boolean enableChatTranslation = true;
+
+        @Setting(displayName = "Target Language Code", description = "What is the ISO two letter language code of the target language?")
+        public String languageName = "sv";
+
+        @Setting(displayName = "Translation Service", description = "Which translation service should be used?")
+        public TranslationManager.TranslationServices translationService = TranslationManager.TranslationServices.GOOGLEAPI;
     }
 
 }

--- a/src/main/java/com/wynntils/modules/chat/configs/ChatConfig.java
+++ b/src/main/java/com/wynntils/modules/chat/configs/ChatConfig.java
@@ -98,7 +98,15 @@ public class ChatConfig extends SettingsClass {
         public String languageName = "sv";
 
         @Setting(displayName = "Translation Service", description = "Which translation service should be used?")
-        public TranslationManager.TranslationServices translationService = TranslationManager.TranslationServices.GOOGLEAPI;
+        public TranslationManager.TranslationServices translationService = TranslationManager.TranslationServices.PIGLATIN;
+
+        @Override
+        public void onSettingChanged(String name) {
+            if (name.equals("translationService")) {
+                ChatManager.translator = null;
+            }
+        }
+
     }
 
 }

--- a/src/main/java/com/wynntils/modules/chat/configs/ChatConfig.java
+++ b/src/main/java/com/wynntils/modules/chat/configs/ChatConfig.java
@@ -92,16 +92,16 @@ public class ChatConfig extends SettingsClass {
         public static ChatTranslation INSTANCE;
 
         @Setting(displayName = "Enable Text Translation", description = "Should text messages be automatically translated to a foreign language?")
-        public boolean enableTextTranslation = true;
+        public boolean enableTextTranslation = false;
 
         @Setting(displayName = "Translate Chat and Shout", description = "Should messages sent by other users be translated?")
-        public boolean translateChatShout = true;
+        public boolean translateChatShout = false;
 
         @Setting(displayName = "Translate NPC Lines", description = "Should messages spoken by NPCs be translated?")
         public boolean translateNpc = true;
 
         @Setting(displayName = "Translate Other", description = "Should other messages, like system information, be translated?")
-        public boolean translateOther = true;
+        public boolean translateOther = false;
 
         @Setting(displayName = "Target Language Code", description = "What is the ISO two letter language code of the target language?")
         public String languageName = "en";

--- a/src/main/java/com/wynntils/modules/chat/configs/ChatConfig.java
+++ b/src/main/java/com/wynntils/modules/chat/configs/ChatConfig.java
@@ -94,8 +94,8 @@ public class ChatConfig extends SettingsClass {
         @Setting(displayName = "Enable Text Translation", description = "Should text messages be automatically translated to a foreign language?")
         public boolean enableTextTranslation = false;
 
-        @Setting(displayName = "Translate Chat and Shout", description = "Should messages sent by other users be translated?")
-        public boolean translateChatShout = false;
+        @Setting(displayName = "Translate Player Chat", description = "Should messages sent by other users be translated?")
+        public boolean translatePlayerChat = false;
 
         @Setting(displayName = "Translate NPC Lines", description = "Should messages spoken by NPCs be translated?")
         public boolean translateNpc = true;

--- a/src/main/java/com/wynntils/modules/chat/configs/ChatConfig.java
+++ b/src/main/java/com/wynntils/modules/chat/configs/ChatConfig.java
@@ -91,19 +91,30 @@ public class ChatConfig extends SettingsClass {
     public static class ChatTranslation extends SettingsClass {
         public static ChatTranslation INSTANCE;
 
-        @Setting(displayName = "Enable Chat Translation", description = "Should chat messages by automatically translated to a foreign language?")
-        public boolean enableChatTranslation = true;
+        @Setting(displayName = "Enable Text Translation", description = "Should text messages be automatically translated to a foreign language?")
+        public boolean enableTextTranslation = true;
+
+        @Setting(displayName = "Translate Chat and Shout", description = "Should messages sent by other users be translated?")
+        public boolean translateChatShout = true;
+
+        @Setting(displayName = "Translate NPC Lines", description = "Should messages spoken by NPCs be translated?")
+        public boolean translateNpc = true;
+
+        @Setting(displayName = "Translate Other", description = "Should other messages, like system information, be translated?")
+        public boolean translateOther = true;
 
         @Setting(displayName = "Target Language Code", description = "What is the ISO two letter language code of the target language?")
-        public String languageName = "sv";
+        public String languageName = "en";
 
         @Setting(displayName = "Translation Service", description = "Which translation service should be used?")
-        public TranslationManager.TranslationServices translationService = TranslationManager.TranslationServices.PIGLATIN;
+        public TranslationManager.TranslationServices translationService = TranslationManager.TranslationServices.GOOGLEAPI;
 
         @Override
         public void onSettingChanged(String name) {
             if (name.equals("translationService")) {
                 ChatManager.translator = null;
+            } else if (name.startsWith("translate")) {
+                ChatManager.translationPattern = null;
             }
         }
 

--- a/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
+++ b/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
@@ -392,8 +392,10 @@ public class ChatManager {
     }
 
     private static Pattern createTranslationPattern() {
-        String chatPrefix = "(?:§8\\[[0-9]{1,3}/[A-Z][a-z](?:/[A-Za-z]+)?\\] §r§7\\[[^]]+\\] [^:]*: §r§7)";
+        String localChatPrefix = "(?:§8\\[[0-9]{1,3}/[A-Z][a-z](?:/[A-Za-z]+)?\\] §r§7\\[[^]]+\\] [^:]*: §r§7)";
         String shoutPrefix = "(?:§3.* \\[[^]]+\\] shouts: §r§b)";
+        String partyPrefix = "(?:§7\\[§r§e.*§r§7\\] §r§f)";
+        String privatePrefix = "(?:§7\\[§r.*§r§6 ➤ §r§2.*§r§7\\] §r§f)";
         String npcPrefix = "(?:§7\\[[0-9]+/[0-9]+\\] §r§2[^:]*: §r§a)";
         String interactPrefix = "(?:§5[^:]*: §r§d)";
         String infoPrefix = "(?:§[0-9a-z])";
@@ -401,8 +403,8 @@ public class ChatManager {
         int components = 0;
         StringBuilder builder = new StringBuilder();
         builder.append("^(");
-        if (ChatConfig.ChatTranslation.INSTANCE.translateChatShout) {
-            builder.append(chatPrefix + "|" + shoutPrefix);
+        if (ChatConfig.ChatTranslation.INSTANCE.translatePlayerChat) {
+            builder.append(localChatPrefix + "|" + shoutPrefix + "|" + partyPrefix + "|" + privatePrefix);
             components++;
         }
         if (ChatConfig.ChatTranslation.INSTANCE.translateNpc) {

--- a/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
+++ b/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
@@ -8,6 +8,10 @@ import com.wynntils.ModCore;
 import com.wynntils.core.utils.StringUtils;
 import com.wynntils.core.utils.objects.Pair;
 import com.wynntils.modules.chat.configs.ChatConfig;
+import com.wynntils.modules.chat.overlays.ChatOverlay;
+import com.wynntils.webapi.services.TranslationManager;
+import com.wynntils.webapi.services.TranslationManager.TranslationServices;
+import com.wynntils.webapi.services.TranslationService;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.audio.PositionedSoundRecord;
 import net.minecraft.init.SoundEvents;
@@ -32,6 +36,8 @@ public class ChatManager {
 
     public static DateFormat dateFormat;
     public static boolean validDateFormat;
+
+    private static TranslationService translator = TranslationManager.getService(TranslationServices.GOOGLEAPI);
 
     private static final SoundEvent popOffSound = new SoundEvent(new ResourceLocation("minecraft", "entity.blaze.hurt"));
 
@@ -90,6 +96,13 @@ public class ChatManager {
         // popup sound
         if (in.getUnformattedText().contains(" requires your ") && in.getUnformattedText().contains(" skill to be at least "))
             ModCore.mc().player.playSound(popOffSound, 1f, 1f);
+
+        if (!in.getUnformattedText().startsWith("[TR]")) {
+            translator.translate(in.getUnformattedText(), "sv", translatedMsg -> {
+                Minecraft.getMinecraft().addScheduledTask(() ->
+                        ChatOverlay.getChat().printChatMessage(new TextComponentString("[TR] [" + translatedMsg + "]")));
+            });
+        }
 
         // wynnic translator
         if (StringUtils.hasWynnic(in.getUnformattedText())) {

--- a/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
+++ b/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
@@ -37,7 +37,7 @@ public class ChatManager {
     public static DateFormat dateFormat;
     public static boolean validDateFormat;
 
-    private static TranslationService translator = TranslationManager.getService(TranslationServices.GOOGLEAPI);
+   private static TranslationService translator = null;
 
     private static final SoundEvent popOffSound = new SoundEvent(new ResourceLocation("minecraft", "entity.blaze.hurt"));
 
@@ -97,11 +97,17 @@ public class ChatManager {
         if (in.getUnformattedText().contains(" requires your ") && in.getUnformattedText().contains(" skill to be at least "))
             ModCore.mc().player.playSound(popOffSound, 1f, 1f);
 
-        if (!in.getUnformattedText().startsWith("[TR]")) {
-            translator.translate(in.getUnformattedText(), "sv", translatedMsg -> {
-                Minecraft.getMinecraft().addScheduledTask(() ->
-                        ChatOverlay.getChat().printChatMessage(new TextComponentString("[TR] [" + translatedMsg + "]")));
-            });
+        // language translation
+        if (ChatConfig.ChatTranslation.INSTANCE.enableChatTranslation) {
+            if (translator == null) {
+                translator = TranslationManager.getService(ChatConfig.ChatTranslation.INSTANCE.translationService);
+            }
+            if (!in.getUnformattedText().startsWith("[TR]")) {
+                translator.translate(in.getUnformattedText(), ChatConfig.ChatTranslation.INSTANCE.languageName, translatedMsg -> {
+                    Minecraft.getMinecraft().addScheduledTask(() ->
+                            ChatOverlay.getChat().printChatMessage(new TextComponentString("[TR] [" + translatedMsg + "]")));
+                });
+            }
         }
 
         // wynnic translator

--- a/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
+++ b/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
@@ -379,6 +379,7 @@ public class ChatManager {
             String formatted = in.getFormattedText();
             Matcher m = translationPattern.matcher(formatted);
             if (m.find()) {
+                // We only want to translate the actual message, not formatting, sender, etc.
                 String message = TextFormatting.getTextWithoutFormattingCodes(m.group(2));
                 String prefix = m.group(1);
                 String suffix = m.group(3);

--- a/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
+++ b/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
@@ -33,6 +33,8 @@ import java.util.regex.Pattern;
 
 public class ChatManager {
 
+    private static final String TRANSLATED_PREFIX = TextFormatting.GRAY + "➢" + TextFormatting.RESET;
+
     public static DateFormat dateFormat;
     public static boolean validDateFormat;
     public static TranslationService translator = null;
@@ -366,14 +368,14 @@ public class ChatManager {
     }
 
     private static void translateMessage(ITextComponent in) {
+        // These might not have been created yet, or reset by ChatConfig changing
         if (translator == null) {
             translator = TranslationManager.getService(ChatConfig.ChatTranslation.INSTANCE.translationService);
         }
         if (translationPattern == null) {
             translationPattern = createTranslationPattern();
         }
-        String translatedPrefix = TextFormatting.GRAY + "➢" + TextFormatting.RESET;
-        if (!in.getUnformattedText().startsWith(translatedPrefix)) {
+        if (!in.getUnformattedText().startsWith(TRANSLATED_PREFIX)) {
             String formatted = in.getFormattedText();
             Matcher m = translationPattern.matcher(formatted);
             if (m.find()) {
@@ -382,7 +384,7 @@ public class ChatManager {
                 String suffix = m.group(3);
                 translator.translate(message, ChatConfig.ChatTranslation.INSTANCE.languageName, translatedMsg -> {
                     Minecraft.getMinecraft().addScheduledTask(() ->
-                            ChatOverlay.getChat().printChatMessage(new TextComponentString(translatedPrefix + prefix + translatedMsg + suffix)));
+                            ChatOverlay.getChat().printChatMessage(new TextComponentString(TRANSLATED_PREFIX + prefix + translatedMsg + suffix)));
                 });
             }
         }

--- a/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
+++ b/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
@@ -36,8 +36,7 @@ public class ChatManager {
 
     public static DateFormat dateFormat;
     public static boolean validDateFormat;
-
-   private static TranslationService translator = null;
+    public static TranslationService translator = null;
 
     private static final SoundEvent popOffSound = new SoundEvent(new ResourceLocation("minecraft", "entity.blaze.hurt"));
 

--- a/src/main/java/com/wynntils/webapi/services/GoogleApiTranslationService.java
+++ b/src/main/java/com/wynntils/webapi/services/GoogleApiTranslationService.java
@@ -1,0 +1,39 @@
+package com.wynntils.webapi.services;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.wynntils.webapi.request.Request;
+import com.wynntils.webapi.request.RequestHandler;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+public class GoogleApiTranslationService implements TranslationService {
+    private static AtomicInteger requestNumber = new AtomicInteger();
+
+    @Override
+    public void translate(String message, String toLanguage, Consumer<String> handleTranslation) {
+        try {
+            String encodedMessage = URLEncoder.encode(message, "UTF-8");
+            String url = "https://translate.googleapis.com/translate_a/single?client=gtx&sl=en&tl=" + toLanguage +
+                    "&dt=t&q=" + encodedMessage;
+
+            RequestHandler handler = new RequestHandler();
+            handler.addAndDispatch(new Request(url, "translate-" + requestNumber.getAndIncrement())
+                    .handleJsonArray(json -> {
+                        StringBuilder builder = new StringBuilder();
+                        JsonArray array = json.get(0).getAsJsonArray();
+                        for (JsonElement elem : array) {
+                            String part = elem.getAsJsonArray().get(0).getAsString();
+                            builder.append(part);
+                        }
+                        handleTranslation.accept(builder.toString());
+                        return true;
+                    }), true);
+        } catch (UnsupportedEncodingException e) {
+            // ignore; cannot happen
+        }
+    }
+}

--- a/src/main/java/com/wynntils/webapi/services/GoogleApiTranslationService.java
+++ b/src/main/java/com/wynntils/webapi/services/GoogleApiTranslationService.java
@@ -10,6 +10,11 @@ import java.net.URLEncoder;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
+/**
+ * A TranslationService that uses the free googleapi translation API. This service is free but is severly
+ * restricted. There is a rate limit of about 100 messages per hour and IP address. This is typically
+ * sufficient for NPCs translation, but not for general chat messages, at least not in chatty areas like Detlas.
+ */
 public class GoogleApiTranslationService implements TranslationService {
     private static AtomicInteger requestNumber = new AtomicInteger();
 

--- a/src/main/java/com/wynntils/webapi/services/TranslationManager.java
+++ b/src/main/java/com/wynntils/webapi/services/TranslationManager.java
@@ -1,0 +1,42 @@
+package com.wynntils.webapi.services;
+
+import java.lang.reflect.Constructor;
+import java.util.function.Consumer;
+
+public class TranslationManager {
+    /**
+     * Get a TranslationService.
+     *
+     * @param service An enum describing which translation service is requested.
+     * @return An instance of the selected translation service, or the dummy (no-op) translation
+     * service if no matching service can be created.
+     */
+    public static TranslationService getService(TranslationServices service) {
+        try {
+            Constructor<? extends TranslationService> ctor = service.serviceClass.getConstructor();
+            return ctor.newInstance();
+        } catch (ReflectiveOperationException e) {
+            e.printStackTrace();
+        }
+
+        return new DummyTranslationService();
+    }
+
+    public enum TranslationServices {
+        DUMMY(DummyTranslationService.class),
+        GOOGLEAPI(GoogleApiTranslationService.class);
+
+        private Class<? extends TranslationService> serviceClass;
+
+        TranslationServices(Class<? extends TranslationService> serviceClass) {
+            this.serviceClass = serviceClass;
+        }
+    }
+
+    public static class DummyTranslationService implements TranslationService {
+        @Override
+        public void translate(String message, String toLanguage, Consumer<String> handleTranslation) {
+            handleTranslation.accept(message);
+        }
+    }
+}

--- a/src/main/java/com/wynntils/webapi/services/TranslationManager.java
+++ b/src/main/java/com/wynntils/webapi/services/TranslationManager.java
@@ -52,7 +52,9 @@ public class TranslationManager {
                     latinString.append(word.substring(1)).append(word.charAt(0)).append("ay ");
                 }
             }
-            handleTranslation.accept(latinString.toString());
+            Thread thread = new Thread(() ->
+                    handleTranslation.accept(latinString.toString()));
+            thread.start();
         }
     }
 }

--- a/src/main/java/com/wynntils/webapi/services/TranslationManager.java
+++ b/src/main/java/com/wynntils/webapi/services/TranslationManager.java
@@ -8,8 +8,7 @@ public class TranslationManager {
      * Get a TranslationService.
      *
      * @param service An enum describing which translation service is requested.
-     * @return An instance of the selected translation service, or the dummy (no-op) translation
-     * service if no matching service can be created.
+     * @return An instance of the selected translation service, or null on failure
      */
     public static TranslationService getService(TranslationServices service) {
         try {
@@ -33,6 +32,10 @@ public class TranslationManager {
         }
     }
 
+    /**
+     * A demo "translation" service that ignores the selected language, and always translates
+     * to "pig latin". Use for test purposes, or for hours of enjoyment for the simple-minded. ;-)
+     */
     public static class PigLatinTranslationService implements TranslationService {
         @Override
         public void translate(String message, String toLanguage, Consumer<String> handleTranslation) {

--- a/src/main/java/com/wynntils/webapi/services/TranslationManager.java
+++ b/src/main/java/com/wynntils/webapi/services/TranslationManager.java
@@ -19,11 +19,10 @@ public class TranslationManager {
             e.printStackTrace();
         }
 
-        return new DummyTranslationService();
+        return null;
     }
 
     public enum TranslationServices {
-        DUMMY(DummyTranslationService.class),
         GOOGLEAPI(GoogleApiTranslationService.class),
         PIGLATIN(PigLatinTranslationService.class);
 
@@ -31,13 +30,6 @@ public class TranslationManager {
 
         TranslationServices(Class<? extends TranslationService> serviceClass) {
             this.serviceClass = serviceClass;
-        }
-    }
-
-    public static class DummyTranslationService implements TranslationService {
-        @Override
-        public void translate(String message, String toLanguage, Consumer<String> handleTranslation) {
-            handleTranslation.accept(message);
         }
     }
 

--- a/src/main/java/com/wynntils/webapi/services/TranslationManager.java
+++ b/src/main/java/com/wynntils/webapi/services/TranslationManager.java
@@ -24,7 +24,8 @@ public class TranslationManager {
 
     public enum TranslationServices {
         DUMMY(DummyTranslationService.class),
-        GOOGLEAPI(GoogleApiTranslationService.class);
+        GOOGLEAPI(GoogleApiTranslationService.class),
+        PIGLATIN(PigLatinTranslationService.class);
 
         private Class<? extends TranslationService> serviceClass;
 
@@ -37,6 +38,21 @@ public class TranslationManager {
         @Override
         public void translate(String message, String toLanguage, Consumer<String> handleTranslation) {
             handleTranslation.accept(message);
+        }
+    }
+
+    public static class PigLatinTranslationService implements TranslationService {
+        @Override
+        public void translate(String message, String toLanguage, Consumer<String> handleTranslation) {
+            StringBuilder latinString = new StringBuilder();
+            for (String word : message.split("\\s")) {
+                if ("AEIOUaeiou".indexOf(word.charAt(0)) != -1) {
+                    latinString.append(word).append("ay ");
+                } else {
+                    latinString.append(word.substring(1)).append(word.charAt(0)).append("ay ");
+                }
+            }
+            handleTranslation.accept(latinString.toString());
         }
     }
 }

--- a/src/main/java/com/wynntils/webapi/services/TranslationService.java
+++ b/src/main/java/com/wynntils/webapi/services/TranslationService.java
@@ -1,0 +1,17 @@
+package com.wynntils.webapi.services;
+
+import java.util.function.Consumer;
+
+public interface TranslationService {
+
+    /**
+     * Translate a message from English to the target language, as described by a two-letter 639-1
+     * language code. The response can be executed asynchronously. The message can contain html,
+     * but no Minecraft formatting.
+     *
+     * @param message           The message to translate.
+     * @param toLanguage        The target language code
+     * @param handleTranslation Handler for the translation. The argument is the translated string.
+     */
+    void translate(String message, String toLanguage, Consumer<String> handleTranslation);
+}


### PR DESCRIPTION
I created this for my kids :-) but hopefully it can be useful to others as well. By using online real-time translation services, chat messages can be automatically translated. The free service included is rate limited but works well for quests. The API is pluggable and paid translations services can easily be included. 

Translations are added as a copy of the original message, since if the translation was poor, it might be needed to check the original (e.g. for Wynncraft names, items etc).