### PR TITLE
Better item level/tier overlays

### DIFF
--- a/src/main/java/com/wynntils/ModCore.java
+++ b/src/main/java/com/wynntils/ModCore.java
@@ -7,6 +7,7 @@ package com.wynntils;
 import com.wynntils.core.CoreManager;
 import com.wynntils.core.events.custom.ClientEvent;
 import com.wynntils.core.framework.FrameworkManager;
+import com.wynntils.core.framework.rendering.WynnRenderItem;
 import com.wynntils.core.framework.rendering.textures.Mappings;
 import com.wynntils.core.framework.rendering.textures.Textures;
 import com.wynntils.modules.ModuleManager;
@@ -75,6 +76,8 @@ public class ModCore {
         }
 
         if (!conflicts.isEmpty()) throw new ModConflictScreen(conflicts);
+
+        WynnRenderItem.inject();
 
         FrameworkManager.postEnableModules();
 

--- a/src/main/java/com/wynntils/core/events/custom/RenderEvent.java
+++ b/src/main/java/com/wynntils/core/events/custom/RenderEvent.java
@@ -1,0 +1,65 @@
+/*
+ *  * Copyright © Wynntils - 2018 - 2020.
+ */
+
+package com.wynntils.core.events.custom;
+
+import com.wynntils.core.framework.rendering.colors.CommonColors;
+import com.wynntils.core.framework.rendering.colors.CustomColor;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+public class RenderEvent extends Event {
+
+    public static class DrawItemOverlay extends RenderEvent {
+
+        private final ItemStack stack;
+        private final int x, y;
+        private String overlayText;
+        private CustomColor overlayTextCol = CommonColors.WHITE;
+        private boolean overlayTextChanged = false;
+
+        public DrawItemOverlay(ItemStack stack, int x, int y, String overlayText) {
+            this.stack = stack;
+            this.x = x;
+            this.y = y;
+            this.overlayText = overlayText;
+        }
+
+        public ItemStack getStack() {
+            return stack;
+        }
+
+        public int getX() {
+            return x;
+        }
+
+        public int getY() {
+            return y;
+        }
+
+        public String getOverlayText() {
+            return overlayText;
+        }
+
+        public void setOverlayText(String text) {
+            this.overlayText = text;
+            this.overlayTextChanged = true;
+        }
+
+        public CustomColor getOverlayTextColor() {
+            return overlayTextCol;
+        }
+
+        public void setOverlayTextColor(CustomColor col) {
+            this.overlayTextCol = col;
+            this.overlayTextChanged = true;
+        }
+
+        public boolean isOverlayTextChanged() {
+            return overlayTextChanged;
+        }
+
+    }
+
+}

--- a/src/main/java/com/wynntils/core/framework/rendering/ScreenRenderer.java
+++ b/src/main/java/com/wynntils/core/framework/rendering/ScreenRenderer.java
@@ -8,7 +8,6 @@ import com.wynntils.core.framework.rendering.colors.CustomColor;
 import com.wynntils.core.framework.rendering.textures.Texture;
 import com.wynntils.core.utils.StringUtils;
 import com.wynntils.modules.core.config.CoreDBConfig;
-
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.ScaledResolution;
 import net.minecraft.client.renderer.GlStateManager;

