### PR TITLE
Redirects for durability messages

### DIFF
--- a/src/main/java/com/wynntils/modules/utilities/configs/OverlayConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/OverlayConfig.java
@@ -345,6 +345,12 @@ public class OverlayConfig extends SettingsClass {
 
             @Setting(displayName = "Redirect pouch Messages", description = "Should messages about ingredients being added to your pouch be redirected to the game update ticker?")
             public boolean redirectPouch = true;
+            
+            @Setting(displayName = "Redirect Gathering Tool Messages", description = "Should messages about your gathering tool durability be redirected to the game update ticker?")
+            public boolean redirectGatheringDura = true;
+            
+            @Setting(displayName = "Redirect Crafted Item Messages", description = "Should messages about crafted item durability be redirected to the game update ticker?")
+            public boolean redirectCraftedDura = true;
         }
 
         @SettingsInfo(name = "game_update_territory_settings", displayPath = "Utilities/Overlays/Update Ticker/Territory Change")

--- a/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
@@ -66,6 +66,7 @@ public class OverlayEvents implements Listener {
     }
 
     private static long tickcounter = 0;
+    private static long msgcounter = 0;
 
     /* XP Gain Messages */
     private static int oldxp = 0;
@@ -544,6 +545,21 @@ public class OverlayEvents implements Listener {
                 return;
             }
         }
+        if (OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectGatheringDura) {
+            if (messageText.equals("Your tool has 0 durability left! You will not receive any new resources until you repair it at a Blacksmith.")) {
+                if (msgcounter++ % 5 == 0)
+                    GameUpdateOverlay.queueMessage(TextFormatting.DARK_RED + "Your tool has 0 durability");
+                e.setCanceled(true);
+                return;
+            }
+        }
+        if (OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectCraftedDura) {
+            if (messageText.equals("Your items are damaged and have become less effective. Bring them to a Blacksmith to repair them.")) {
+                GameUpdateOverlay.queueMessage(TextFormatting.DARK_RED + "Your items are damaged");
+                e.setCanceled(true);
+                return;
+            }
+        }
 
         if (messageText.matches("^You need to wait 60 seconds after logging in to gather from this resource!")) {
             if (OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectCooldown) {
@@ -715,6 +731,7 @@ public class OverlayEvents implements Listener {
         }
         // WynnCraft seem to be off with its timer with around 10 seconds
         loginTime = Minecraft.getSystemTime() + 10000;
+        msgcounter = 0;
     }
 
     @SubscribeEvent

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/BankOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/BankOverlay.java
@@ -149,10 +149,6 @@ public class BankOverlay implements Listener {
         FontRenderer fr = Minecraft.getMinecraft().fontRenderer;
         ScreenRenderer.beginGL(0, 0);
         {
-            { // gl setup
-                GlStateManager.translate(0, 0, 500);
-            }
-
             { // quick access numbers
                 int[] destinations = getQuickAccessDestinations();
                 for (int i = 0; i < QA_BUTTONS; i++) {


### PR DESCRIPTION
Adds redirect message toggles for gathering tool durability and crafted item durability warnings. Gathering tool warnings only appear every 5 messages (could be higher?) to avoid spam.

Also includes a one-line removal of an unnecessary GL translation in the bank overlay that was causing some layering problems.