### PR TITLE
Improvements to level overlays

### DIFF
--- a/src/main/java/com/wynntils/core/utils/ItemUtils.java
+++ b/src/main/java/com/wynntils/core/utils/ItemUtils.java
@@ -4,7 +4,7 @@
 
 package com.wynntils.core.utils;
 
-import com.wynntils.core.utils.objects.CombatLevel;
+import com.wynntils.core.utils.objects.IntRange;
 import com.wynntils.core.utils.reference.EmeraldSymbols;
 import com.wynntils.webapi.WebManager;
 import com.wynntils.webapi.profiles.item.enums.ItemType;
@@ -27,8 +27,8 @@ import java.util.regex.Pattern;
 
 public class ItemUtils {
 
-    private static final Pattern COMBAT_LEVEL_PATTERN = Pattern.compile("Combat Lv\\. Min: ([0-9]+)");
-    private static final Pattern COMBAT_LEVEL_RANGE_PATTERN = Pattern.compile("Lv\\. Range: " + TextFormatting.WHITE.toString() + "([0-9]+)-([0-9]+)");
+    private static final Pattern LEVEL_PATTERN = Pattern.compile("(?:Combat|Crafting|Mining|Woodcutting|Farming|Fishing) Lv\\. Min: ([0-9]+)");
+    private static final Pattern LEVEL_RANGE_PATTERN = Pattern.compile("Lv\\. Range: " + TextFormatting.WHITE.toString() + "([0-9]+)-([0-9]+)");
 
     /**
      * Get the lore NBT tag from an item
@@ -190,11 +190,11 @@ public class ItemUtils {
         return desc.toString();
     }
 
-    public static CombatLevel getLevel(String lore) {
-        Matcher m = COMBAT_LEVEL_PATTERN.matcher(lore);
-        if (m.find()) return new CombatLevel(Integer.parseInt(m.group(1)));
-        m = COMBAT_LEVEL_RANGE_PATTERN.matcher(lore);
-        if (m.find()) return new CombatLevel(Integer.parseInt(m.group(1)), Integer.parseInt(m.group(2)));
+    public static IntRange getLevel(String lore) {
+        Matcher m = LEVEL_PATTERN.matcher(lore);
+        if (m.find()) return new IntRange(Integer.parseInt(m.group(1)));
+        m = LEVEL_RANGE_PATTERN.matcher(lore);
+        if (m.find()) return new IntRange(Integer.parseInt(m.group(1)), Integer.parseInt(m.group(2)));
         return null;
     }
 

--- a/src/main/java/com/wynntils/core/utils/objects/IntRange.java
+++ b/src/main/java/com/wynntils/core/utils/objects/IntRange.java
@@ -4,16 +4,16 @@
 
 package com.wynntils.core.utils.objects;
 
-public class CombatLevel {
+public class IntRange {
 
     private final int min, max;
 
-    public CombatLevel(int min, int max) {
+    public IntRange(int min, int max) {
         this.min = min;
         this.max = max;
     }
 
-    public CombatLevel(int level) {
+    public IntRange(int level) {
         this(level, level);
     }
 

--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -8,16 +8,13 @@ import com.wynntils.core.framework.rendering.colors.CustomColor;
 import com.wynntils.core.framework.settings.annotations.Setting;
 import com.wynntils.core.framework.settings.annotations.SettingsInfo;
 import com.wynntils.core.framework.settings.instances.SettingsClass;
-import com.wynntils.core.utils.objects.Pair;
 import com.wynntils.modules.utilities.events.ServerEvents;
 import com.wynntils.modules.utilities.instances.SkillPointAllocation;
 import com.wynntils.modules.utilities.managers.WindowIconManager;
 import com.wynntils.webapi.WebManager;
 import com.wynntils.webapi.profiles.item.ItemProfile;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -196,6 +193,9 @@ public class UtilitiesConfig extends SettingsClass {
 
         @Setting(displayName = "Roman Numeral Powder Tier", description = "Should the tier of powders be displayed using roman numerals?", order = 4)
         public boolean romanNumeralPowderTier = true;
+
+        @Setting(displayName = "Item Levels Outside GUIs", description = "Should the item level overlay key be enabled even when no GUI is open?", order = 5)
+        public boolean itemLevelOverlayOutsideGui = false;
 
         @Setting(displayName = "Dungeon Key Specification", description = "Should a letter indicating the destination of dungeon keys be displayed?", order = 8)
         public boolean keySpecification = true;

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemLevelOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemLevelOverlay.java
@@ -8,7 +8,7 @@ import com.wynntils.core.events.custom.RenderEvent;
 import com.wynntils.core.framework.interfaces.Listener;
 import com.wynntils.core.utils.ItemUtils;
 import com.wynntils.core.utils.StringUtils;
-import com.wynntils.core.utils.objects.CombatLevel;
+import com.wynntils.core.utils.objects.IntRange;
 import com.wynntils.modules.utilities.configs.UtilitiesConfig;
 import com.wynntils.modules.utilities.managers.KeyManager;
 import net.minecraft.client.Minecraft;
@@ -23,7 +23,6 @@ import java.util.regex.Pattern;
 public class ItemLevelOverlay implements Listener {
 
     private static final Pattern POWDER_NAME_PATTERN = Pattern.compile("(?:Earth|Thunder|Water|Fire|Air|Blank) Powder (IV|V|VI|I{1,3})");
-    private static final Pattern CRAFTING_LEVEL_PATTERN = Pattern.compile("Crafting Lv\\. Min: ([0-9]+)");
 
     @SubscribeEvent
     public void onItemOverlay(RenderEvent.DrawItemOverlay event) {
@@ -70,17 +69,10 @@ public class ItemLevelOverlay implements Listener {
 
         String lore = ItemUtils.getStringLore(stack);
 
-        // identifiable item combat level
-        CombatLevel level = ItemUtils.getLevel(lore);
+        // item level
+        IntRange level = ItemUtils.getLevel(lore);
         if (level != null) {
             event.setOverlayText(UtilitiesConfig.Items.INSTANCE.averageUnidentifiedLevel ? level.toString() : Integer.toString(level.getAverage()));
-            return;
-        }
-
-        // ingredient crafting level
-        Matcher craftLevelMatcher = CRAFTING_LEVEL_PATTERN.matcher(lore);
-        if (craftLevelMatcher.find()) {
-            event.setOverlayText(craftLevelMatcher.group(1));
             return;
         }
     }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemLevelOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemLevelOverlay.java
@@ -11,11 +11,11 @@ import com.wynntils.core.utils.StringUtils;
 import com.wynntils.core.utils.objects.CombatLevel;
 import com.wynntils.modules.utilities.configs.UtilitiesConfig;
 import com.wynntils.modules.utilities.managers.KeyManager;
+import net.minecraft.client.Minecraft;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
-import org.lwjgl.input.Keyboard;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -27,6 +27,7 @@ public class ItemLevelOverlay implements Listener {
 
     @SubscribeEvent
     public void onItemOverlay(RenderEvent.DrawItemOverlay event) {
+        if (!UtilitiesConfig.Items.INSTANCE.itemLevelOverlayOutsideGui && Minecraft.getMinecraft().currentScreen == null) return;
         if (!KeyManager.getShowLevelOverlayKey().isKeyDown()) return;
 
         ItemStack stack = event.getStack();

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/RarityColorOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/RarityColorOverlay.java
@@ -12,7 +12,7 @@ import com.wynntils.core.framework.rendering.colors.CustomColor;
 import com.wynntils.core.framework.rendering.textures.Textures;
 import com.wynntils.core.utils.ItemUtils;
 import com.wynntils.core.utils.StringUtils;
-import com.wynntils.core.utils.objects.CombatLevel;
+import com.wynntils.core.utils.objects.IntRange;
 import com.wynntils.modules.utilities.configs.UtilitiesConfig;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.client.renderer.BufferBuilder;
@@ -206,7 +206,7 @@ public class RarityColorOverlay implements Listener {
         Tessellator.getInstance().draw();
     }
 
-    private static void drawLevelArc(GuiContainer guiContainer, Slot s, CombatLevel level) {
+    private static void drawLevelArc(GuiContainer guiContainer, Slot s, IntRange level) {
         if (!UtilitiesConfig.Items.INSTANCE.itemLevelArc) return;
         if (level == null) return;
 


### PR DESCRIPTION
Some small improvements to level overlays (and level arcs, by extension):
* Level overlays can now be disabled outside GUIs using a config option, which renders the corresponding keybind inert when a GUI is not open.
* Level overlays (and also level arcs) now display for most items related to professions, including raw materials and gathering tools.