--- a/src/main/java/com/wynntils/core/framework/rendering/WynnRenderItem.java
+++ b/src/main/java/com/wynntils/core/framework/rendering/WynnRenderItem.java
@@ -35,8 +35,6 @@ public class WynnRenderItem extends RenderItem {
 
     private static final int GUI_OVERLAY_WIDTH_THRESH = 16;
 
-    private final ScreenRenderer renderer = new ScreenRenderer();
-
     private WynnRenderItem(RenderItem parent, TextureManager texMan, ItemColors itemCols) {
         super(texMan, parent.getItemModelMesher().getModelManager(), itemCols);
         ReflectionFields.RenderItem_itemModelMesher.setValue(this, ReflectionFields.RenderItem_itemModelMesher.getValue(parent));
@@ -46,28 +44,32 @@ public class WynnRenderItem extends RenderItem {
     public void renderItemOverlayIntoGUI(FontRenderer fr, ItemStack stack, int xPosition, int yPosition, String text) {
         RenderEvent.DrawItemOverlay event = new RenderEvent.DrawItemOverlay(stack, xPosition, yPosition, text);
         FrameworkManager.getEventBus().post(event);
-        if (event.isOverlayTextChanged()) {
-            super.renderItemOverlayIntoGUI(fr, stack, xPosition, yPosition, "");
-            GlStateManager.disableLighting();
-            GlStateManager.disableDepth();
-            GlStateManager.disableBlend();
-            GlStateManager.pushMatrix();
-            int width = ScreenRenderer.fontRenderer.getStringWidth(event.getOverlayText());
-            GlStateManager.translate(xPosition + 17f, yPosition + 9f, 0f);
-            if (width > GUI_OVERLAY_WIDTH_THRESH) {
-                float scaleRatio = GUI_OVERLAY_WIDTH_THRESH / (float)width;
-                GlStateManager.translate(0f, ScreenRenderer.fontRenderer.FONT_HEIGHT * (1f - scaleRatio) / 2f, 0f);
-                GlStateManager.scale(scaleRatio, scaleRatio, 1f);
-            }
-            ScreenRenderer.fontRenderer.drawString(event.getOverlayText(), 0, 0, event.getOverlayTextColor(),
-                    SmartFontRenderer.TextAlignment.RIGHT_LEFT, SmartFontRenderer.TextShadow.NORMAL);
-            GlStateManager.popMatrix();
-            GlStateManager.enableLighting();
-            GlStateManager.enableDepth();
-            GlStateManager.enableBlend();
-        } else {
+        if (!event.isOverlayTextChanged()) {
             super.renderItemOverlayIntoGUI(fr, stack, xPosition, yPosition, text);
+            return;
         }
+
+        super.renderItemOverlayIntoGUI(fr, stack, xPosition, yPosition, "");
+        GlStateManager.disableLighting();
+        GlStateManager.disableDepth();
+        GlStateManager.disableBlend();
+        GlStateManager.pushMatrix();
+
+        int width = ScreenRenderer.fontRenderer.getStringWidth(event.getOverlayText());
+        GlStateManager.translate(xPosition + 17f, yPosition + 9f, 0f);
+        if (width > GUI_OVERLAY_WIDTH_THRESH) {
+            float scaleRatio = GUI_OVERLAY_WIDTH_THRESH / (float)width;
+            GlStateManager.translate(0f, ScreenRenderer.fontRenderer.FONT_HEIGHT * (1f - scaleRatio) / 2f, 0f);
+            GlStateManager.scale(scaleRatio, scaleRatio, 1f);
+        }
+
+        ScreenRenderer.fontRenderer.drawString(event.getOverlayText(), 0, 0, event.getOverlayTextColor(),
+                SmartFontRenderer.TextAlignment.RIGHT_LEFT, SmartFontRenderer.TextShadow.NORMAL);
+
+        GlStateManager.popMatrix();
+        GlStateManager.enableLighting();
+        GlStateManager.enableDepth();
+        GlStateManager.enableBlend();
     }
 
 }

--- a/src/main/java/com/wynntils/core/framework/rendering/WynnRenderItem.java
+++ b/src/main/java/com/wynntils/core/framework/rendering/WynnRenderItem.java
@@ -1,0 +1,73 @@
+/*
+ *  * Copyright © Wynntils - 2018 - 2020.
+ */
+
+package com.wynntils.core.framework.rendering;
+
+import com.wynntils.core.events.custom.RenderEvent;
+import com.wynntils.core.framework.FrameworkManager;
+import com.wynntils.core.utils.reflections.ReflectionFields;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.renderer.RenderItem;
+import net.minecraft.client.renderer.color.ItemColors;
+import net.minecraft.client.renderer.texture.TextureManager;
+import net.minecraft.item.ItemStack;
+
+public class WynnRenderItem extends RenderItem {
+
+    private static WynnRenderItem instance = null;
+
+    public static void inject() {
+        if (instance != null) throw new IllegalStateException("Wynntils item renderer has already been installed!");
+        Minecraft mc = Minecraft.getMinecraft();
+        instance = new WynnRenderItem(mc.getRenderItem(), mc.renderEngine, mc.getItemColors());
+        // the resource manager reload listener for the item renderer merely invalidates the cache of the held item model mesher
+        // since we're inheriting the one from the original item renderer and also not unregistering it as a reload listener, we don't need to register our own renderer as a listener
+        ReflectionFields.Minecraft_renderItem.setValue(mc, instance);
+    }
+
+    public static WynnRenderItem getInstance() {
+        if (instance == null) throw new IllegalStateException("Wynntils item renderer has not yet been installed!");
+        return instance;
+    }
+
+    private static final int GUI_OVERLAY_WIDTH_THRESH = 16;
+
+    private final ScreenRenderer renderer = new ScreenRenderer();
+
+    private WynnRenderItem(RenderItem parent, TextureManager texMan, ItemColors itemCols) {
+        super(texMan, parent.getItemModelMesher().getModelManager(), itemCols);
+        ReflectionFields.RenderItem_itemModelMesher.setValue(this, ReflectionFields.RenderItem_itemModelMesher.getValue(parent));
+    }
+
+    @Override
+    public void renderItemOverlayIntoGUI(FontRenderer fr, ItemStack stack, int xPosition, int yPosition, String text) {
+        RenderEvent.DrawItemOverlay event = new RenderEvent.DrawItemOverlay(stack, xPosition, yPosition, text);
+        FrameworkManager.getEventBus().post(event);
+        if (event.isOverlayTextChanged()) {
+            super.renderItemOverlayIntoGUI(fr, stack, xPosition, yPosition, "");
+            GlStateManager.disableLighting();
+            GlStateManager.disableDepth();
+            GlStateManager.disableBlend();
+            GlStateManager.pushMatrix();
+            int width = ScreenRenderer.fontRenderer.getStringWidth(event.getOverlayText());
+            GlStateManager.translate(xPosition + 17f, yPosition + 9f, 0f);
+            if (width > GUI_OVERLAY_WIDTH_THRESH) {
+                float scaleRatio = GUI_OVERLAY_WIDTH_THRESH / (float)width;
+                GlStateManager.translate(0f, ScreenRenderer.fontRenderer.FONT_HEIGHT * (1f - scaleRatio) / 2f, 0f);
+                GlStateManager.scale(scaleRatio, scaleRatio, 1f);
+            }
+            ScreenRenderer.fontRenderer.drawString(event.getOverlayText(), 0, 0, event.getOverlayTextColor(),
+                    SmartFontRenderer.TextAlignment.RIGHT_LEFT, SmartFontRenderer.TextShadow.NORMAL);
+            GlStateManager.popMatrix();
+            GlStateManager.enableLighting();
+            GlStateManager.enableDepth();
+            GlStateManager.enableBlend();
+        } else {
+            super.renderItemOverlayIntoGUI(fr, stack, xPosition, yPosition, text);
+        }
+    }
+
+}

--- a/src/main/java/com/wynntils/core/utils/ItemUtils.java
+++ b/src/main/java/com/wynntils/core/utils/ItemUtils.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.core.utils;
 
+import com.wynntils.core.utils.objects.CombatLevel;
 import com.wynntils.core.utils.reference.EmeraldSymbols;
 import com.wynntils.webapi.WebManager;
 import com.wynntils.webapi.profiles.item.enums.ItemType;
@@ -195,38 +196,6 @@ public class ItemUtils {
         m = COMBAT_LEVEL_RANGE_PATTERN.matcher(lore);
         if (m.find()) return new CombatLevel(Integer.parseInt(m.group(1)), Integer.parseInt(m.group(2)));
         return null;
-    }
-
-    public static class CombatLevel {
-
-        private final int min, max;
-
-        public CombatLevel(int min, int max) {
-            this.min = min;
-            this.max = max;
-        }
-
-        public CombatLevel(int level) {
-            this(level, level);
-        }
-
-        public int getAverage() {
-            return (min + max) / 2;
-        }
-
-        public int getMin() {
-            return min;
-        }
-
-        public int getMax() {
-            return max;
-        }
-
-        @Override
-        public String toString() {
-            return min == max ? Integer.toString(max) : String.format("%d-%d", min, max);
-        }
-
     }
 
 }

--- a/src/main/java/com/wynntils/core/utils/ItemUtils.java
+++ b/src/main/java/com/wynntils/core/utils/ItemUtils.java
@@ -7,7 +7,6 @@ package com.wynntils.core.utils;
 import com.wynntils.core.utils.reference.EmeraldSymbols;
 import com.wynntils.webapi.WebManager;
 import com.wynntils.webapi.profiles.item.enums.ItemType;
-
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.inventory.IInventory;
@@ -22,8 +21,13 @@ import net.minecraft.util.text.TextFormatting;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class ItemUtils {
+
+    private static final Pattern COMBAT_LEVEL_PATTERN = Pattern.compile("Combat Lv\\. Min: ([0-9]+)");
+    private static final Pattern COMBAT_LEVEL_RANGE_PATTERN = Pattern.compile("Lv\\. Range: " + TextFormatting.WHITE.toString() + "([0-9]+)-([0-9]+)");
 
     /**
      * Get the lore NBT tag from an item
@@ -103,10 +107,10 @@ public class ItemUtils {
         }
         return toReturn.toString();
     }
-    
+
     /**
      * Determines the equipment type of the given item.
-     * 
+     *
      * @param item
      * @return The ItemType of the item, or null if invalid or not an equipment piece
      */
@@ -184,4 +188,45 @@ public class ItemUtils {
         }
         return desc.toString();
     }
+
+    public static CombatLevel getLevel(String lore) {
+        Matcher m = COMBAT_LEVEL_PATTERN.matcher(lore);
+        if (m.find()) return new CombatLevel(Integer.parseInt(m.group(1)));
+        m = COMBAT_LEVEL_RANGE_PATTERN.matcher(lore);
+        if (m.find()) return new CombatLevel(Integer.parseInt(m.group(1)), Integer.parseInt(m.group(2)));
+        return null;
+    }
+
+    public static class CombatLevel {
+
+        private final int min, max;
+
+        public CombatLevel(int min, int max) {
+            this.min = min;
+            this.max = max;
+        }
+
+        public CombatLevel(int level) {
+            this(level, level);
+        }
+
+        public int getAverage() {
+            return (min + max) / 2;
+        }
+
+        public int getMin() {
+            return min;
+        }
+
+        public int getMax() {
+            return max;
+        }
+
+        @Override
+        public String toString() {
+            return min == max ? Integer.toString(max) : String.format("%d-%d", min, max);
+        }
+
+    }
+
 }

--- a/src/main/java/com/wynntils/core/utils/objects/CombatLevel.java
+++ b/src/main/java/com/wynntils/core/utils/objects/CombatLevel.java
@@ -1,0 +1,37 @@
+/*
+ *  * Copyright © Wynntils - 2018 - 2020.
+ */
+
+package com.wynntils.core.utils.objects;
+
+public class CombatLevel {
+
+    private final int min, max;
+
+    public CombatLevel(int min, int max) {
+        this.min = min;
+        this.max = max;
+    }
+
+    public CombatLevel(int level) {
+        this(level, level);
+    }
+
+    public int getAverage() {
+        return (min + max) / 2;
+    }
+
+    public int getMin() {
+        return min;
+    }
+
+    public int getMax() {
+        return max;
+    }
+
+    @Override
+    public String toString() {
+        return min == max ? Integer.toString(max) : String.format("%d-%d", min, max);
+    }
+
+}

--- a/src/main/java/com/wynntils/core/utils/reflections/ReflectionFields.java
+++ b/src/main/java/com/wynntils/core/utils/reflections/ReflectionFields.java
@@ -12,6 +12,7 @@ import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.inventory.GuiChest;
 import net.minecraft.client.gui.inventory.GuiScreenHorseInventory;
 import net.minecraft.client.model.ModelRenderer;
+import net.minecraft.client.renderer.RenderItem;
 import net.minecraft.entity.Entity;
 import net.minecraft.network.play.client.CPacketClientSettings;
 import net.minecraftforge.fml.common.eventhandler.Event;
@@ -37,7 +38,9 @@ public enum ReflectionFields {
     GuiPlayerTabOverlay_ENTRY_ORDERING(GuiPlayerTabOverlay.class, "ENTRY_ORDERING", "field_175252_a"),
     Minecraft_resourcePackRepository(Minecraft.class, "resourcePackRepository", "field_110448_aq"),
     CPacketClientSettings_chatVisibility(CPacketClientSettings.class, "chatVisibility", "field_149529_c"),
-    ModelRenderer_compiled(ModelRenderer.class, "compiled", "field_78812_q");
+    ModelRenderer_compiled(ModelRenderer.class, "compiled", "field_78812_q"),
+    Minecraft_renderItem(Minecraft.class, "renderItem", "field_175621_X"),
+    RenderItem_itemModelMesher(RenderItem.class, "itemModelMesher", "field_175059_m");
 
     static {
         GuiPlayerTabOverlay_ENTRY_ORDERING.removeFinal();

--- a/src/main/java/com/wynntils/modules/utilities/UtilitiesModule.java
+++ b/src/main/java/com/wynntils/modules/utilities/UtilitiesModule.java
@@ -38,6 +38,7 @@ public class UtilitiesModule extends Module {
         // Inventory Overlays
         registerEvents(new ItemIdentificationOverlay());
         registerEvents(new RarityColorOverlay());
+        registerEvents(new ItemLevelOverlay());
         registerEvents(new SkillPointOverlay());
         registerEvents(new ItemLockOverlay());
         registerEvents(new FavoriteTradesOverlay());

--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -81,7 +81,7 @@ public class UtilitiesConfig extends SettingsClass {
 
     @Setting(displayName = "Show Leaderboard Badges", description = "Should leaderboard players have a badge above their heads?")
     public boolean renderLeaderboardBadges = true;
-    
+
     @Setting(displayName = "Shift-click Accessories", description = "Allow accessories to be shift-clicked on and off?")
     public boolean shiftClickAccessories = true;
 
@@ -183,6 +183,9 @@ public class UtilitiesConfig extends SettingsClass {
 
         @Setting(displayName = "Crafted Item Durability Arc", description = "Should crafted items' durability be shown with an arc?", order = 2)
         public boolean craftedDurabilityBars = true;
+
+        @Setting(displayName = "Show Average Unidentified Level", description = "Should the average level of an unidentified item be shown instead of the entire range?", order = 3)
+        public boolean averageUnidentifiedLevel = true;
 
         @Setting(displayName = "Dungeon Key Specification", description = "Should a letter indicating the destination of dungeon keys be displayed?", order = 8)
         public boolean keySpecification = true;

--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -187,6 +187,9 @@ public class UtilitiesConfig extends SettingsClass {
         @Setting(displayName = "Show Average Unidentified Level", description = "Should the average level of an unidentified item be shown instead of the entire range?", order = 3)
         public boolean averageUnidentifiedLevel = true;
 
+        @Setting(displayName = "Roman Numeral Powder Tier", description = "Should the tier of powders be displayed using roman numerals?", order = 4)
+        public boolean romanNumeralPowderTier = true;
+
         @Setting(displayName = "Dungeon Key Specification", description = "Should a letter indicating the destination of dungeon keys be displayed?", order = 8)
         public boolean keySpecification = true;
 

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemLevelOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemLevelOverlay.java
@@ -1,0 +1,60 @@
+/*
+ *  * Copyright © Wynntils - 2018 - 2020.
+ */
+
+package com.wynntils.modules.utilities.overlays.inventories;
+
+import com.wynntils.core.events.custom.RenderEvent;
+import com.wynntils.core.framework.interfaces.Listener;
+import com.wynntils.core.utils.ItemUtils;
+import com.wynntils.core.utils.StringUtils;
+import com.wynntils.modules.utilities.configs.UtilitiesConfig;
+import net.minecraft.init.Items;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import org.lwjgl.input.Keyboard;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ItemLevelOverlay implements Listener {
+
+    private static final Pattern POWDER_NAME_PATTERN = Pattern.compile("(?:Earth|Thunder|Water|Fire|Air|Blank) Powder (IV|V|VI|I{1,3})");
+    private static final Pattern CRAFTING_LEVEL_PATTERN = Pattern.compile("Crafting Lv\\. Min: ([0-9]+)");
+
+    @SubscribeEvent
+    public void onItemOverlay(RenderEvent.DrawItemOverlay event) {
+        if (!(Keyboard.isKeyDown(Keyboard.KEY_LCONTROL) || Keyboard.isKeyDown(Keyboard.KEY_RCONTROL))) return;
+
+        ItemStack stack = event.getStack();
+        Item item = stack.getItem();
+        String name = stack.getDisplayName();
+
+        // powder tier
+        if (item == Items.DYE || item == Items.GUNPOWDER || item == Items.CLAY_BALL || item == Items.SUGAR) {
+            Matcher powderMatcher = POWDER_NAME_PATTERN.matcher(StringUtils.normalizeBadString(name));
+            if (powderMatcher.find()) {
+                event.setOverlayText(powderMatcher.group(1));
+                return;
+            }
+        }
+
+        String lore = ItemUtils.getStringLore(stack);
+
+        // identifiable item combat level
+        ItemUtils.CombatLevel level = ItemUtils.getLevel(lore);
+        if (level != null) {
+            event.setOverlayText(UtilitiesConfig.Items.INSTANCE.averageUnidentifiedLevel ? level.toString() : Integer.toString(level.getAverage()));
+            return;
+        }
+
+        // ingredient crafting level
+        Matcher craftLevelMatcher = CRAFTING_LEVEL_PATTERN.matcher(lore);
+        if (craftLevelMatcher.find()) {
+            event.setOverlayText(craftLevelMatcher.group(1));
+            return;
+        }
+    }
+
+}

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemLevelOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemLevelOverlay.java
@@ -8,6 +8,7 @@ import com.wynntils.core.events.custom.RenderEvent;
 import com.wynntils.core.framework.interfaces.Listener;
 import com.wynntils.core.utils.ItemUtils;
 import com.wynntils.core.utils.StringUtils;
+import com.wynntils.core.utils.objects.CombatLevel;
 import com.wynntils.modules.utilities.configs.UtilitiesConfig;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
@@ -37,30 +38,30 @@ public class ItemLevelOverlay implements Listener {
             if (powderMatcher.find()) {
                 if (UtilitiesConfig.Items.INSTANCE.romanNumeralPowderTier) {
                     event.setOverlayText(powderMatcher.group(1));
-                } else {
-                    int tier = 0;
-                    switch (powderMatcher.group(1)) {
-                        case "I":
-                            tier = 1;
-                            break;
-                        case "II":
-                            tier = 2;
-                            break;
-                        case "III":
-                            tier = 3;
-                            break;
-                        case "IV":
-                            tier = 4;
-                            break;
-                        case "V":
-                            tier = 5;
-                            break;
-                        case "VI":
-                            tier = 6;
-                            break;
-                    }
-                    event.setOverlayText(Integer.toString(tier));
+                    return;
                 }
+                int tier = 0;
+                switch (powderMatcher.group(1)) {
+                    case "I":
+                        tier = 1;
+                        break;
+                    case "II":
+                        tier = 2;
+                        break;
+                    case "III":
+                        tier = 3;
+                        break;
+                    case "IV":
+                        tier = 4;
+                        break;
+                    case "V":
+                        tier = 5;
+                        break;
+                    case "VI":
+                        tier = 6;
+                        break;
+                }
+                event.setOverlayText(Integer.toString(tier));
                 return;
             }
         }
@@ -68,7 +69,7 @@ public class ItemLevelOverlay implements Listener {
         String lore = ItemUtils.getStringLore(stack);
 
         // identifiable item combat level
-        ItemUtils.CombatLevel level = ItemUtils.getLevel(lore);
+        CombatLevel level = ItemUtils.getLevel(lore);
         if (level != null) {
             event.setOverlayText(UtilitiesConfig.Items.INSTANCE.averageUnidentifiedLevel ? level.toString() : Integer.toString(level.getAverage()));
             return;

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemLevelOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemLevelOverlay.java
@@ -35,7 +35,32 @@ public class ItemLevelOverlay implements Listener {
         if (item == Items.DYE || item == Items.GUNPOWDER || item == Items.CLAY_BALL || item == Items.SUGAR) {
             Matcher powderMatcher = POWDER_NAME_PATTERN.matcher(StringUtils.normalizeBadString(name));
             if (powderMatcher.find()) {
-                event.setOverlayText(powderMatcher.group(1));
+                if (UtilitiesConfig.Items.INSTANCE.romanNumeralPowderTier) {
+                    event.setOverlayText(powderMatcher.group(1));
+                } else {
+                    int tier = 0;
+                    switch (powderMatcher.group(1)) {
+                        case "I":
+                            tier = 1;
+                            break;
+                        case "II":
+                            tier = 2;
+                            break;
+                        case "III":
+                            tier = 3;
+                            break;
+                        case "IV":
+                            tier = 4;
+                            break;
+                        case "V":
+                            tier = 5;
+                            break;
+                        case "VI":
+                            tier = 6;
+                            break;
+                    }
+                    event.setOverlayText(Integer.toString(tier));
+                }
                 return;
             }
         }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/RarityColorOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/RarityColorOverlay.java
@@ -12,6 +12,7 @@ import com.wynntils.core.framework.rendering.colors.CustomColor;
 import com.wynntils.core.framework.rendering.textures.Textures;
 import com.wynntils.core.utils.ItemUtils;
 import com.wynntils.core.utils.StringUtils;
+import com.wynntils.core.utils.objects.CombatLevel;
 import com.wynntils.modules.utilities.configs.UtilitiesConfig;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.client.renderer.BufferBuilder;
@@ -205,7 +206,7 @@ public class RarityColorOverlay implements Listener {
         Tessellator.getInstance().draw();
     }
 
-    private static void drawLevelArc(GuiContainer guiContainer, Slot s, ItemUtils.CombatLevel level) {
+    private static void drawLevelArc(GuiContainer guiContainer, Slot s, CombatLevel level) {
         if (!UtilitiesConfig.Items.INSTANCE.itemLevelArc) return;
         if (level == null) return;
 

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/RarityColorOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/RarityColorOverlay.java
@@ -26,7 +26,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
-import org.lwjgl.input.Keyboard;
 import org.lwjgl.opengl.GL11;
 
 import java.util.HashMap;
@@ -47,33 +46,6 @@ public class RarityColorOverlay implements Listener {
     public static final float MAX_CIRCLE_STEPS = 16.0f;
     private static final Pattern DURABILITY_PATTERN = Pattern.compile("\\[([0-9]+)/([0-9]+) Durability\\]");
     private static String professionFilter = "-";
-
-    @SubscribeEvent
-    public void onChestClosed(GuiOverlapEvent.ChestOverlap.GuiClosed e) {
-        resetCount(e.getGui());
-    }
-
-    @SubscribeEvent
-    public void onHorseClosed(GuiOverlapEvent.HorseOverlap.GuiClosed e) {
-        resetCount(e.getGui());
-    }
-
-    @SubscribeEvent
-    public void onInventoryClosed(GuiOverlapEvent.InventoryOverlap.GuiClosed e) {
-        resetCount(e.getGui());
-    }
-
-    private void resetCount(GuiContainer guiContainer) {
-        for (Slot s : guiContainer.inventorySlots.inventorySlots) {
-            ItemStack is = s.getStack();
-            String lore = ItemUtils.getStringLore(is);
-            int level = getLevel(lore);
-
-            if (level != -1) {
-                is.setCount(1);
-            }
-        }
-    }
 
     @SubscribeEvent
     public void onChestInventory(GuiOverlapEvent.ChestOverlap.DrawGuiContainerBackgroundLayer e) {
@@ -129,23 +101,10 @@ public class RarityColorOverlay implements Listener {
         String lore = ItemUtils.getStringLore(is);
         String name = StringUtils.normalizeBadString(is.getDisplayName());
 
-        CustomColor colour = getHighlightColor(s, is, lore, name, isChest, guiContainer.getSlotUnderMouse());
-        int level = getLevel(lore);
-        float durability = getDurability(lore);
-
-        if (level != -1) {
-            if (Keyboard.isKeyDown(Keyboard.KEY_LCONTROL) || Keyboard.isKeyDown(Keyboard.KEY_RCONTROL)) {
-                is.setCount(level);
-            } else {
-                is.setCount(1);
-            }
-        }
-
         // start rendering
-        drawLevelArc(guiContainer, s, level);
-        drawHighlightColor(guiContainer, s, colour);
-        drawDurabilityArc(guiContainer, s, durability);
-
+        drawLevelArc(guiContainer, s, ItemUtils.getLevel(lore));
+        drawHighlightColor(guiContainer, s, getHighlightColor(s, is, lore, name, isChest, guiContainer.getSlotUnderMouse()));
+        drawDurabilityArc(guiContainer, s, getDurability(lore));
     }
 
     private static CustomColor getHighlightColor(Slot s, ItemStack is, String lore, String name, boolean isChest, Slot slotUnderMouse) {
@@ -200,23 +159,6 @@ public class RarityColorOverlay implements Listener {
         }
     }
 
-    private static int getLevel(String lore) {
-        Pattern p = Pattern.compile("Combat Lv. Min: ([0-9]+)");
-        Matcher m = p.matcher(lore);
-        if (m.find()) {
-            return Integer.parseInt(m.group(1));
-        } else {
-            Pattern p2 = Pattern.compile("Lv. Range: " + TextFormatting.WHITE.toString() + "([0-9]+)-([0-9]+)");
-            Matcher m2 = p2.matcher(lore);
-            if (m2.find()) {
-                int lowLevel =  Integer.parseInt(m2.group(1));
-                int highLevel =  Integer.parseInt(m2.group(2));
-                return (lowLevel + highLevel) / 2;
-            }
-        }
-        return -1;
-    }
-
     private static float getDurability(String lore) {
     	Matcher m = DURABILITY_PATTERN.matcher(lore);
     	if(m.find()) {
@@ -263,9 +205,9 @@ public class RarityColorOverlay implements Listener {
         Tessellator.getInstance().draw();
     }
 
-    private static void drawLevelArc(GuiContainer guiContainer, Slot s, int level) {
+    private static void drawLevelArc(GuiContainer guiContainer, Slot s, ItemUtils.CombatLevel level) {
         if (!UtilitiesConfig.Items.INSTANCE.itemLevelArc) return;
-        if (level == -1) return;
+        if (level == null) return;
 
         int x = guiContainer.getGuiLeft() + s.xPos;
         int y = guiContainer.getGuiTop() + s.yPos;
@@ -279,7 +221,7 @@ public class RarityColorOverlay implements Listener {
 
         Tessellator tessellator = Tessellator.getInstance();
         BufferBuilder bufferbuilder = tessellator.getBuffer();
-        float arcFill = (level / MAX_LEVEL);
+        float arcFill = (level.getAverage() / MAX_LEVEL);
         drawArc(bufferbuilder, x, y, arcFill, 8, 0, 0, 0, 120);
 
         GlStateManager.disableBlend();


### PR DESCRIPTION
Currently, item level overlays are implemented with this hacky thing in `RarityColorOverlay` that just modifies stack sizes for identifiable items when the ctrl key is held. Not only is this a rather ugly implementation, but it also precludes the ability to show an overlay over stackable items, such as ingredients or powders, as it relies on the assumption that the item is unstackable.

This PR remedies this by tossing out the entire stack size trick entirely. Instead, it creates a class `WynnRenderItem extends RenderItem`, then uses reflection to inject an instance of this into `Minecraft#renderItem`. This means that all `renderItemOverlayIntoGUI` calls will go through `WynnRenderItem`, giving us the opportunity to intercept them and do our own rendering instead.

The solution for specifying the overlay text that I came up with is to create a new event `RenderEvent.DrawItemOverlay` which any interested party can listen for and use to modify the text that renders in the item overlay. Then, I've created a handler class `ItemLevelOverlay` in the utilities module that replicates the original item level overlay behaviour using the new event-based system. The exact features are:
* Combat level overlays for identified items, exactly as in the old implementation
* Combat level overlays for unidentified items, with a config option for toggling between displaying the entire level range or display only the average level
* Crafting level overlays for crafting ingredients
* Powder tier overlays, with a config option for toggling between roman and arabic numerals

![](https://media.discordapp.net/attachments/424990456435310602/789360021347106826/unknown.png?width=352&height=442)