### PR TITLE
Improved Powder Manual

### DIFF
--- a/src/main/java/com/wynntils/core/framework/enums/PowderManualChapter.java
+++ b/src/main/java/com/wynntils/core/framework/enums/PowderManualChapter.java
@@ -1,0 +1,46 @@
+package com.wynntils.core.framework.enums;
+
+import net.minecraft.util.StringUtils;
+
+public enum PowderManualChapter {
+    
+    ONE("                     §6Chapter 1 - The Basics\n\n" +
+                "    §7§oThere exist five varieties of magic powder, each corresponding to one of five different elements; §c✹ Fire§7§o, §b❉ Water§7§o, §e✦ Thunder§7§o, §2✤ Earth§7§o, and §f❋ Air§7§o.\n" +
+                "    §7§oIt is possible to augment items with these powders, if one is versed in the art of enchantment. Many offer this service for a price, as Powder Masters.\n" +
+                "    §7§oCertain items have a higher magical capacity, and thusly are able to hold more powders within them. Some have many, some have few, others still have none.\n" +
+                "    §7§oShould a §lweapon§r§7§o be enchanted with a powder, the powder will imbue the item with a slight amount of elemental damage, but also transfer basic neutral damage into its element.\n" +
+                "    §7§oShould a piece of §larmour§r§7§o be enchanted with a powder, the garment will gain a resistance towards that powder's element, at the cost of an elemental weakness."),
+    TWO("                  §6Chapter 2 - Elemental Abilities\n\n" +
+                "    §7§oIf a powder is more concentrated, they can unlock powerful elemental magicks within an item. Powders appraised to be Tier IV or higher are capable of forming these special abilities.\n" +
+                "    §7§oTwo or more like-elemented powders are necessary for this. While items can be augmented with powders even after unlocking an ability, only one amplified magic power can be kept within an item at one time.\n" +
+                "    §7§oWeapons and armour channel this magical energy in radically different ways, just as powders change their more mundane abilities. The method of use for each piece can be referred to in Chapter 3.\n" +
+                "    §7§oUsing different tiers of powder to try to form an ability on an item is somewhat unpredictable in the end potency of the magic, but using higher tiers of powder will generally lead to a stronger effect.\n" +
+                "    §7§oTo unleash the unique ability imbued in your weapon, one must first charge the power by attacking enemies. Then, heavily focus on the latent energies within the item, and release them with a swing. §r(Shift+Left-Click)"),
+    THREE("                  §6Chapter 3 - Elemental Abilities\n\n" +
+                "    §2§l✤ Earth:  §7§oEarth-imbued weapons will unleash a powerful quake, rupturing the nearby ground and disorienting enemies. Earth-augmented armors produce a rage-state in the user as they near death, turning Earth-based attacks more potent, and more violent.\n" +
+                "    §e§l✦ Thunder:  §7§oThunder-imbued weapons can release a streak of lightning that seeks enemies, bouncing from one foe to the next nearby. Thunder-augmented armors will steal the life force of the slain, and in kind increase the power of Thunder-based attacks temporarily.\n" +
+                "    §b§l❉ Water:  §7§oWater-imbued weapons will curse one's nearby enemies. This curse weakens armor, and turns them vulnerable to further attack. Water-augmented armors recycle used mana, transferring it into a short boost to Water-affiliated techniques, depending on how much mana was consumed.\n" +
+                "    §c§l✹ Fire:  §7§oFire-imbued weapons will generate a fan of flames that burn one's enemies and empower one's allies. Fire-augmented armors react to being struck, turning the impact of the blow, no matter how weak, into a temporary power boost to Fire-based attacks.\n" +
+                "    §f§l❋ Air:  §7§oAir-imbued weapons trap nearby enemies in a vortex of wind, and blow the victims away when struck. Air-augmented armors will, so long as they are kept close, leach energy from nearby foes to improve the strength of Air-based attacks.");
+    
+    String chapterText;
+    
+    PowderManualChapter(String text) {
+        chapterText = text;
+    }
+    
+    public String getText() {
+        return chapterText;
+    }
+    
+    public static boolean isPowderManualLine(String line) {
+        PowderManualChapter[] chapters = PowderManualChapter.values();
+        for (PowderManualChapter chapter : chapters) {
+            if (StringUtils.stripControlCodes(chapter.getText()).contains(line)) return true;
+        }
+        
+        return false;
+        
+    }
+
+}

