### PR TITLE
Add chat-based gear viewer

### DIFF
--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -4,22 +4,19 @@
 
 package com.wynntils.modules.utilities.configs;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
 import com.wynntils.core.framework.rendering.colors.CustomColor;
 import com.wynntils.core.framework.settings.annotations.Setting;
 import com.wynntils.core.framework.settings.annotations.SettingsInfo;
 import com.wynntils.core.framework.settings.instances.SettingsClass;
-import com.wynntils.core.utils.objects.Pair;
 import com.wynntils.modules.utilities.events.ServerEvents;
 import com.wynntils.modules.utilities.instances.SkillPointAllocation;
 import com.wynntils.modules.utilities.managers.WindowIconManager;
 import com.wynntils.webapi.WebManager;
 import com.wynntils.webapi.profiles.item.ItemProfile;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 @SettingsInfo(name = "main", displayPath = "Utilities")
 public class UtilitiesConfig extends SettingsClass {
@@ -45,6 +42,12 @@ public class UtilitiesConfig extends SettingsClass {
 
     @Setting(displayName = "Show Players' Armour", description = "Should the worn armour of players be listed underneath their nametag?")
     public boolean showArmors = false;
+    
+    @Setting(displayName = "Show Gear Viewer GUI", description = "Should the gear viewer open a gui when displaying a player's gear?")
+    public boolean gearViewerGui = true;
+    
+    @Setting(displayName = "Show Gear Viewer Chat Message", description = "Should the gear viewer display a message in chat when displaying a player's gear?")
+    public boolean gearViewerMsg = false;
 
     @Setting(displayName = "Prevent Mythic Chest Closing", description = "Should the closing of loot chests be prevented when they contain mythics?")
     public boolean preventMythicChestClose = true;

--- a/src/main/java/com/wynntils/modules/utilities/managers/KeyManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/KeyManager.java
@@ -86,7 +86,7 @@ public class KeyManager {
         itemScreenshotKey = CoreModule.getModule().registerKeyBinding("Screenshot Current Item", Keyboard.KEY_F4, "Wynntils", true, () -> {});
       
         // -98 for middle click
-        CoreModule.getModule().registerKeyBinding("View Player's Gear", -98, "Wynntils", true, GearViewerUI::openGearViewer);
+        CoreModule.getModule().registerKeyBinding("View Player's Gear", -98, "Wynntils", true, GearViewerUI::inspectGear);
     }
 
     public static KeyHolder getFavoriteTradeKey() {


### PR DESCRIPTION
Per popular demand, this adds toggles for the gear viewer GUI and a new text form of the gear viewer. Hovering over the item name will show its stats. Users may have one or both forms of the viewer enabled.

![image](https://user-images.githubusercontent.com/3767283/98993394-3cbb0e00-24e3-11eb-9a42-cc498d0b815e.png)
![image](https://user-images.githubusercontent.com/3767283/98993421-4a709380-24e3-11eb-9451-5ca29e1e1830.png)
