### PR TITLE
Consumable timer improvements

### DIFF
--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -726,7 +726,7 @@ public class ClientEvents implements Listener {
 
     @SubscribeEvent
     public void onClassChange(WynnClassChangeEvent e) {
-        ConsumableTimerOverlay.clearConsumables(true); // clear consumable list
+        ConsumableTimerOverlay.clearConsumables(false); // clear consumable list
     }
 
     @SubscribeEvent

--- a/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
@@ -544,7 +544,7 @@ public class OverlayEvents implements Listener {
                     long timeNow = Minecraft.getSystemTime();
                     int timeLeft = 60 - (int)(timeNow - loginTime)/1000;
                     if (timeLeft > 0) {
-                        ConsumableTimerOverlay.addBasicTimer("Gather cooldown", timeLeft, true);
+                        ConsumableTimerOverlay.addBasicTimer("Gather cooldown", timeLeft, false);
                     }
                 }
                 return;

--- a/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
@@ -535,32 +535,34 @@ public class OverlayEvents implements Listener {
             }
         }
 
-        if (OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectCooldown) {
-            if (messageText.matches("^You need to wait 60 seconds after logging in to gather from this resource!")) {
+        if (messageText.matches("^You need to wait 60 seconds after logging in to gather from this resource!")) {
+            if (OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectCooldown) {
                 GameUpdateOverlay.queueMessage("Wait 60 seconds to gather");
                 e.setCanceled(true);
-
-                if (OverlayConfig.ConsumableTimer.INSTANCE.showCooldown) {
-                    long timeNow = Minecraft.getSystemTime();
-                    int timeLeft = 60 - (int)(timeNow - loginTime)/1000;
-                    if (timeLeft > 0) {
-                        ConsumableTimerOverlay.addBasicTimer("Gather cooldown", timeLeft, false);
-                    }
-                }
-                return;
             }
+                
+            if (OverlayConfig.ConsumableTimer.INSTANCE.showCooldown) {
+                long timeNow = Minecraft.getSystemTime();
+                int timeLeft = 60 - (int)(timeNow - loginTime)/1000;
+                if (timeLeft > 0) {
+                    ConsumableTimerOverlay.addBasicTimer("Gather cooldown", timeLeft, false);
+                }
+            }      
+            return;
+        }
 
-            Matcher matcher = CHEST_COOLDOWN_PATTERN.matcher(messageText);
-            if (matcher.find()) {
-                int minutes = Integer.parseInt(matcher.group(1));
+        Matcher matcher = CHEST_COOLDOWN_PATTERN.matcher(messageText);
+        if (matcher.find()) {
+            int minutes = Integer.parseInt(matcher.group(1));
+            if (OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectCooldown) {
                 GameUpdateOverlay.queueMessage("Wait " + minutes + " minutes for loot chest");
                 e.setCanceled(true);
-
-                if (OverlayConfig.ConsumableTimer.INSTANCE.showCooldown) {
-                    ConsumableTimerOverlay.addBasicTimer("Loot cooldown", minutes*60, true);
-                }
-                return;
             }
+
+            if (OverlayConfig.ConsumableTimer.INSTANCE.showCooldown) {
+                ConsumableTimerOverlay.addBasicTimer("Loot cooldown", minutes*60, true);
+            }
+            return;
         }
     }
 

--- a/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
@@ -10,6 +10,7 @@ import com.wynntils.core.events.custom.*;
 import com.wynntils.core.framework.enums.ClassType;
 import com.wynntils.core.framework.instances.PlayerInfo;
 import com.wynntils.core.framework.interfaces.Listener;
+import com.wynntils.core.utils.helpers.Delay;
 import com.wynntils.modules.utilities.UtilitiesModule;
 import com.wynntils.modules.utilities.configs.OverlayConfig;
 import com.wynntils.modules.utilities.instances.Toast;
@@ -150,6 +151,15 @@ public class OverlayEvents implements Listener {
         }
     }
 
+    @SubscribeEvent(priority = EventPriority.LOWEST)
+    public void onScrollUsed(ChatEvent.Post e) {
+        String messageText = e.getMessage().getUnformattedText();
+        if (messageText.matches(".*? for [0-9]* seconds\\]")) { //consumable message
+            //10 tick delay, since chat event occurs before default consumable event
+            new Delay(() -> ConsumableTimerOverlay.addExternalScroll(messageText), 10); 
+        }
+    }
+    
     @SubscribeEvent(priority = EventPriority.LOW)
     public void onChatToRedirect(ChatEvent.Pre e) {
         if (!UtilitiesModule.getModule().getGameUpdateOverlay().active) {

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/ConsumableTimerOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/ConsumableTimerOverlay.java
@@ -151,6 +151,17 @@ public class ConsumableTimerOverlay extends Overlay {
         }
 
         if (!consumable.isValid()) return;
+        
+        //check for duplicates to avoid doubling timers
+        for (ConsumableContainer c : activeConsumables) {
+            if (Math.abs(consumable.getExpirationTime() - c.getExpirationTime()) <= 1000) { // check within a second
+                for (String cEf : c.getEffects().keySet()) {
+                    if (consumable.getEffects().containsKey(cEf) && c.getEffects().get(cEf).getCurrentAmount() == consumable.getEffects().get(cEf).getCurrentAmount()) {
+                        return; // consumable has already been added, ignore this one
+                    }
+                }
+            }
+        }
 
         activeConsumables.add(consumable);
         updateActiveEffects();


### PR DESCRIPTION
Handful of changes:

- Fixed loot chest cooldown disappearing on /class
- Fixed loot chest cooldown only enabling when redirect cooldown messages was enabled (if the implementation here should be changed to separate the two options, let me know)
- Fixed consumables sometimes doubling up in the timer when used
- Added mana pots to the consumable timer
- Added scrolls used by other players to the consumable timer