### PR TITLE
General improvements and bug fixes

### DIFF
--- a/src/main/java/com/wynntils/modules/chat/overlays/gui/ChatGUI.java
+++ b/src/main/java/com/wynntils/modules/chat/overlays/gui/ChatGUI.java
@@ -138,16 +138,16 @@ public class ChatGUI extends GuiChat {
             this.inputField.drawTextBox();
             ITextComponent itextcomponent = this.mc.ingameGUI.getChatGUI().getChatComponent(Mouse.getX(), Mouse.getY());
 
-            if (itextcomponent != null && itextcomponent.getStyle().getHoverEvent() != null) {
-                this.handleComponentHover(itextcomponent, mouseX, mouseY);
-            }
-
             for (int i = 0; i < this.buttonList.size(); ++i) {
                 ((GuiButton) this.buttonList.get(i)).drawButton(this.mc, mouseX, mouseY, partialTicks);
             }
 
             for (int j = 0; j < this.labelList.size(); ++j) {
                 ((GuiLabel) this.labelList.get(j)).drawLabel(this.mc, mouseX, mouseY);
+            }
+            
+            if (itextcomponent != null && itextcomponent.getStyle().getHoverEvent() != null) {
+                this.handleComponentHover(itextcomponent, mouseX, mouseY);
             }
         } else {
             super.drawScreen(mouseX, mouseY, partialTicks);

--- a/src/main/java/com/wynntils/modules/core/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/core/events/ClientEvents.java
@@ -27,6 +27,8 @@ import com.wynntils.modules.core.overlays.inventories.ChestReplacer;
 import com.wynntils.modules.core.overlays.inventories.HorseReplacer;
 import com.wynntils.modules.core.overlays.inventories.IngameMenuReplacer;
 import com.wynntils.modules.core.overlays.inventories.InventoryReplacer;
+import com.wynntils.modules.utilities.UtilitiesModule;
+
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
@@ -215,7 +217,7 @@ public class ClientEvents implements Listener {
         if (!Reference.onServer || e.getPacket().getType() != ChatType.GAME_INFO) return;
 
         PlayerInfo.getPlayerInfo().updateActionBar(e.getPacket().getChatComponent().getUnformattedText());
-        e.setCanceled(true);
+        if (UtilitiesModule.getModule().getActionBarOverlay().active) e.setCanceled(true); // only disable when the wynntils action bar is enabled
     }
 
     @SubscribeEvent

--- a/src/main/java/com/wynntils/modules/utilities/UtilitiesModule.java
+++ b/src/main/java/com/wynntils/modules/utilities/UtilitiesModule.java
@@ -24,6 +24,7 @@ public class UtilitiesModule extends Module {
 
     private static UtilitiesModule module;
     private GameUpdateOverlay gameUpdateOverlay;
+    private ActionBarOverlay actionBarOverlay;
     private InfoFormatter infoFormatter;
 
     public void onEnable() {
@@ -54,7 +55,7 @@ public class UtilitiesModule extends Module {
 
         // Real overlays
         registerOverlay(new WarTimerOverlay(), Priority.LOWEST);
-        registerOverlay(new ActionBarOverlay(), Priority.LOWEST);
+        registerOverlay(actionBarOverlay = new ActionBarOverlay(), Priority.LOWEST);
         registerOverlay(new HealthBarOverlay(), Priority.NORMAL);
         registerOverlay(new HotbarOverlay(), Priority.NORMAL);
         registerOverlay(new ManaBarOverlay(), Priority.NORMAL);
@@ -120,6 +121,10 @@ public class UtilitiesModule extends Module {
 
     public GameUpdateOverlay getGameUpdateOverlay() {
         return gameUpdateOverlay;
+    }
+    
+    public ActionBarOverlay getActionBarOverlay() {
+        return actionBarOverlay;
     }
 
     public InfoFormatter getInfoFormatter() {

--- a/src/main/java/com/wynntils/modules/utilities/managers/MountHorseManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/MountHorseManager.java
@@ -85,7 +85,11 @@ public class MountHorseManager {
             return MountHorseStatus.HORSE_TOO_FAR;
         }
 
+        int prev = mc.player.inventory.currentItem;
+        
+        mc.player.inventory.currentItem = 8; // swap to soul points to avoid any right-click conflicts
         mc.playerController.interactWithEntity(player, playersHorse, EnumHand.MAIN_HAND);
+        mc.player.inventory.currentItem = prev;
         return MountHorseStatus.SUCCESS;
     }
 

--- a/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
@@ -662,7 +662,6 @@ public class OverlayEvents implements Listener {
 
     @SubscribeEvent
     public void onServerLeave(WynncraftServerEvent.Leave e) {
-        ModCore.mc().gameSettings.heldItemTooltips = true;
         ObjectivesOverlay.restoreVanillaScoreboard();
     }
 

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/PlayerInfoOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/PlayerInfoOverlay.java
@@ -34,8 +34,8 @@ public class PlayerInfoOverlay extends Overlay {
         if (!Reference.onWorld || !OverlayConfig.PlayerInfo.INSTANCE.replaceVanilla) return;
         if (!mc.gameSettings.keyBindPlayerList.isKeyDown() && animationProgress <= 0.0) return;
 
-        double animation;
-        { // Animation Detection
+        double animation = 1;
+        if (OverlayConfig.PlayerInfo.INSTANCE.openingDuration > 0) { // Animation Detection
             if (lastTime == -1) lastTime += Minecraft.getSystemTime();
 
             if (mc.gameSettings.keyBindPlayerList.isKeyDown()) {

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/EmeraldCountOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/EmeraldCountOverlay.java
@@ -73,24 +73,17 @@ public class EmeraldCountOverlay implements Listener {
 
     @SubscribeEvent
     public void onChestInventory(GuiOverlapEvent.HorseOverlap.DrawGuiContainerForegroundLayer e) {
-        if (!Reference.onWorld || !(UtilitiesConfig.Items.INSTANCE.emeraldCountInventory || UtilitiesConfig.Items.INSTANCE.emeraldCountChest)) return;
+        if (!Reference.onWorld || !UtilitiesConfig.Items.INSTANCE.emeraldCountInventory) return;
 
         IInventory lowerInv = e.getGui().getLowerInv();
-        IInventory upperInv = e.getGui().getUpperInv();
 
         ScreenRenderer renderer = new ScreenRenderer();
         if (UtilitiesConfig.Items.INSTANCE.emeraldCountText) {
-            if (UtilitiesConfig.Items.INSTANCE.emeraldCountInventory)
-                drawTextMoneyAmount(190, -10, ItemUtils.countMoney(lowerInv), renderer, CommonColors.WHITE);
-            if (UtilitiesConfig.Items.INSTANCE.emeraldCountChest)
-                drawTextMoneyAmount(190, 2 * (lowerInv.getSizeInventory() + 10), ItemUtils.countMoney(upperInv), renderer, textColor);
+            drawTextMoneyAmount(170, 7, ItemUtils.countMoney(lowerInv), new ScreenRenderer(), textColor);
             return;
         }
 
-        if (UtilitiesConfig.Items.INSTANCE.emeraldCountInventory)
-            drawIconsMoneyAmount(178, 0, ItemUtils.countMoney(lowerInv), renderer);
-        if (UtilitiesConfig.Items.INSTANCE.emeraldCountChest)
-            drawIconsMoneyAmount(178, 2 * (lowerInv.getSizeInventory() + 10), ItemUtils.countMoney(upperInv), renderer);
+        drawIconsMoneyAmount(178, 0, ItemUtils.countMoney(lowerInv), renderer);
     }
 
     /**

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/RarityColorOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/RarityColorOverlay.java
@@ -111,11 +111,11 @@ public class RarityColorOverlay implements Listener {
     private static CustomColor getHighlightColor(Slot s, ItemStack is, String lore, String name, boolean isChest, Slot slotUnderMouse) {
         if (is.isEmpty()) {
             return null;
-        } else if (!isChest && (lore.contains("Reward") || containsIgnoreCase(lore, "rewards"))) {
+        } else if (!isChest && (lore.contains("Reward") || containsIgnoreCase(lore, "rewards")) && !lore.contains("Raid Reward")) {
             return null;
         } else if (isChest && UtilitiesConfig.Items.INSTANCE.filterEnabled && !professionFilter.equals("-") && lore.contains(professionFilter)) {
             return new CustomColor(0.078f, 0.35f, 0.8f);
-        } else if (isChest && UtilitiesConfig.Items.INSTANCE.highlightCosmeticDuplicates && slotUnderMouse != null && lore.contains("Reward") && slotUnderMouse.slotNumber != s.slotNumber && slotUnderMouse.getStack().getDisplayName().equals(name)) {
+        } else if (isChest && UtilitiesConfig.Items.INSTANCE.highlightCosmeticDuplicates && slotUnderMouse != null && lore.contains("Reward") && !lore.contains("Raid Reward") && slotUnderMouse.slotNumber != s.slotNumber && slotUnderMouse.getStack().getDisplayName().equals(name)) {
             return new CustomColor(0f, 1f, 0f);
         } else if (isChest && lore.contains(TextFormatting.GOLD + "Epic") && lore.contains("Reward") && UtilitiesConfig.Items.INSTANCE.epicEffectsHighlight) {
             return new CustomColor(1f, 0.666f, 0f);

--- a/src/main/java/com/wynntils/modules/utilities/overlays/ui/GearViewerUI.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/ui/GearViewerUI.java
@@ -344,6 +344,7 @@ public class GearViewerUI extends FakeGuiContainer {
     public static void openGearViewer() {
         if (!Reference.onWorld) return;
         
+        if (ModCore.mc().objectMouseOver == null) return;
         Entity e = ModCore.mc().objectMouseOver.entityHit;
         if (e == null || !(e instanceof EntityPlayer)) return;
         EntityPlayer ep = (EntityPlayer) e;


### PR DESCRIPTION
Fixes a couple small bugs. Also includes a change to the way the custom action bar handles held item tooltips, which no longer requires changing the value of the heldItemTooltip setting. Additionally, disabling the custom action bar overlay will render the default Wynncraft action bar and the vanilla held item tooltips, for players who prefer that.