### PR TITLE
Fix bank overlay not appearing for IGNs ending in s

### DIFF
--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/BankOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/BankOverlay.java
@@ -41,7 +41,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
 public class BankOverlay implements Listener {
 
-    private static final Pattern PAGE_PATTERN = Pattern.compile("\\[Pg\\. ([0-9]*)\\] [a-z_A-Z0-9]*'s Bank");
+    private static final Pattern PAGE_PATTERN = Pattern.compile("\\[Pg\\. ([0-9]*)\\] [a-z_A-Z0-9]*'s? Bank");
 
     private static final ResourceLocation COLUMN_ARROW = new ResourceLocation("minecraft:textures/wynn/gui/column_arrow_right.png");
 


### PR DESCRIPTION
Small fix to the bank page name regex to account for Wynn using ' over 's on names that end in s.