### PR TITLE
Trade market price input formatter

### DIFF
--- a/src/main/java/com/wynntils/core/utils/StringUtils.java
+++ b/src/main/java/com/wynntils/core/utils/StringUtils.java
@@ -16,10 +16,16 @@ import java.text.DecimalFormat;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.zip.CRC32;
 
 public class StringUtils {
+    
+    private static final Pattern STX_PATTERN = Pattern.compile("([\\d\\.]+)stx");
+    private static final Pattern LE_PATTERN = Pattern.compile("([\\d\\.]+)le");
+    private static final Pattern EB_PATTERN = Pattern.compile("([\\d\\.]+)eb");
+    private static final Pattern E_PATTERN = Pattern.compile("(\\d+)($|\\s)");
 
     /**
      * Removes the characters 'À' ('\u00c0') and '\u058e' that is sometimes added in Wynn APIs and
@@ -356,6 +362,43 @@ public class StringUtils {
         return (0x2474 <= character && character <= 0x247C)
             || (0x247D <= character && character <= 0x247F);
     }
+    
+    public static int convertEmeraldPrice(String input) {
+        input = input.toLowerCase();
+        int emeralds = 0;
+        
+        // stx
+        Matcher m = STX_PATTERN.matcher(input);
+        while (m.find()) {
+            emeralds += Float.parseFloat(m.group(1)) * 64 * 64 * 64;
+        }
+        
+        // le
+        m = LE_PATTERN.matcher(input);
+        while (m.find()) {
+            emeralds += Float.parseFloat(m.group(1)) * 64 * 64;
+        }
+        
+        // eb
+        m = EB_PATTERN.matcher(input);
+        while (m.find()) {
+            emeralds += Float.parseFloat(m.group(1)) * 64;;
+        }
+        
+        // standard numbers/emeralds
+        m = E_PATTERN.matcher(input);
+        while (m.find()) {
+            emeralds += Integer.parseInt(m.group(1));
+        }
+        
+        // account for tax if flagged
+        if (input.contains("-t")) {
+            emeralds = Math.round(emeralds / 1.05F);
+        }
+        
+        return emeralds;
+    }
+    
     /**
      * @param count the number
      * @return The formatted shortened string

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -11,6 +11,7 @@ import com.wynntils.core.framework.enums.wynntils.WynntilsSound;
 import com.wynntils.core.framework.instances.PlayerInfo;
 import com.wynntils.core.framework.interfaces.Listener;
 import com.wynntils.core.utils.ItemUtils;
+import com.wynntils.core.utils.StringUtils;
 import com.wynntils.core.utils.Utils;
 import com.wynntils.modules.chat.overlays.ChatOverlay;
 import com.wynntils.modules.chat.overlays.gui.ChatGUI;
@@ -89,6 +90,8 @@ public class ClientEvents implements Listener {
 
     public static boolean isAwaitingHorseMount = false;
     private static int lastHorseId = -1;
+    
+    private static boolean priceInput = false;
 
     @SubscribeEvent
     public void onMoveEvent(InputEvent.MouseInputEvent e) {
@@ -256,16 +259,33 @@ public class ClientEvents implements Listener {
 
     @SubscribeEvent
     public void onPostChatEvent(ChatEvent.Post e) {
+        if (e.getMessage().getUnformattedText().matches("Type the price in emeralds or type 'cancel' to cancel:")) {
+            priceInput = true;
+            if (UtilitiesConfig.Market.INSTANCE.openChatMarket)
+                scheduledGuiScreen = new ChatGUI();
+        }
+        
         if (UtilitiesConfig.Market.INSTANCE.openChatMarket) {
-            if (e.getMessage().getUnformattedText().matches("Type the (item name|amount you wish to (buy|sell)|price in emeralds) or type 'cancel' to cancel:")) {
+            if (e.getMessage().getUnformattedText().matches("Type the (item name|amount you wish to (buy|sell)) or type 'cancel' to cancel:")) {
                 scheduledGuiScreen = new ChatGUI();
             }
         }
+        
         if (UtilitiesConfig.Bank.INSTANCE.openChatBankSearch) {
             if (e.getMessage().getUnformattedText().matches("Please type an item name in chat!")) {
                 scheduledGuiScreen = new ChatGUI();
             }
         }
+    }
+    
+    @SubscribeEvent
+    public void onSendMessage(ClientChatEvent e) {
+        if (!priceInput) return;
+        
+        priceInput = false;        
+        int price = StringUtils.convertEmeraldPrice(e.getMessage());
+        if (price != 0) // price of 0 means either garbage input or actual 0, can be ignored either way
+            e.setMessage("" + price);
     }
 
     @SubscribeEvent


### PR DESCRIPTION
Adds ability to input a formatted price when prompted by the trade market, e.g.:
1.5stx
2stx 16le
17le 32eb
1eb 45

The flag -t can be added to account for the 5% tax (subject to occasional unavoidable rounding errors). Does not interfere with regular emerald value input.