### PR TITLE
Add option to apply update at Minecraft exit instead of immediately

### DIFF
--- a/src/main/java/com/wynntils/modules/core/overlays/UpdateOverlay.java
+++ b/src/main/java/com/wynntils/modules/core/overlays/UpdateOverlay.java
@@ -1,5 +1,5 @@
 /*
- *  * Copyright © Wynntils - 2018 - 2020.
+ *  * Copyright © Wynntils - 2018 - 2021.
  */
 
 package com.wynntils.modules.core.overlays;
@@ -120,27 +120,20 @@ public class UpdateOverlay extends Overlay {
             download = false;
 
             try {
-                File f = new File(Reference.MOD_STORAGE_ROOT, "updates");
-
-                String url;
-                if (CoreDBConfig.INSTANCE.updateStream == UpdateStream.CUTTING_EDGE) {
-                    url = WebManager.getCuttingEdgeJarFileUrl();
-                } else {
-                    url = WebManager.getStableJarFileUrl();
-                }
-                String[] sUrl = url.split("/");
-                String jar_name = sUrl[sUrl.length - 1];
+                File directory = new File(Reference.MOD_STORAGE_ROOT, "updates");
+                String url = getUpdateDownloadUrl();
+                String jarName = getJarNameFromUrl(url);
 
                 DownloadOverlay.size = 0;
                 DownloaderManager.restartGameOnNextQueue();
-                DownloaderManager.queueDownload("Updating to " + WebManager.getUpdate().getLatestUpdate(), url, f, DownloadAction.SAVE, (x) -> {
+                DownloaderManager.queueDownload("Updating to " + WebManager.getUpdate().getLatestUpdate(), url, directory, DownloadAction.SAVE, (x) -> {
                     if (x) {
                         try {
                             String message = TextFormatting.DARK_AQUA + "An update to Wynntils (";
-                            message += CoreDBConfig.INSTANCE.updateStream == UpdateStream.STABLE ? "Version " + jar_name.split("_")[0].split("-")[1] : "Build " + jar_name.split("_")[1].replace(".jar", "");
+                            message += CoreDBConfig.INSTANCE.updateStream == UpdateStream.STABLE ? "Version " + jarName.split("_")[0].split("-")[1] : "Build " + jarName.split("_")[1].replace(".jar", "");
                             message += ") has been downloaded, and will be applied when the game is restarted.";
                             ModCore.mc().player.sendMessage(new TextComponentString(message));
-                            copyUpdate(jar_name);
+                            scheduleCopyUpdateAtShutdown(jarName);
                         } catch (Exception ex) {
                             ex.printStackTrace();
                         }
@@ -168,7 +161,20 @@ public class UpdateOverlay extends Overlay {
         }
     }
 
-    public static void copyUpdate(String jarName) {
+    public static String getJarNameFromUrl(String url) {
+        String[] sUrl = url.split("/");
+        return sUrl[sUrl.length - 1];
+    }
+
+    public static String getUpdateDownloadUrl() throws IOException {
+        if (CoreDBConfig.INSTANCE.updateStream == UpdateStream.CUTTING_EDGE) {
+            return WebManager.getCuttingEdgeJarFileUrl();
+        } else {
+            return WebManager.getStableJarFileUrl();
+        }
+    }
+
+    public static void scheduleCopyUpdateAtShutdown(String jarName) {
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             try {
                 Reference.LOGGER.info("Attempting to apply Wynntils update.");

--- a/src/main/java/com/wynntils/modules/core/overlays/ui/UpdateAvailableScreen.java
+++ b/src/main/java/com/wynntils/modules/core/overlays/ui/UpdateAvailableScreen.java
@@ -1,5 +1,5 @@
 /*
- *  * Copyright © Wynntils - 2018 - 2020.
+ *  * Copyright © Wynntils - 2018 - 2021.
  */
 
 package com.wynntils.modules.core.overlays.ui;
@@ -31,39 +31,41 @@ public class UpdateAvailableScreen extends GuiScreen {
 
     @Override
     public void initGui() {
-        this.buttonList.add(new GuiButton(0, this.width / 2 - 100, this.height / 4 + 108, 98, 20, "Update"));
-        this.buttonList.add(new GuiButton(1, this.width / 2 + 2, this.height / 4 + 108, 98, 20, "Ignore"));
-        this.buttonList.add(new GuiButton(2, this.width / 2 - 100, this.height / 4 + 132, 200, 20, "Cancel"));
-        this.buttonList.add(new GuiButton(3, this.width / 2 - 100, this.height / 4 + 84, 200, 20, "View changelog"));
+        this.buttonList.add(new GuiButton(0, this.width / 2 - 100, this.height / 4 + 84, 200, 20, "View changelog"));
+        this.buttonList.add(new GuiButton(1, this.width / 2 - 100, this.height / 4 + 108, 98, 20, "Update now"));
+        this.buttonList.add(new GuiButton(2, this.width / 2 + 2, this.height / 4 + 108, 98, 20, "Update at exit"));
+        this.buttonList.add(new GuiButton(3, this.width / 2 - 100, this.height / 4 + 132, 98, 20, "Ignore update"));
+        this.buttonList.add(new GuiButton(4, this.width / 2 + 2, this.height / 4 + 132, 98, 20, "Cancel"));
     }
 
     @Override
     public void drawScreen(int mouseX, int mouseY, float partialTicks) {
         drawDefaultBackground();
 
-        int yOffset = Math.min(this.height / 2, this.height / 4 + 82 - mc.fontRenderer.FONT_HEIGHT);
+        int yOffset = Math.min(this.height / 2, this.height / 4 + 80 - mc.fontRenderer.FONT_HEIGHT * 2);
         drawCenteredString(mc.fontRenderer, text, this.width/2, yOffset - mc.fontRenderer.FONT_HEIGHT - 2, 0xFFFFFFFF);
-        drawCenteredString(mc.fontRenderer, "Update before joining?", this.width/2, yOffset, 0xFFFFFFFF);
+        drawCenteredString(mc.fontRenderer, "Update now or when leaving Minecraft?", this.width/2, yOffset, 0xFFFFFFFF);
+        drawCenteredString(mc.fontRenderer, "(Updating now will exit Minecraft after downloading update)", this.width/2, yOffset + mc.fontRenderer.FONT_HEIGHT + 2, 0xFFFFFFFF);
 
         super.drawScreen(mouseX, mouseY, partialTicks);
     }
 
     @Override
     public void actionPerformed(GuiButton button) {
-        if (button.id == 0) {
+        if (button.id == 1 || button.id == 2) {
             // Update
             CoreDBConfig.INSTANCE.showChangelogs = true;
             CoreDBConfig.INSTANCE.lastVersion = Reference.VERSION;
             CoreDBConfig.INSTANCE.saveSettings(CoreModule.getModule());
-            mc.displayGuiScreen(new UpdatingScreen());
-        } else if (button.id == 1) {
+            mc.displayGuiScreen(new UpdatingScreen(button.id == 1));
+        } else if (button.id == 3) {
             // Ignore
             WebManager.skipJoinUpdate();
             ServerUtils.connect(null, server);
-        } else if (button.id == 2) {
+        } else if (button.id == 4) {
             // Cancel
             mc.displayGuiScreen(null);
-        } else if (button.id == 3) {
+        } else if (button.id == 0) {
             // View changelog
             boolean major = CoreDBConfig.INSTANCE.updateStream == UpdateStream.STABLE;
             ChangelogUI.loadChangelogAndShow(this, major, true);


### PR DESCRIPTION
This is inspired by https://github.com/Wynntils/Wynntils/pull/274 and hints from @P0keDev.

I did some general cleanup in the updating area as well. It still seems like we have a bit of duplicated logic here, but I can't be bothered to untangle it completely right now.

Anyway, this patch makes the "Update before join?" screen instead give the user two options: `Update now` and `Update at exit`. The first works like it always has done and restarts Minecraft forcefully. The second will just delay updating until the user exits Minecraft by themselves. I also added some more description on what the different options mean.