### PR TITLE
Display active lootrun on map/minimap

### DIFF
--- a/src/main/java/com/wynntils/modules/map/configs/MapConfig.java
+++ b/src/main/java/com/wynntils/modules/map/configs/MapConfig.java
@@ -199,6 +199,9 @@ public class MapConfig extends SettingsClass {
         @Setting(displayName = "Rainbow Path Transitioning", description = "How many blocks should loot run paths be shown in a colour before transitioning to a different colour?", order = 5)
         @Setting.Limitations.IntLimit(min = 1, max = 500)
         public int cycleDistance = 20;
+        
+        @Setting(displayName = "Show Loot Run Path on Map", description = "Should the active lootrun path be shown on the map?", order = 6)
+        public boolean displayLootrunOnMap = true;
 
         @Override
         public void onSettingChanged(String name) {

--- a/src/main/java/com/wynntils/modules/map/instances/PathWaypointProfile.java
+++ b/src/main/java/com/wynntils/modules/map/instances/PathWaypointProfile.java
@@ -7,6 +7,7 @@ package com.wynntils.modules.map.instances;
 import com.google.gson.*;
 import com.wynntils.core.framework.rendering.colors.CommonColors;
 import com.wynntils.core.framework.rendering.colors.CustomColor;
+import com.wynntils.modules.map.configs.MapConfig;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -68,6 +69,14 @@ public class PathWaypointProfile {
         posZ = other.posZ;
         sizeX = other.sizeX;
         sizeZ = other.sizeZ;
+    }
+    
+    public PathWaypointProfile(LootRunPath lootrun) {
+        name = "Lootrun path";
+        color = MapConfig.LootRun.INSTANCE.activePathColour;
+        this.points = new ArrayList<>(lootrun.getPoints().size());
+        lootrun.getPoints().forEach(c -> points.add(new PathPoint((int) c.x, (int) c.z)));
+        recalculateBounds();
     }
 
     public PathPoint getPoint(int index) {

--- a/src/main/java/com/wynntils/modules/map/managers/LootRunManager.java
+++ b/src/main/java/com/wynntils/modules/map/managers/LootRunManager.java
@@ -12,6 +12,9 @@ import com.wynntils.core.framework.rendering.textures.Textures;
 import com.wynntils.core.utils.objects.Location;
 import com.wynntils.modules.map.configs.MapConfig;
 import com.wynntils.modules.map.instances.LootRunPath;
+import com.wynntils.modules.map.instances.PathWaypointProfile;
+import com.wynntils.modules.map.overlays.objects.MapIcon;
+import com.wynntils.modules.map.overlays.objects.MapPathWaypointIcon;
 import com.wynntils.modules.map.rendering.PointRenderer;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3i;
@@ -20,6 +23,7 @@ import java.io.*;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -34,6 +38,7 @@ public class LootRunManager {
 
     private static LootRunPath activePath = null;
     private static LootRunPath recordingPath = null;
+    private static PathWaypointProfile mapPath = null;
 
     public static void setup() {
         // Make sure lootrun folder exists at startup to simplify for users wanting to import lootruns
@@ -68,6 +73,7 @@ public class LootRunManager {
 
     public static void hide() {
         activePath = null;
+        updateMapPath();
     }
 
     public static boolean loadFromFile(String lootRunName) {
@@ -77,6 +83,7 @@ public class LootRunManager {
         try {
             InputStreamReader reader = new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8);
             activePath = GSON.fromJson(reader, LootRunPathIntermediary.class).toPath();
+            updateMapPath();
 
             reader.close();
         } catch (Exception ex) {
@@ -132,6 +139,7 @@ public class LootRunManager {
     public static void clear() {
         activePath = null;
         recordingPath = null;
+        updateMapPath();
     }
 
     public static LootRunPath getActivePath() {
@@ -140,6 +148,17 @@ public class LootRunManager {
 
     public static LootRunPath getRecordingPath() {
         return recordingPath;
+    }
+    
+    public static PathWaypointProfile getMapPath() {
+        return mapPath;
+    }
+    
+    public static List<MapIcon> getMapPathWaypoints() {
+        if (mapPath != null)
+            return Arrays.asList(new MapPathWaypointIcon(mapPath));
+        else
+            return new ArrayList<>();
     }
 
     public static boolean isRecording() {
@@ -191,6 +210,13 @@ public class LootRunManager {
         if (recordingPath != null) {
             PointRenderer.drawLines(recordingPath.getSmoothPointsByChunk(), MapConfig.LootRun.INSTANCE.recordingPathColour);
             recordingPath.getChests().forEach(c -> PointRenderer.drawCube(c, MapConfig.LootRun.INSTANCE.recordingPathColour));
+        }
+    }
+    
+    private static void updateMapPath() {
+        mapPath = null;
+        if (activePath != null) {
+            mapPath = new PathWaypointProfile(activePath);
         }
     }
 

--- a/src/main/java/com/wynntils/modules/map/managers/LootRunManager.java
+++ b/src/main/java/com/wynntils/modules/map/managers/LootRunManager.java
@@ -155,7 +155,7 @@ public class LootRunManager {
     }
     
     public static List<MapIcon> getMapPathWaypoints() {
-        if (mapPath != null)
+        if (mapPath != null && MapConfig.LootRun.INSTANCE.displayLootrunOnMap)
             return Arrays.asList(new MapPathWaypointIcon(mapPath));
         else
             return new ArrayList<>();

--- a/src/main/java/com/wynntils/modules/map/overlays/MiniMapOverlay.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/MiniMapOverlay.java
@@ -12,6 +12,7 @@ import com.wynntils.core.framework.rendering.textures.Textures;
 import com.wynntils.modules.map.MapModule;
 import com.wynntils.modules.map.configs.MapConfig;
 import com.wynntils.modules.map.instances.MapProfile;
+import com.wynntils.modules.map.managers.LootRunManager;
 import com.wynntils.modules.map.overlays.objects.MapCompassIcon;
 import com.wynntils.modules.map.overlays.objects.MapIcon;
 import net.minecraft.client.renderer.BufferBuilder;
@@ -183,6 +184,7 @@ public class MiniMapOverlay extends Overlay {
                 MapIcon.getWaypoints().forEach(consumer);
                 MapIcon.getPathWaypoints().forEach(consumer);
                 MapIcon.getPlayers().forEach(consumer);
+                LootRunManager.getMapPathWaypoints().forEach(consumer);
 
                 MapIcon compassIcon = MapIcon.getCompass();
 

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/WorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/WorldMapUI.java
@@ -16,6 +16,7 @@ import com.wynntils.modules.core.managers.CompassManager;
 import com.wynntils.modules.map.MapModule;
 import com.wynntils.modules.map.configs.MapConfig;
 import com.wynntils.modules.map.instances.MapProfile;
+import com.wynntils.modules.map.managers.LootRunManager;
 import com.wynntils.modules.map.overlays.objects.*;
 import com.wynntils.modules.questbook.managers.QuestManager;
 import com.wynntils.modules.utilities.managers.KeyManager;
@@ -80,6 +81,8 @@ public class WorldMapUI extends GuiMovementScreen {
         List<MapIcon> pathWpMapIcons = MapIcon.getPathWaypoints();
         // Handles guild / party / friends
         List<MapIcon> friendsIcons = MapIcon.getPlayers();
+        // Handles lootrun path waypoints
+        List<MapIcon> lootrunWpMapIcons = LootRunManager.getMapPathWaypoints();
         // Handles compass
         compassIcon = new WorldMapIcon(MapIcon.getCompass());
 
@@ -90,7 +93,8 @@ public class WorldMapUI extends GuiMovementScreen {
             wpMapIcons,
             pathWpMapIcons,
             mapLabels,
-            friendsIcons
+            friendsIcons,
+            lootrunWpMapIcons
         )) {
             if (i.isEnabled(false)) {
                 WorldMapIcon icon;


### PR DESCRIPTION
When enabled, displays the active lootrun on the map as a map path in the lootrun path color.

![image](https://user-images.githubusercontent.com/3767283/95781918-967dad80-0c83-11eb-99de-49f9be60c0c7.png)
