### PR TITLE
Item screenshotter

### DIFF
--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -497,6 +497,11 @@ public class ClientEvents implements Listener {
 
             return;
         }
+        
+        if (e.getKeyCode() == KeyManager.getItemScreenshotKey().getKeyBinding().getKeyCode()) {
+            ItemScreenshotManager.takeScreenshot();
+            return;
+        }
 
         if (e.getGui().getSlotUnderMouse() != null && Minecraft.getMinecraft().player.inventory == e.getGui().getSlotUnderMouse().inventory) {
             if (!UtilitiesConfig.INSTANCE.locked_slots.containsKey(PlayerInfo.getPlayerInfo().getClassId())) return;
@@ -539,6 +544,11 @@ public class ClientEvents implements Listener {
 
             return;
         }
+        
+        if (e.getKeyCode() == KeyManager.getItemScreenshotKey().getKeyBinding().getKeyCode()) {
+            ItemScreenshotManager.takeScreenshot();
+            return;
+        }
 
         if (e.getGui().getSlotUnderMouse() != null && Minecraft.getMinecraft().player.inventory == e.getGui().getSlotUnderMouse().inventory) {
             if (!UtilitiesConfig.INSTANCE.locked_slots.containsKey(PlayerInfo.getPlayerInfo().getClassId())) return;
@@ -556,6 +566,11 @@ public class ClientEvents implements Listener {
                 checkLockState(e.getGui().getSlotUnderMouse().getSlotIndex());
             }
 
+            return;
+        }
+        
+        if (e.getKeyCode() == KeyManager.getItemScreenshotKey().getKeyBinding().getKeyCode()) {
+            ItemScreenshotManager.takeScreenshot();
             return;
         }
 

--- a/src/main/java/com/wynntils/modules/utilities/managers/ItemScreenshotManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/ItemScreenshotManager.java
@@ -1,0 +1,142 @@
+package com.wynntils.modules.utilities.managers;
+
+import java.awt.Image;
+import java.awt.Toolkit;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.Transferable;
+import java.awt.datatransfer.UnsupportedFlavorException;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.nio.IntBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.lwjgl.BufferUtils;
+
+import com.wynntils.ModCore;
+import com.wynntils.Reference;
+
+import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.renderer.texture.TextureUtil;
+import net.minecraft.client.shader.Framebuffer;
+import net.minecraft.client.util.ITooltipFlag;
+import net.minecraft.inventory.Slot;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.text.TextFormatting;
+import net.minecraftforge.fml.client.config.GuiUtils;
+
+public class ItemScreenshotManager {
+    
+    private static Pattern ITEM_PATTERN = Pattern.compile("(Normal|Set|Unique|Rare|Legendary|Fabled|Mythic) Item.*");
+    
+    public static void takeScreenshot() {
+        if (!Reference.onWorld) return;
+        GuiScreen gui = ModCore.mc().currentScreen;
+        if (!(gui instanceof GuiContainer)) return;
+        
+        Slot slot = ((GuiContainer) gui).getSlotUnderMouse();
+        if (slot == null || !slot.getHasStack()) return;
+        ItemStack stack = slot.getStack();
+        if (!stack.hasDisplayName()) return;
+        
+        List<String> tooltip = stack.getTooltip(ModCore.mc().player, ITooltipFlag.TooltipFlags.NORMAL);
+        removeItemLore(tooltip);
+        
+        FontRenderer fr = ModCore.mc().fontRenderer;
+        int width = 0;
+        int height = 8;
+        
+        // calculate width of tooltip
+        for (String s : tooltip) {
+            int w = fr.getStringWidth(s);
+            if (w > width) width = w;
+        }
+        width += 8;
+        
+        // calculate height of tooltip
+        if (tooltip.size() > 1) height += 2 + (tooltip.size() - 1) * 10;
+        height += 8;
+        
+        // calculate scale of tooltip to fit it to the framebuffer
+        float scale = (float) gui.height/height;
+        
+        // draw tooltip to framebuffer, create image from it
+        GlStateManager.pushMatrix();
+        Framebuffer fb = new Framebuffer((int) (gui.width*(1/scale)), (int) (gui.height*(1/scale)), true);
+        fb.bindFramebuffer(false);
+        GlStateManager.scale(scale, scale, scale);
+        GuiUtils.drawHoveringText(tooltip, -8, 8, gui.width, gui.height, -1, fr);
+        BufferedImage bi = createScreenshot(width, height, fb);
+        fb.unbindFramebuffer();
+        GlStateManager.popMatrix();
+        
+        // copy to clipboard
+        ClipboardImage ci = new ClipboardImage(bi);
+        Toolkit.getDefaultToolkit().getSystemClipboard().setContents(ci, null);
+    }
+    
+    private static void removeItemLore(List<String> tooltip) {
+        // iterate through each line of the tooltip and remove item lore
+        List<String> temp = new ArrayList<>();
+        boolean lore = false;
+        for (String s : tooltip) {
+            // only remove text after the item type indicator
+            Matcher m = ITEM_PATTERN.matcher(TextFormatting.getTextWithoutFormattingCodes(s));
+            if (!lore && m.matches()) lore = true;
+            
+            if (lore && s.contains("" + TextFormatting.DARK_GRAY)) temp.add(s);
+        }
+        tooltip.removeAll(temp);
+    }
+    
+    private static BufferedImage createScreenshot(int width, int height, Framebuffer framebufferIn) {
+        // create pixel arrays
+        int i = width * height;
+        IntBuffer pixelBuffer = BufferUtils.createIntBuffer(i);
+        int[] pixelValues = new int[i];
+
+        GlStateManager.glPixelStorei(3333, 1);
+        GlStateManager.glPixelStorei(3317, 1);
+        pixelBuffer.clear();
+
+        // create image from pixels
+        GlStateManager.glReadPixels(0, 0, width, height, 32993, 33639, pixelBuffer);
+        pixelBuffer.get(pixelValues);
+        TextureUtil.processPixelValues(pixelValues, width, height);
+        BufferedImage bufferedimage = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+        bufferedimage.setRGB(0, 0, width, height, pixelValues, 0, width);
+        return bufferedimage;
+    }
+    
+    private static class ClipboardImage implements Transferable {
+        
+        Image image;
+        
+        public ClipboardImage(Image image) {
+            this.image = image;
+        }
+
+        @Override
+        public DataFlavor[] getTransferDataFlavors() {
+            return new DataFlavor[] { DataFlavor.imageFlavor };
+        }
+
+        @Override
+        public boolean isDataFlavorSupported(DataFlavor flavor) {
+            return DataFlavor.imageFlavor.equals(flavor);
+        }
+
+        @Override
+        public Object getTransferData(DataFlavor flavor) throws UnsupportedFlavorException, IOException {
+            if (!DataFlavor.imageFlavor.equals(flavor)) throw new UnsupportedFlavorException(flavor);
+            return this.image;
+        }
+        
+    }
+
+}

--- a/src/main/java/com/wynntils/modules/utilities/managers/KeyManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/KeyManager.java
@@ -30,6 +30,7 @@ public class KeyManager {
     private static KeyHolder zoomInKey;
     private static KeyHolder zoomOutKey;
     private static KeyHolder stopwatchKey;
+    private static KeyHolder itemScreenshotKey;
 
     public static void registerKeys() {
         UtilitiesModule.getModule().registerKeyBinding("Gammabright", Keyboard.KEY_G, "Wynntils", true, () -> {
@@ -80,6 +81,8 @@ public class KeyManager {
         });
 
         stopwatchKey = CoreModule.getModule().registerKeyBinding("Start/Stop Stopwatch", Keyboard.KEY_NUMPAD5, "Wynntils", true, StopWatchOverlay::start);
+        
+        itemScreenshotKey = CoreModule.getModule().registerKeyBinding("Screenshot Current Item", Keyboard.KEY_F4, "Wynntils", true, () -> {});
     }
 
     public static KeyHolder getFavoriteTradeKey() {
@@ -104,6 +107,10 @@ public class KeyManager {
 
     public static KeyHolder getStopwatchKey() {
         return stopwatchKey;
+    }
+    
+    public static KeyHolder getItemScreenshotKey() {
+        return itemScreenshotKey;
     }
 
 }


### PR DESCRIPTION
While hovering an item, press the hotkey (F4 by default) to copy only the item's tooltip to the clipboard. Removes any Wynncraft item lore to focus on the item's stats. 

![image](https://user-images.githubusercontent.com/3767283/98414318-03405980-2030-11eb-8484-c04a64c31c5c.png)
![image](https://user-images.githubusercontent.com/3767283/98414306-fa4f8800-202f-11eb-95f6-c9fcaf03143c.png)
