### PR TITLE
Add conflict contexts for keybindings

### DIFF
--- a/src/main/java/com/wynntils/core/framework/enums/wynntils/WynntilsConflictContext.java
+++ b/src/main/java/com/wynntils/core/framework/enums/wynntils/WynntilsConflictContext.java
@@ -11,6 +11,10 @@ import net.minecraftforge.client.settings.KeyConflictContext;
 
 public enum WynntilsConflictContext implements IKeyConflictContext {
 
+    /**
+     * Context for keybindings related to player movement. Allows for movement inputs to register while in certain
+     * non-movement-obstructing GUIs.
+     */
     ALLOW_MOVEMENTS {
         @Override
         public boolean isActive() {
@@ -23,6 +27,11 @@ public enum WynntilsConflictContext implements IKeyConflictContext {
         }
     },
 
+    /**
+     * Context for keybindings that are always active, in some sense, but that are allowed to conflict with other
+     * keybindings. For example, the "item level overlay" keybinding is ambient, since it functions independently of
+     * any other context, and therefore is okay to bind to CTRL, which would normally conflict with sprint.
+     */
     AMBIENT {
         @Override
         public boolean isActive() {

--- a/src/main/java/com/wynntils/core/framework/enums/wynntils/WynntilsConflictContext.java
+++ b/src/main/java/com/wynntils/core/framework/enums/wynntils/WynntilsConflictContext.java
@@ -21,6 +21,18 @@ public enum WynntilsConflictContext implements IKeyConflictContext {
         public boolean conflicts(IKeyConflictContext other) {
             return this == other || other == KeyConflictContext.IN_GAME;
         }
+    },
+
+    AMBIENT {
+        @Override
+        public boolean isActive() {
+            return true;
+        }
+
+        @Override
+        public boolean conflicts(IKeyConflictContext other) {
+            return this == other;
+        }
     }
 
 }

--- a/src/main/java/com/wynntils/core/framework/instances/KeyHolder.java
+++ b/src/main/java/com/wynntils/core/framework/instances/KeyHolder.java
@@ -5,7 +5,9 @@
 package com.wynntils.core.framework.instances;
 
 import net.minecraft.client.settings.KeyBinding;
+import net.minecraftforge.client.settings.IKeyConflictContext;
 import net.minecraftforge.fml.client.registry.ClientRegistry;
+import org.lwjgl.input.Keyboard;
 
 public class KeyHolder {
 
@@ -15,17 +17,18 @@ public class KeyHolder {
 
     /**
      * @param name The key name, will be displayed at configurations
-     * @param key The LWGL key value {@see Keyboard}
+     * @param key The LWJGL key value {@see Keyboard}
      * @param tab The configuration tab that will be used (usually Wynntils)
-     * @param press If true pressing the key will only trigger onAction once, while fale will continously call it
+     * @param conflictCtx The conflict context that the key belongs to
+     * @param press If true pressing the key will only trigger onAction once, while false will continuously call it
      *              for the time the key is still down
      * @param onPress Will be executed when the key press is detected
      */
-    public KeyHolder(String name, int key, String tab, boolean press, Runnable onPress) {
+    public KeyHolder(String name, int key, String tab, IKeyConflictContext conflictCtx, boolean press, Runnable onPress) {
         this.onPress = onPress;
         this.press = press;
 
-        keyBinding = new KeyBinding(name, key, tab);
+        keyBinding = conflictCtx != null ? new KeyBinding(name, conflictCtx, key, tab) : new KeyBinding(name, key, tab);
         ClientRegistry.registerKeyBinding(keyBinding);
     }
 
@@ -51,6 +54,10 @@ public class KeyHolder {
 
     public int getKey() {
         return keyBinding.getKeyCode();
+    }
+
+    public boolean isKeyDown() {
+        return Keyboard.isKeyDown(getKey());
     }
 
 }

--- a/src/main/java/com/wynntils/core/framework/instances/Module.java
+++ b/src/main/java/com/wynntils/core/framework/instances/Module.java
@@ -13,6 +13,7 @@ import com.wynntils.core.framework.settings.instances.SettingsHolder;
 import net.minecraft.client.Minecraft;
 import net.minecraft.command.ICommand;
 import net.minecraftforge.client.ClientCommandHandler;
+import net.minecraftforge.client.settings.IKeyConflictContext;
 import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import org.apache.logging.log4j.Logger;
@@ -103,14 +104,29 @@ public abstract class Module {
      * Registers a new Keybind linked to the module
      *
      * @param name The key name, will be displayed at configurations
-     * @param key The LWGL key value {@see Keyboard}
+     * @param key The LWJGL key value {@see Keyboard}
      * @param tab The configuration tab that will be used (usually Wynntils)
-     * @param press If true pressing the key will only trigger onAction once, while fale will continously call it
+     * @param conflictCtx The conflict context that the key belongs to
+     * @param press If true pressing the key will only trigger onAction once, while false will continuously call it
+     *              for the time the key is still down
+     * @param onPress Will be executed when the key press is detected
+     */
+    public KeyHolder registerKeyBinding(String name, int key, String tab, IKeyConflictContext conflictCtx, boolean press, Runnable onPress) {
+        return FrameworkManager.registerKeyBinding(this, new KeyHolder(name, key, tab, conflictCtx, press, onPress));
+    }
+
+    /**
+     * Registers a new Keybind linked to the module, with the default universal conflict context
+     *
+     * @param name The key name, will be displayed at configurations
+     * @param key The LWJGL key value {@see Keyboard}
+     * @param tab The configuration tab that will be used (usually Wynntils)
+     * @param press If true pressing the key will only trigger onAction once, while false will continuously call it
      *              for the time the key is still down
      * @param onPress Will be executed when the key press is detected
      */
     public KeyHolder registerKeyBinding(String name, int key, String tab, boolean press, Runnable onPress) {
-        return FrameworkManager.registerKeyBinding(this, new KeyHolder(name, key, tab, press, onPress));
+        return registerKeyBinding(name, key, tab, null, press, onPress);
     }
 
     /**

--- a/src/main/java/com/wynntils/modules/map/MapModule.java
+++ b/src/main/java/com/wynntils/modules/map/MapModule.java
@@ -22,6 +22,7 @@ import com.wynntils.modules.map.overlays.ui.WaypointCreationMenu;
 import com.wynntils.webapi.WebManager;
 import com.wynntils.webapi.WebReader;
 import net.minecraft.client.Minecraft;
+import net.minecraftforge.client.settings.KeyConflictContext;
 import org.lwjgl.input.Keyboard;
 
 @ModuleInfo(name = "map", displayName = "Map")
@@ -55,12 +56,12 @@ public class MapModule extends Module {
         registerCommand(new CommandLootRun());
         registerCommand(new CommandLocate());
 
-        registerKeyBinding("New Waypoint", Keyboard.KEY_B, "Wynntils", true, () -> {
+        registerKeyBinding("New Waypoint", Keyboard.KEY_B, "Wynntils", KeyConflictContext.IN_GAME, true, () -> {
             if (Reference.onWorld)
                 Minecraft.getMinecraft().displayGuiScreen(new WaypointCreationMenu(null));
         });
 
-        mapKey = registerKeyBinding("Open Map", Keyboard.KEY_M, "Wynntils", true, () -> {
+        mapKey = registerKeyBinding("Open Map", Keyboard.KEY_M, "Wynntils", KeyConflictContext.IN_GAME, true, () -> {
             if (Reference.onWorld) {
                 if (WebManager.getApiUrls() == null) {
                     WebManager.tryReloadApiUrls(true);

--- a/src/main/java/com/wynntils/modules/questbook/QuestBookModule.java
+++ b/src/main/java/com/wynntils/modules/questbook/QuestBookModule.java
@@ -13,6 +13,7 @@ import com.wynntils.modules.questbook.enums.QuestBookPages;
 import com.wynntils.modules.questbook.events.ClientEvents;
 import com.wynntils.modules.questbook.managers.QuestManager;
 import com.wynntils.modules.questbook.overlays.hud.TrackedQuestOverlay;
+import net.minecraftforge.client.settings.KeyConflictContext;
 import org.lwjgl.input.Keyboard;
 
 @ModuleInfo(name = "quest_book", displayName = "Quest Book")
@@ -26,11 +27,11 @@ public class QuestBookModule extends Module {
 
         registerCommand(new CommandExportDiscoveries());
 
-        registerKeyBinding("Open Quest Book", Keyboard.KEY_K, "Wynntils", true, () -> QuestBookPages.QUESTS.getPage().open(true));
-        registerKeyBinding("Open Discoveries", Keyboard.KEY_U, "Wynntils", true, () -> QuestBookPages.DISCOVERIES.getPage().open(true));
-        registerKeyBinding("Open Item Guide", Keyboard.KEY_NONE, "Wynntils", true, () -> QuestBookPages.ITEMGUIDE.getPage().open(true));
-        registerKeyBinding("Open HUD configuration", Keyboard.KEY_NONE, "Wynntils", true, () -> QuestBookPages.HUDCONFIG.getPage().open(true));
-        registerKeyBinding("Open Menu", Keyboard.KEY_I, "Wynntils", true, () -> {
+        registerKeyBinding("Open Quest Book", Keyboard.KEY_K, "Wynntils", KeyConflictContext.IN_GAME, true, () -> QuestBookPages.QUESTS.getPage().open(true));
+        registerKeyBinding("Open Discoveries", Keyboard.KEY_U, "Wynntils", KeyConflictContext.IN_GAME, true, () -> QuestBookPages.DISCOVERIES.getPage().open(true));
+        registerKeyBinding("Open Item Guide", Keyboard.KEY_NONE, "Wynntils", KeyConflictContext.IN_GAME, true, () -> QuestBookPages.ITEMGUIDE.getPage().open(true));
+        registerKeyBinding("Open HUD configuration", Keyboard.KEY_NONE, "Wynntils", KeyConflictContext.IN_GAME, true, () -> QuestBookPages.HUDCONFIG.getPage().open(true));
+        registerKeyBinding("Open Menu", Keyboard.KEY_I, "Wynntils", KeyConflictContext.IN_GAME, true, () -> {
             QuestBookPages.MAIN.getPage().open(true);
             QuestManager.readQuestBook();
         });

--- a/src/main/java/com/wynntils/modules/utilities/managers/KeyManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/KeyManager.java
@@ -6,6 +6,7 @@ package com.wynntils.modules.utilities.managers;
 
 import com.wynntils.ModCore;
 import com.wynntils.Reference;
+import com.wynntils.core.framework.enums.wynntils.WynntilsConflictContext;
 import com.wynntils.core.framework.instances.KeyHolder;
 import com.wynntils.core.framework.settings.ui.SettingsUI;
 import com.wynntils.modules.core.CoreModule;
@@ -19,6 +20,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.inventory.ClickType;
 import net.minecraft.network.play.client.CPacketClickWindow;
+import net.minecraftforge.client.settings.KeyConflictContext;
 import org.lwjgl.input.Keyboard;
 
 public class KeyManager {
@@ -32,9 +34,10 @@ public class KeyManager {
     private static KeyHolder zoomOutKey;
     private static KeyHolder stopwatchKey;
     private static KeyHolder itemScreenshotKey;
+    private static KeyHolder showLevelOverlayKey;
 
     public static void registerKeys() {
-        UtilitiesModule.getModule().registerKeyBinding("Gammabright", Keyboard.KEY_G, "Wynntils", true, () -> {
+        UtilitiesModule.getModule().registerKeyBinding("Gammabright", Keyboard.KEY_G, "Wynntils", KeyConflictContext.IN_GAME, true, () -> {
             if (ModCore.mc().gameSettings.gammaSetting < 1000) {
                 lastGamma = ModCore.mc().gameSettings.gammaSetting;
                 ModCore.mc().gameSettings.gammaSetting = 1000;
@@ -46,31 +49,31 @@ public class KeyManager {
 
         checkForUpdatesKey = CoreModule.getModule().registerKeyBinding("Check for Updates", Keyboard.KEY_L, "Wynntils", true, WebManager::checkForUpdates);
 
-        CoreModule.getModule().registerKeyBinding("Open Settings", Keyboard.KEY_P, "Wynntils", true, () -> ModCore.mc().displayGuiScreen(SettingsUI.getInstance(ModCore.mc().currentScreen)));
+        CoreModule.getModule().registerKeyBinding("Open Settings", Keyboard.KEY_P, "Wynntils", KeyConflictContext.IN_GAME, true, () -> ModCore.mc().displayGuiScreen(SettingsUI.getInstance(ModCore.mc().currentScreen)));
 
-        lockInventoryKey = UtilitiesModule.getModule().registerKeyBinding("Lock Slot", Keyboard.KEY_H, "Wynntils", true, () -> {});
-        favoriteTradeKey = UtilitiesModule.getModule().registerKeyBinding("Favorite Trade", Keyboard.KEY_F, "Wynntils", true, () -> {});
+        lockInventoryKey = UtilitiesModule.getModule().registerKeyBinding("Lock Slot", Keyboard.KEY_H, "Wynntils", KeyConflictContext.GUI, true, () -> {});
+        favoriteTradeKey = UtilitiesModule.getModule().registerKeyBinding("Favorite Trade", Keyboard.KEY_F, "Wynntils", KeyConflictContext.GUI, true, () -> {});
 
-         UtilitiesModule.getModule().registerKeyBinding("Toggle AFK Protection", Keyboard.KEY_N, "Wynntils", true, ClientEvents::toggleAfkProtection);
+        UtilitiesModule.getModule().registerKeyBinding("Toggle AFK Protection", Keyboard.KEY_N, "Wynntils", KeyConflictContext.IN_GAME, true, ClientEvents::toggleAfkProtection);
 
-        zoomInKey = CoreModule.getModule().registerKeyBinding("Zoom In", Keyboard.KEY_EQUALS, "Wynntils", false, () -> MiniMapOverlay.zoomBy(+1));
+        zoomInKey = CoreModule.getModule().registerKeyBinding("Zoom In", Keyboard.KEY_EQUALS, "Wynntils", KeyConflictContext.IN_GAME, false, () -> MiniMapOverlay.zoomBy(+1));
 
-        zoomOutKey = CoreModule.getModule().registerKeyBinding("Zoom Out", Keyboard.KEY_MINUS, "Wynntils", false, () -> MiniMapOverlay.zoomBy(-1));
+        zoomOutKey = CoreModule.getModule().registerKeyBinding("Zoom Out", Keyboard.KEY_MINUS, "Wynntils", KeyConflictContext.IN_GAME, false, () -> MiniMapOverlay.zoomBy(-1));
 
-        CoreModule.getModule().registerKeyBinding("Cast First Spell", Keyboard.KEY_Z, "Wynntils", true, QuickCastManager::castFirstSpell);
-        CoreModule.getModule().registerKeyBinding("Cast Second Spell", Keyboard.KEY_X, "Wynntils", true, QuickCastManager::castSecondSpell);
-        CoreModule.getModule().registerKeyBinding("Cast Third Spell", Keyboard.KEY_C, "Wynntils", true, QuickCastManager::castThirdSpell);
-        CoreModule.getModule().registerKeyBinding("Cast Fourth Spell", Keyboard.KEY_V, "Wynntils", true, QuickCastManager::castFourthSpell);
+        CoreModule.getModule().registerKeyBinding("Cast First Spell", Keyboard.KEY_Z, "Wynntils", KeyConflictContext.IN_GAME, true, QuickCastManager::castFirstSpell);
+        CoreModule.getModule().registerKeyBinding("Cast Second Spell", Keyboard.KEY_X, "Wynntils", KeyConflictContext.IN_GAME, true, QuickCastManager::castSecondSpell);
+        CoreModule.getModule().registerKeyBinding("Cast Third Spell", Keyboard.KEY_C, "Wynntils", KeyConflictContext.IN_GAME, true, QuickCastManager::castThirdSpell);
+        CoreModule.getModule().registerKeyBinding("Cast Fourth Spell", Keyboard.KEY_V, "Wynntils", KeyConflictContext.IN_GAME, true, QuickCastManager::castFourthSpell);
 
-        CoreModule.getModule().registerKeyBinding("Mount Horse", Keyboard.KEY_Y, "Wynntils", true, MountHorseManager::mountHorseAndShowMessage);
+        CoreModule.getModule().registerKeyBinding("Mount Horse", Keyboard.KEY_Y, "Wynntils", KeyConflictContext.IN_GAME, true, MountHorseManager::mountHorseAndShowMessage);
 
-        CoreModule.getModule().registerKeyBinding("Mob Totem Menu", Keyboard.KEY_J, "Wynntils", true, () -> {
+        CoreModule.getModule().registerKeyBinding("Mob Totem Menu", Keyboard.KEY_J, "Wynntils", KeyConflictContext.IN_GAME, true, () -> {
             if (!Reference.onWorld) return;
 
             Minecraft.getMinecraft().player.sendChatMessage("/totem");
         });
 
-        CoreModule.getModule().registerKeyBinding("Open Ingredient Pouch", Keyboard.KEY_O, "Wynntils", true, () -> {
+        CoreModule.getModule().registerKeyBinding("Open Ingredient Pouch", Keyboard.KEY_O, "Wynntils", KeyConflictContext.IN_GAME, true, () -> {
             if (!Reference.onWorld) return;
 
             EntityPlayerSP player = Minecraft.getMinecraft().player;
@@ -81,12 +84,14 @@ public class KeyManager {
             ));
         });
 
-        stopwatchKey = CoreModule.getModule().registerKeyBinding("Start/Stop Stopwatch", Keyboard.KEY_NUMPAD5, "Wynntils", true, StopWatchOverlay::start);
+        stopwatchKey = CoreModule.getModule().registerKeyBinding("Start/Stop Stopwatch", Keyboard.KEY_NUMPAD5, "Wynntils", KeyConflictContext.IN_GAME, true, StopWatchOverlay::start);
 
-        itemScreenshotKey = CoreModule.getModule().registerKeyBinding("Screenshot Current Item", Keyboard.KEY_F4, "Wynntils", true, () -> {});
-      
+        itemScreenshotKey = CoreModule.getModule().registerKeyBinding("Screenshot Current Item", Keyboard.KEY_F4, "Wynntils", KeyConflictContext.GUI, true, () -> {});
+
         // -98 for middle click
-        CoreModule.getModule().registerKeyBinding("View Player's Gear", -98, "Wynntils", true, GearViewerUI::openGearViewer);
+        CoreModule.getModule().registerKeyBinding("View Player's Gear", -98, "Wynntils", KeyConflictContext.IN_GAME, true, GearViewerUI::openGearViewer);
+
+        showLevelOverlayKey = UtilitiesModule.getModule().registerKeyBinding("Show Item Level Overlay", Keyboard.KEY_LCONTROL, "Wynntils", WynntilsConflictContext.AMBIENT, true, () -> {});
     }
 
     public static KeyHolder getFavoriteTradeKey() {
@@ -112,9 +117,13 @@ public class KeyManager {
     public static KeyHolder getStopwatchKey() {
         return stopwatchKey;
     }
-    
+
     public static KeyHolder getItemScreenshotKey() {
         return itemScreenshotKey;
+    }
+
+    public static KeyHolder getShowLevelOverlayKey() {
+        return showLevelOverlayKey;
     }
 
 }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemLevelOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemLevelOverlay.java
@@ -10,6 +10,7 @@ import com.wynntils.core.utils.ItemUtils;
 import com.wynntils.core.utils.StringUtils;
 import com.wynntils.core.utils.objects.CombatLevel;
 import com.wynntils.modules.utilities.configs.UtilitiesConfig;
+import com.wynntils.modules.utilities.managers.KeyManager;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -26,7 +27,7 @@ public class ItemLevelOverlay implements Listener {
 
     @SubscribeEvent
     public void onItemOverlay(RenderEvent.DrawItemOverlay event) {
-        if (!(Keyboard.isKeyDown(Keyboard.KEY_LCONTROL) || Keyboard.isKeyDown(Keyboard.KEY_RCONTROL))) return;
+        if (!KeyManager.getShowLevelOverlayKey().isKeyDown()) return;
 
         ItemStack stack = event.getStack();
         Item item = stack.getItem();


### PR DESCRIPTION
Wynntils keybindings don't have conflict contexts, so they're all placed in the universal conflict context. This PR remedies this by assigning reasonable conflict contexts to most Wynntils keybindings. Additionally, it adds a new keybinding for the item level overlay.