--- a/src/main/java/com/wynntils/core/framework/enums/PowderManualChapter.java
+++ b/src/main/java/com/wynntils/core/framework/enums/PowderManualChapter.java
@@ -40,7 +40,6 @@ public enum PowderManualChapter {
         }
         
         return false;
-        
     }
 
 }

--- a/src/main/java/com/wynntils/modules/chat/configs/ChatConfig.java
+++ b/src/main/java/com/wynntils/modules/chat/configs/ChatConfig.java
@@ -42,6 +42,9 @@ public class ChatConfig extends SettingsClass {
 
     @Setting(displayName = "Filter Territory Enter", description = "Should territory enter messages be displayed in chat?\n\n§8Territory enter messages look like §7[You are now entering Detlas]§8.")
     public boolean filterTerritoryEnter = true;
+    
+    @Setting(displayName = "Improved Powder Manual", description = "Should the powder manual be replaced with a custom, sleeker menu?")
+    public boolean customPowderManual = true;
 
     @Setting(displayName = "Show Held Item Chat Message", description = "Should the details of your compass and soul points be shown in chat whilst you are holding them?")
     public boolean heldItemChat = true;

--- a/src/main/java/com/wynntils/modules/chat/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/chat/events/ClientEvents.java
@@ -4,10 +4,9 @@
 
 package com.wynntils.modules.chat.events;
 
-import java.util.List;
-
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.WynncraftServerEvent;
+import com.wynntils.core.framework.enums.PowderManualChapter;
 import com.wynntils.core.framework.interfaces.Listener;
 import com.wynntils.core.utils.objects.Pair;
 import com.wynntils.core.utils.reflections.ReflectionFields;
@@ -26,31 +25,8 @@ import net.minecraftforge.client.event.GuiOpenEvent;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
-import scala.actors.threadpool.Arrays;
 
 public class ClientEvents implements Listener {
-    
-    @SuppressWarnings("unchecked")
-    private static final List<String> POWDER_MANUAL_LINES = Arrays.asList(new String[] {
-            "                     Chapter 1 - The Basics",
-            "    There exist five varieties of magic powder, each corresponding to one of five different elements; ✹ Fire, ❉ Water, ✦ Thunder, ✤ Earth, and ❋ Air.",
-            "    It is possible to augment items with these powders, if one is versed in the art of enchantment. Many offer this service for a price, as Powder Masters.",
-            "    Certain items have a higher magical capacity, and thusly are able to hold more powders within them. Some have many, some have few, others still have none.",
-            "    Should a weapon be enchanted with a powder, the powder will imbue the item with a slight amount of elemental damage, but also transfer basic neutral damage into its element.",
-            "    Should a piece of armour be enchanted with a powder, the garment will gain a resistance towards that powder's element, at the cost of an elemental weakness.",
-            "                  Chapter 2 - Elemental Abilities",
-            "    If a powder is more concentrated, they can unlock powerful elemental magicks within an item. Powders appraised to be Tier IV or higher are capable of forming these special abilities.",
-            "    Two or more like-elemented powders are necessary for this. While items can be augmented with powders even after unlocking an ability, only one amplified magic power can be kept within an item at one time.",
-            "    Weapons and armour channel this magical energy in radically different ways, just as powders change their more mundane abilities. The method of use for each piece can be referred to in Chapter 3.",
-            "    Using different tiers of powder to try to form an ability on an item is somewhat unpredictable in the end potency of the magic, but using higher tiers of powder will generally lead to a stronger effect.",
-            "    To unleash the unique ability imbued in your weapon, one must first charge the power by attacking enemies. Then, heavily focus on the latent energies within the item, and release them with a swing. (Shift+Left-Click)",
-            "                  Chapter 3 - Elemental Abilities",
-            "    ✤ Earth:  Earth-imbued weapons will unleash a powerful quake, rupturing the nearby ground and disorienting enemies. Earth-augmented armors produce a rage-state in the user as they near death, turning Earth-based attacks more potent, and more violent.",
-            "    ✦ Thunder:  Thunder-imbued weapons can release a streak of lightning that seeks enemies, bouncing from one foe to the next nearby. Thunder-augmented armors will steal the life force of the slain, and in kind increase the power of Thunder-based attacks temporarily.",
-            "    ❉ Water:  Water-imbued weapons will curse one's nearby enemies. This curse weakens armor, and turns them vulnerable to further attack. Water-augmented armors recycle used mana, transferring it into a short boost to Water-affiliated techniques, depending on how much mana was consumed.",
-            "    ✹ Fire:  Fire-imbued weapons will generate a fan of flames that burn one's enemies and empower one's allies. Fire-augmented armors react to being struck, turning the impact of the blow, no matter how weak, into a temporary power boost to Fire-based attacks.",
-            "    ❋ Air:  Air-imbued weapons trap nearby enemies in a vortex of wind, and blow the victims away when struck. Air-augmented armors will, so long as they are kept close, leach energy from nearby foes to improve the strength of Air-based attacks."
-    });
     
     private boolean ignoreNextBlank = false;
 
@@ -70,7 +46,7 @@ public class ClientEvents implements Listener {
             e.setCanceled(true);
         } else if (e.getMessage().getFormattedText().startsWith(TextFormatting.GRAY + "[You are now entering") && ChatConfig.INSTANCE.filterTerritoryEnter) {
             e.setCanceled(true);
-        } else if (POWDER_MANUAL_LINES.contains(e.getMessage().getUnformattedText()) && ChatConfig.INSTANCE.customPowderManual) {
+        } else if (PowderManualChapter.isPowderManualLine(e.getMessage().getUnformattedText()) && ChatConfig.INSTANCE.customPowderManual) {
             e.setCanceled(true);
         } else if (e.getMessage().getUnformattedText().equals("                         Powder Manual") && ChatConfig.INSTANCE.customPowderManual) {
             ignoreNextBlank = true;

--- a/src/main/java/com/wynntils/modules/chat/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/chat/events/ClientEvents.java
@@ -4,6 +4,8 @@
 
 package com.wynntils.modules.chat.events;
 
+import java.util.List;
+
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.WynncraftServerEvent;
 import com.wynntils.core.framework.interfaces.Listener;
@@ -24,8 +26,33 @@ import net.minecraftforge.client.event.GuiOpenEvent;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
+import scala.actors.threadpool.Arrays;
 
 public class ClientEvents implements Listener {
+    
+    @SuppressWarnings("unchecked")
+    private static final List<String> POWDER_MANUAL_LINES = Arrays.asList(new String[] {
+            "                     Chapter 1 - The Basics",
+            "    There exist five varieties of magic powder, each corresponding to one of five different elements; ✹ Fire, ❉ Water, ✦ Thunder, ✤ Earth, and ❋ Air.",
+            "    It is possible to augment items with these powders, if one is versed in the art of enchantment. Many offer this service for a price, as Powder Masters.",
+            "    Certain items have a higher magical capacity, and thusly are able to hold more powders within them. Some have many, some have few, others still have none.",
+            "    Should a weapon be enchanted with a powder, the powder will imbue the item with a slight amount of elemental damage, but also transfer basic neutral damage into its element.",
+            "    Should a piece of armour be enchanted with a powder, the garment will gain a resistance towards that powder's element, at the cost of an elemental weakness.",
+            "                  Chapter 2 - Elemental Abilities",
+            "    If a powder is more concentrated, they can unlock powerful elemental magicks within an item. Powders appraised to be Tier IV or higher are capable of forming these special abilities.",
+            "    Two or more like-elemented powders are necessary for this. While items can be augmented with powders even after unlocking an ability, only one amplified magic power can be kept within an item at one time.",
+            "    Weapons and armour channel this magical energy in radically different ways, just as powders change their more mundane abilities. The method of use for each piece can be referred to in Chapter 3.",
+            "    Using different tiers of powder to try to form an ability on an item is somewhat unpredictable in the end potency of the magic, but using higher tiers of powder will generally lead to a stronger effect.",
+            "    To unleash the unique ability imbued in your weapon, one must first charge the power by attacking enemies. Then, heavily focus on the latent energies within the item, and release them with a swing. (Shift+Left-Click)",
+            "                  Chapter 3 - Elemental Abilities",
+            "    ✤ Earth:  Earth-imbued weapons will unleash a powerful quake, rupturing the nearby ground and disorienting enemies. Earth-augmented armors produce a rage-state in the user as they near death, turning Earth-based attacks more potent, and more violent.",
+            "    ✦ Thunder:  Thunder-imbued weapons can release a streak of lightning that seeks enemies, bouncing from one foe to the next nearby. Thunder-augmented armors will steal the life force of the slain, and in kind increase the power of Thunder-based attacks temporarily.",
+            "    ❉ Water:  Water-imbued weapons will curse one's nearby enemies. This curse weakens armor, and turns them vulnerable to further attack. Water-augmented armors recycle used mana, transferring it into a short boost to Water-affiliated techniques, depending on how much mana was consumed.",
+            "    ✹ Fire:  Fire-imbued weapons will generate a fan of flames that burn one's enemies and empower one's allies. Fire-augmented armors react to being struck, turning the impact of the blow, no matter how weak, into a temporary power boost to Fire-based attacks.",
+            "    ❋ Air:  Air-imbued weapons trap nearby enemies in a vortex of wind, and blow the victims away when struck. Air-augmented armors will, so long as they are kept close, leach energy from nearby foes to improve the strength of Air-based attacks."
+    });
+    
+    private boolean ignoreNextBlank = false;
 
     @SubscribeEvent
     public void onGuiOpen(GuiOpenEvent e) {
@@ -43,6 +70,13 @@ public class ClientEvents implements Listener {
             e.setCanceled(true);
         } else if (e.getMessage().getFormattedText().startsWith(TextFormatting.GRAY + "[You are now entering") && ChatConfig.INSTANCE.filterTerritoryEnter) {
             e.setCanceled(true);
+        } else if (POWDER_MANUAL_LINES.contains(e.getMessage().getUnformattedText()) && ChatConfig.INSTANCE.customPowderManual) {
+            e.setCanceled(true);
+        } else if (e.getMessage().getUnformattedText().equals("                         Powder Manual") && ChatConfig.INSTANCE.customPowderManual) {
+            ignoreNextBlank = true;
+        } else if (e.getMessage().getUnformattedText().isEmpty() && ignoreNextBlank) {
+            e.setCanceled(true);
+            ignoreNextBlank = false;
         }
     }
 

--- a/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
+++ b/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
@@ -5,6 +5,7 @@
 package com.wynntils.modules.chat.managers;
 
 import com.wynntils.ModCore;
+import com.wynntils.core.framework.enums.PowderManualChapter;
 import com.wynntils.core.utils.StringUtils;
 import com.wynntils.core.utils.helpers.TextAction;
 import com.wynntils.core.utils.objects.Pair;
@@ -711,47 +712,25 @@ public class ChatManager {
     
     private static class ChapterReader implements Runnable {
         
-        private static final String CHAPTER_1 = "                     §6Chapter 1 - The Basics\n\n" +
-                "    §7§oThere exist five varieties of magic powder, each corresponding to one of five different elements; §c✹ Fire§7§o, §b❉ Water§7§o, §e✦ Thunder§7§o, §2✤ Earth§7§o, and §f❋ Air§7§o.\n" +
-                "    §7§oIt is possible to augment items with these powders, if one is versed in the art of enchantment. Many offer this service for a price, as Powder Masters.\n" +
-                "    Certain items have a higher magical capacity, and thusly are able to hold more powders within them. Some have many, some have few, others still have none.\n" +
-                "    Should a §lweapon§r§7§o be enchanted with a powder, the powder will imbue the item with a slight amount of elemental damage, but also transfer basic neutral damage into its element.\n" +
-                "    Should a piece of §larmour§r§7§o be enchanted with a powder, the garment will gain a resistance towards that powder's element, at the cost of an elemental weakness.";
-        
-        private static final String CHAPTER_2 = "                  §6Chapter 2 - Elemental Abilities\n\n" +
-                "    §7§oIf a powder is more concentrated, they can unlock powerful elemental magicks within an item. Powders appraised to be Tier IV or higher are capable of forming these special abilities.\n" +
-                "    Two or more like-elemented powders are necessary for this. While items can be augmented with powders even after unlocking an ability, only one amplified magic power can be kept within an item at one time.\n" +
-                "    Weapons and armour channel this magical energy in radically different ways, just as powders change their more mundane abilities. The method of use for each piece can be referred to in Chapter 3.\n" +
-                "    Using different tiers of powder to try to form an ability on an item is somewhat unpredictable in the end potency of the magic, but using higher tiers of powder will generally lead to a stronger effect.\n" +
-                "    To unleash the unique ability imbued in your weapon, one must first charge the power by attacking enemies. Then, heavily focus on the latent energies within the item, and release them with a swing. §r(Shift+Left-Click)";
-        
-        private static final String CHAPTER_3 = "                  §6Chapter 3 - Elemental Abilities\n\n" +
-                "    §2§l✤ Earth:  §7§oEarth-imbued weapons will unleash a powerful quake, rupturing the nearby ground and disorienting enemies. Earth-augmented armors produce a rage-state in the user as they near death, turning Earth-based attacks more potent, and more violent.\n" +
-                "    §e§l✦ Thunder:  §7§oThunder-imbued weapons can release a streak of lightning that seeks enemies, bouncing from one foe to the next nearby. Thunder-augmented armors will steal the life force of the slain, and in kind increase the power of Thunder-based attacks temporarily.\n" +
-                "    §b§l❉ Water:  §7§oWater-imbued weapons will curse one's nearby enemies. This curse weakens armor, and turns them vulnerable to further attack. Water-augmented armors recycle used mana, transferring it into a short boost to Water-affiliated techniques, depending on how much mana was consumed.\n" +
-                "    §c§l✹ Fire:  §7§oFire-imbued weapons will generate a fan of flames that burn one's enemies and empower one's allies. Fire-augmented armors react to being struck, turning the impact of the blow, no matter how weak, into a temporary power boost to Fire-based attacks.\n" +
-                "    §f§l❋ Air:  §7§oAir-imbued weapons trap nearby enemies in a vortex of wind, and blow the victims away when struck. Air-augmented armors will, so long as they are kept close, leach energy from nearby foes to improve the strength of Air-based attacks.";
-        
         ITextComponent chapterText;
 
         public ChapterReader(int chapter) {
             String text;
             switch (chapter) {
                 case 1:
-                    text = CHAPTER_1;
+                    text = PowderManualChapter.ONE.getText();
                     break;
                 case 2:
-                    text = CHAPTER_2;
+                    text = PowderManualChapter.TWO.getText();
                     break;
                 case 3:
-                    text = CHAPTER_3;
+                    text = PowderManualChapter.THREE.getText();
                     break;
                 default: text = "";
             }
+            
             chapterText = new TextComponentString(text);
-            chapterText.getStyle()
-                    .setColor(TextFormatting.GRAY)
-                    .setItalic(true);
+
         }
         
         @Override

--- a/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
+++ b/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
@@ -389,7 +389,6 @@ public class ChatManager {
                 chapter.getStyle()
                         .setColor(TextFormatting.GOLD)
                         .setUnderlined(true)
-                        //.setClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "test"))
                         .setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new TextComponentString("Click to read Chapter " + i)));
                 chapter = TextAction.withDynamicEvent(chapter, new ChapterReader(i));
                 

--- a/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
+++ b/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
@@ -6,6 +6,7 @@ package com.wynntils.modules.chat.managers;
 
 import com.wynntils.ModCore;
 import com.wynntils.core.utils.StringUtils;
+import com.wynntils.core.utils.helpers.TextAction;
 import com.wynntils.core.utils.objects.Pair;
 import com.wynntils.modules.chat.configs.ChatConfig;
 import com.wynntils.modules.chat.overlays.ChatOverlay;
@@ -373,6 +374,33 @@ public class ChatManager {
                 break;
             }
         }
+        
+        //powder manual
+        if (ChatConfig.INSTANCE.customPowderManual && in.getUnformattedText().equals("                         Powder Manual")) {
+            List<ITextComponent> chapterSelect = new ArrayList<ITextComponent>();
+            
+            ITextComponent offset = new TextComponentString("\n               "); //to center chapter select
+            ITextComponent spacer = new TextComponentString("   "); //space between chapters
+            
+            chapterSelect.add(offset);
+            
+            for (int i = 1; i <= 3; i++) {
+                ITextComponent chapter = new TextComponentString("Chapter " + i);
+                chapter.getStyle()
+                        .setColor(TextFormatting.GOLD)
+                        .setUnderlined(true)
+                        //.setClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "test"))
+                        .setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new TextComponentString("Click to read Chapter " + i)));
+                chapter = TextAction.withDynamicEvent(chapter, new ChapterReader(i));
+                
+                chapterSelect.add(chapter);
+                chapterSelect.add(spacer);
+            }
+            
+            chapterSelect.add(new TextComponentString("\n"));
+            in.getSiblings().addAll(chapterSelect);
+            
+        }
 
         return in;
     }
@@ -680,6 +708,58 @@ public class ChatManager {
         }
 
         return new Pair<>(after, cancel);
+    }
+    
+    private static class ChapterReader implements Runnable {
+        
+        private static final String CHAPTER_1 = "                     §6Chapter 1 - The Basics\n\n" +
+                "    §7§oThere exist five varieties of magic powder, each corresponding to one of five different elements; §c✹ Fire§7§o, §b❉ Water§7§o, §e✦ Thunder§7§o, §2✤ Earth§7§o, and §f❋ Air§7§o.\n" +
+                "    §7§oIt is possible to augment items with these powders, if one is versed in the art of enchantment. Many offer this service for a price, as Powder Masters.\n" +
+                "    Certain items have a higher magical capacity, and thusly are able to hold more powders within them. Some have many, some have few, others still have none.\n" +
+                "    Should a §lweapon§r§7§o be enchanted with a powder, the powder will imbue the item with a slight amount of elemental damage, but also transfer basic neutral damage into its element.\n" +
+                "    Should a piece of §larmour§r§7§o be enchanted with a powder, the garment will gain a resistance towards that powder's element, at the cost of an elemental weakness.";
+        
+        private static final String CHAPTER_2 = "                  §6Chapter 2 - Elemental Abilities\n\n" +
+                "    §7§oIf a powder is more concentrated, they can unlock powerful elemental magicks within an item. Powders appraised to be Tier IV or higher are capable of forming these special abilities.\n" +
+                "    Two or more like-elemented powders are necessary for this. While items can be augmented with powders even after unlocking an ability, only one amplified magic power can be kept within an item at one time.\n" +
+                "    Weapons and armour channel this magical energy in radically different ways, just as powders change their more mundane abilities. The method of use for each piece can be referred to in Chapter 3.\n" +
+                "    Using different tiers of powder to try to form an ability on an item is somewhat unpredictable in the end potency of the magic, but using higher tiers of powder will generally lead to a stronger effect.\n" +
+                "    To unleash the unique ability imbued in your weapon, one must first charge the power by attacking enemies. Then, heavily focus on the latent energies within the item, and release them with a swing. §r(Shift+Left-Click)";
+        
+        private static final String CHAPTER_3 = "                  §6Chapter 3 - Elemental Abilities\n\n" +
+                "    §2§l✤ Earth:  §7§oEarth-imbued weapons will unleash a powerful quake, rupturing the nearby ground and disorienting enemies. Earth-augmented armors produce a rage-state in the user as they near death, turning Earth-based attacks more potent, and more violent.\n" +
+                "    §e§l✦ Thunder:  §7§oThunder-imbued weapons can release a streak of lightning that seeks enemies, bouncing from one foe to the next nearby. Thunder-augmented armors will steal the life force of the slain, and in kind increase the power of Thunder-based attacks temporarily.\n" +
+                "    §b§l❉ Water:  §7§oWater-imbued weapons will curse one's nearby enemies. This curse weakens armor, and turns them vulnerable to further attack. Water-augmented armors recycle used mana, transferring it into a short boost to Water-affiliated techniques, depending on how much mana was consumed.\n" +
+                "    §c§l✹ Fire:  §7§oFire-imbued weapons will generate a fan of flames that burn one's enemies and empower one's allies. Fire-augmented armors react to being struck, turning the impact of the blow, no matter how weak, into a temporary power boost to Fire-based attacks.\n" +
+                "    §f§l❋ Air:  §7§oAir-imbued weapons trap nearby enemies in a vortex of wind, and blow the victims away when struck. Air-augmented armors will, so long as they are kept close, leach energy from nearby foes to improve the strength of Air-based attacks.";
+        
+        ITextComponent chapterText;
+
+        public ChapterReader(int chapter) {
+            String text;
+            switch (chapter) {
+                case 1:
+                    text = CHAPTER_1;
+                    break;
+                case 2:
+                    text = CHAPTER_2;
+                    break;
+                case 3:
+                    text = CHAPTER_3;
+                    break;
+                default: text = "";
+            }
+            chapterText = new TextComponentString(text);
+            chapterText.getStyle()
+                    .setColor(TextFormatting.GRAY)
+                    .setItalic(true);
+        }
+        
+        @Override
+        public void run() {
+            Minecraft.getMinecraft().player.sendMessage(chapterText);
+        }
+        
     }
 
 }


### PR DESCRIPTION
Replaces the default powder manual with an in-chat menu that allows you to select each chapter, for a cleaner and less annoying experience. Can be toggled.
![image](https://user-images.githubusercontent.com/3767283/91038676-05158780-e5c0-11ea-8b12-20caefd24c95.png)
