### PR TITLE
Allow accessories to be shift-clicked on/off

### DIFF
--- a/src/main/java/com/wynntils/core/utils/ItemUtils.java
+++ b/src/main/java/com/wynntils/core/utils/ItemUtils.java
@@ -104,6 +104,12 @@ public class ItemUtils {
         return toReturn.toString();
     }
     
+    /**
+     * Determines the equipment type of the given item.
+     * 
+     * @param item
+     * @return The ItemType of the item, or null if invalid or not an equipment piece
+     */
     public static ItemType getItemType(ItemStack item) {
         for (Entry<ItemType, String[]> e : WebManager.getMaterialTypes().entrySet()) {
             for (String id : e.getValue()) {

--- a/src/main/java/com/wynntils/core/utils/ItemUtils.java
+++ b/src/main/java/com/wynntils/core/utils/ItemUtils.java
@@ -5,6 +5,9 @@
 package com.wynntils.core.utils;
 
 import com.wynntils.core.utils.reference.EmeraldSymbols;
+import com.wynntils.webapi.WebManager;
+import com.wynntils.webapi.profiles.item.enums.ItemType;
+
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.inventory.IInventory;
@@ -18,6 +21,7 @@ import net.minecraft.util.text.TextFormatting;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map.Entry;
 
 public class ItemUtils {
 
@@ -98,6 +102,27 @@ public class ItemUtils {
             toReturn.append(x);
         }
         return toReturn.toString();
+    }
+    
+    public static ItemType getItemType(ItemStack item) {
+        for (Entry<ItemType, String[]> e : WebManager.getMaterialTypes().entrySet()) {
+            for (String id : e.getValue()) {
+                if (id.matches("[A-Za-z_:]+")) {
+                    if (Item.getByNameOrId(id).equals(item.getItem())) return e.getKey();
+                } else {
+                    int damageValue = 0;
+
+                    String[] values = id.split(":");
+                    int i = Integer.parseInt(values[0]);
+                    if (values.length == 2) {
+                        damageValue = Integer.parseInt(values[1]);
+                    }
+
+                    if (Item.getIdFromItem(item.getItem()) == i && item.getItemDamage() == damageValue) return e.getKey();
+                }
+            }
+        }
+        return null;
     }
 
     private static final Item EMERALD_BLOCK = Item.getItemFromBlock(Blocks.EMERALD_BLOCK);

--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -81,6 +81,9 @@ public class UtilitiesConfig extends SettingsClass {
 
     @Setting(displayName = "Show Leaderboard Badges", description = "Should leaderboard players have a badge above their heads?")
     public boolean renderLeaderboardBadges = true;
+    
+    @Setting(displayName = "Shift-click Accessories", description = "Allow accessories to be shift-clicked on and off?")
+    public boolean shiftClickAccessories = true;
 
     @Setting(upload = false)
     public String lastServerResourcePack = "";

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -585,8 +585,6 @@ public class ClientEvents implements Listener {
                 }
                 
                 // move accessory into inventory
-                e.setCanceled(true);
-                
                 // find first open slot
                 int openSlot = 0;
                 for (int i = 14; i < 36; i++) {
@@ -597,6 +595,8 @@ public class ClientEvents implements Listener {
                 }
                 if (openSlot == 0) return; // no open slots, cannot move accessory anywhere
                 accessoryDestinationSlot = openSlot;
+                
+                e.setCanceled(true);
                 
             } else { // putting on accessory
                 // verify it's an accessory

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -65,6 +65,8 @@ import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.InputEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
+import net.minecraftforge.fml.common.gameevent.TickEvent.Phase;
+
 import org.lwjgl.opengl.Display;
 
 import java.time.*;
@@ -637,6 +639,7 @@ public class ClientEvents implements Listener {
     
     @SubscribeEvent
     public void handleAccessoryMovement(TickEvent.ClientTickEvent e) {
+        if (e.phase != Phase.END) return;
         if (!Reference.onWorld || accessoryDestinationSlot == -1) return;
 
         // inventory was closed

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -27,6 +27,7 @@ import com.wynntils.modules.utilities.overlays.hud.ConsumableTimerOverlay;
 import com.wynntils.modules.utilities.overlays.hud.GameUpdateOverlay;
 import com.wynntils.modules.utilities.overlays.ui.SkillPointLoadoutUI;
 import com.wynntils.webapi.WebManager;
+import com.wynntils.webapi.profiles.item.enums.ItemType;
 import com.wynntils.webapi.profiles.player.PlayerStatsProfile;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.audio.PositionedSoundRecord;
@@ -563,11 +564,101 @@ public class ClientEvents implements Listener {
         }
     }
 
+    private static int accessoryDestinationSlot = -1;
+    
     @SubscribeEvent
     public void clickOnInventory(GuiOverlapEvent.InventoryOverlap.HandleMouseClick e) {
+        if(!Reference.onWorld) return;
+        
         if (UtilitiesConfig.INSTANCE.preventSlotClicking && e.getGui().getSlotUnderMouse() != null && e.getGui().getSlotUnderMouse().inventory == Minecraft.getMinecraft().player.inventory) {
-            e.setCanceled(checkDropState(e.getGui().getSlotUnderMouse().getSlotIndex(), Minecraft.getMinecraft().gameSettings.keyBindDrop.getKeyCode()));
+            if (checkDropState(e.getGui().getSlotUnderMouse().getSlotIndex(), Minecraft.getMinecraft().gameSettings.keyBindDrop.getKeyCode())) {
+                e.setCanceled(true);
+                return;
+            }
         }
+        
+        if (UtilitiesConfig.INSTANCE.shiftClickAccessories && e.getGui().isShiftKeyDown() && e.getGui().getSlotUnderMouse() != null && ModCore.mc().player.inventory.getItemStack().isEmpty() && e.getGui().getSlotUnderMouse().inventory == ModCore.mc().player.inventory) {
+            if (e.getSlotId() >= 9 && e.getSlotId() <= 12) { // taking off accessory
+                // check if hotbar has open slot; if so, no action required
+                for (int i = 36; i < 45; i++) {
+                    if (!e.getGui().inventorySlots.getSlot(i).getHasStack()) return;
+                }
+                
+                // move accessory into inventory
+                e.setCanceled(true);
+                
+                // find first open slot
+                int openSlot = 0;
+                for (int i = 14; i < 36; i++) {
+                    if (!e.getGui().inventorySlots.getSlot(i).getHasStack()) {
+                        openSlot = i;
+                        break;
+                    }
+                }
+                if (openSlot == 0) return; // no open slots, cannot move accessory anywhere
+                accessoryDestinationSlot = openSlot;
+                
+            } else { // putting on accessory
+                // verify it's an accessory
+                ItemType item = ItemUtils.getItemType(e.getSlotIn().getStack());
+                if (item != ItemType.RING && item != ItemType.BRACELET && item != ItemType.NECKLACE) return;
+                
+                // check if the appropriate slot is open (snow layer = empty)
+                int openSlot = 0;
+                switch (item) {
+                    case RING:
+                        if (e.getGui().inventorySlots.getSlot(9).getHasStack() && e.getGui().inventorySlots.getSlot(9).getStack().getItem().equals(Item.getItemFromBlock(Blocks.SNOW_LAYER)))
+                            openSlot = 9; // first ring slot
+                        else if (e.getGui().inventorySlots.getSlot(10).getHasStack() && e.getGui().inventorySlots.getSlot(10).getStack().getItem().equals(Item.getItemFromBlock(Blocks.SNOW_LAYER)))
+                            openSlot = 10; // second ring slot
+                        break;
+                    case BRACELET:
+                        if (e.getGui().inventorySlots.getSlot(11).getHasStack() && e.getGui().inventorySlots.getSlot(11).getStack().getItem().equals(Item.getItemFromBlock(Blocks.SNOW_LAYER)))
+                            openSlot = 11; // bracelet slot
+                        break;
+                    case NECKLACE:
+                        if (e.getGui().inventorySlots.getSlot(12).getHasStack() && e.getGui().inventorySlots.getSlot(12).getStack().getItem().equals(Item.getItemFromBlock(Blocks.SNOW_LAYER)))
+                            openSlot = 12; // necklace slot
+                        break;
+                    default:
+                        return;
+                }
+                if (openSlot == 0) return;
+                accessoryDestinationSlot = openSlot;
+                
+                e.setCanceled(true); // only cancel after finding open slot
+            }
+                
+            // pick up accessory
+            CPacketClickWindow packet = new CPacketClickWindow(e.getGui().inventorySlots.windowId, e.getSlotId(), 0, ClickType.PICKUP, e.getSlotIn().getStack(), e.getGui().inventorySlots.getNextTransactionID(ModCore.mc().player.inventory));
+            ModCore.mc().getConnection().sendPacket(packet);
+        }
+    }
+    
+    @SubscribeEvent
+    public void handleAccessoryMovement(TickEvent.ClientTickEvent e) {
+        if (!Reference.onWorld || accessoryDestinationSlot == -1) return;
+
+        // inventory was closed
+        if (!(ModCore.mc().currentScreen instanceof InventoryReplacer)) {
+            accessoryDestinationSlot = -1;
+            return;
+        }
+        InventoryReplacer gui = (InventoryReplacer) ModCore.mc().currentScreen;
+        
+        // no item picked up
+        if (ModCore.mc().player.inventory.getItemStack().isEmpty()) return;
+        
+        // destination slot was filled in the meantime
+        if (gui.inventorySlots.getSlot(accessoryDestinationSlot).getHasStack() &&
+                !gui.inventorySlots.getSlot(accessoryDestinationSlot).getStack().getItem().equals(Item.getItemFromBlock(Blocks.SNOW_LAYER))) {
+            accessoryDestinationSlot = -1;
+            return;
+        }
+        
+        // move accessory
+        gui.handleMouseClick(gui.inventorySlots.getSlot(accessoryDestinationSlot), accessoryDestinationSlot, 0, ClickType.PICKUP);
+        accessoryDestinationSlot = -1;
     }
 
     private boolean bankPageConfirmed = false;

--- a/src/main/java/com/wynntils/webapi/WebManager.java
+++ b/src/main/java/com/wynntils/webapi/WebManager.java
@@ -21,6 +21,7 @@ import com.wynntils.webapi.profiles.guild.GuildProfile;
 import com.wynntils.webapi.profiles.item.IdentificationOrderer;
 import com.wynntils.webapi.profiles.item.ItemGuessProfile;
 import com.wynntils.webapi.profiles.item.ItemProfile;
+import com.wynntils.webapi.profiles.item.enums.ItemType;
 import com.wynntils.webapi.profiles.item.objects.IdentificationContainer;
 import com.wynntils.webapi.profiles.music.MusicLocationsProfile;
 import com.wynntils.webapi.profiles.player.PlayerStatsProfile;
@@ -57,6 +58,7 @@ public class WebManager {
     private static HashMap<String, ItemProfile> items = new HashMap<>();
     private static Collection<ItemProfile> directItems = new ArrayList<>();
     private static HashMap<String, String> translatedReferences = new HashMap<>();
+    private static HashMap<ItemType, String[]> materialTypes = new HashMap<>();
     private static HashMap<String, ItemGuessProfile> itemGuesses = new HashMap<>();
 
     private static ArrayList<MapMarkerProfile> mapMarkers = new ArrayList<>();
@@ -198,6 +200,10 @@ public class WebManager {
 
     public static Collection<ItemProfile> getDirectItems() {
         return directItems;
+    }
+    
+    public static HashMap<ItemType, String[]> getMaterialTypes() {
+        return materialTypes;
     }
 
     public static ArrayList<DiscoveryProfile> getDiscoveries() {
@@ -436,6 +442,8 @@ public class WebManager {
                 items = citems;
 
                 translatedReferences = gson.fromJson(j.getAsJsonObject("translatedReferences"), HashMap.class);
+                Type materialTypesType = new TypeToken<HashMap<ItemType, String[]>>(){}.getType();
+                materialTypes = gson.fromJson(j.getAsJsonObject("materialTypes"), materialTypesType);
                 IdentificationOrderer.INSTANCE = gson.fromJson(j.getAsJsonObject("identificationOrder"), IdentificationOrderer.class);
                 return true;
             })


### PR DESCRIPTION
Adds a toggleable feature to let accessories be shift clicked as if they were armor pieces.

Also includes some code to determine what item type (ring, wand, etc.) a given itemstack is.