### PR TITLE
Athena offline checks

### DIFF
--- a/src/main/java/com/wynntils/modules/core/events/ServerEvents.java
+++ b/src/main/java/com/wynntils/modules/core/events/ServerEvents.java
@@ -246,7 +246,7 @@ public class ServerEvents implements Listener {
         TextComponentString msg = new TextComponentString("Failed to connect to the Wynntils servers! You can still use Wynntils, but some features may not work.");
         msg.getStyle().setColor(TextFormatting.RED);
         msg.getStyle().setBold(true);
-        new Delay(() -> Minecraft.getMinecraft().player.sendMessage(msg), 10); // delay so the player actually loads in
+        new Delay(() -> Minecraft.getMinecraft().player.sendMessage(msg), 30); // delay so the player actually loads in
     }
 
     private static boolean triedToShowChangelog = false;

--- a/src/main/java/com/wynntils/modules/core/events/ServerEvents.java
+++ b/src/main/java/com/wynntils/modules/core/events/ServerEvents.java
@@ -4,16 +4,34 @@
 
 package com.wynntils.modules.core.events;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.wynntils.ModCore;
 import com.wynntils.Reference;
-import com.wynntils.core.events.custom.*;
+import com.wynntils.core.events.custom.PacketEvent;
+import com.wynntils.core.events.custom.SchedulerEvent;
+import com.wynntils.core.events.custom.WynnClassChangeEvent;
+import com.wynntils.core.events.custom.WynnSocialEvent;
+import com.wynntils.core.events.custom.WynnWorldEvent;
+import com.wynntils.core.events.custom.WynncraftServerEvent;
 import com.wynntils.core.framework.FrameworkManager;
 import com.wynntils.core.framework.entities.EntityManager;
 import com.wynntils.core.framework.enums.ClassType;
 import com.wynntils.core.framework.instances.PlayerInfo;
 import com.wynntils.core.framework.interfaces.Listener;
+import com.wynntils.core.utils.helpers.Delay;
 import com.wynntils.core.utils.reflections.ReflectionFields;
 import com.wynntils.modules.core.CoreModule;
 import com.wynntils.modules.core.config.CoreDBConfig;
@@ -30,25 +48,20 @@ import com.wynntils.modules.core.overlays.ui.PlayerInfoReplacer;
 import com.wynntils.webapi.WebManager;
 import com.wynntils.webapi.downloader.DownloaderManager;
 import com.wynntils.webapi.profiles.TerritoryProfile;
+
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.client.gui.GuiIngame;
 import net.minecraft.network.play.server.SPacketSpawnPosition;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.ChatType;
+import net.minecraft.util.text.TextComponentString;
+import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.client.event.ClientChatEvent;
 import net.minecraftforge.client.event.ClientChatReceivedEvent;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.network.FMLNetworkEvent;
-
-import java.util.*;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class ServerEvents implements Listener {
 
@@ -221,6 +234,19 @@ public class ServerEvents implements Listener {
     @SubscribeEvent
     public void onReceivePacket(PacketEvent e) {
         PacketQueue.checkResponse(e.getPacket());
+    }
+    
+    /**
+     * Warns user if Athena is currently down
+     */
+    @SubscribeEvent
+    public void onJoinServer(WynncraftServerEvent.Login e) {
+        if (WebManager.isAthenaOnline()) return;
+        
+        TextComponentString msg = new TextComponentString("Failed to connect to the Wynntils servers! You can still use Wynntils, but some features may not work.");
+        msg.getStyle().setColor(TextFormatting.RED);
+        msg.getStyle().setBold(true);
+        new Delay(() -> Minecraft.getMinecraft().player.sendMessage(msg), 10); // delay so the player actually loads in
     }
 
     private static boolean triedToShowChangelog = false;

--- a/src/main/java/com/wynntils/modules/core/managers/UserManager.java
+++ b/src/main/java/com/wynntils/modules/core/managers/UserManager.java
@@ -25,6 +25,7 @@ public class UserManager {
     private static final Map<UUID, WynntilsUser> users = new HashMap<>();
 
     public static void loadUser(UUID uuid) {
+        if (!WebManager.isAthenaOnline()) return;
         if (users.containsKey(uuid)) return;
         users.put(uuid, null); // temporary null, avoid extra loads
 

--- a/src/main/java/com/wynntils/webapi/WebManager.java
+++ b/src/main/java/com/wynntils/webapi/WebManager.java
@@ -126,7 +126,8 @@ public class WebManager {
             ProgressManager.pop(progressBar);
         }
 
-        updateTerritoryThreadStatus(true);
+        if (isAthenaOnline())
+            updateTerritoryThreadStatus(true);
     }
 
     public static void checkForUpdatesOnJoin() {
@@ -263,7 +264,7 @@ public class WebManager {
      * Request a update to territories {@link ArrayList}
      */
     public static void updateTerritories(RequestHandler handler) {
-        if (apiUrls == null || !isAthenaOnline()) return;
+        if (apiUrls == null) return;
         String url = apiUrls.get("Athena") + "/cache/get/territoryList";
         handler.addRequest(new Request(url, "territory")
             .cacheTo(new File(API_CACHE_ROOT, "territories.json"))

--- a/src/main/java/com/wynntils/webapi/WebManager.java
+++ b/src/main/java/com/wynntils/webapi/WebManager.java
@@ -156,6 +156,10 @@ public class WebManager {
         account = new WynntilsAccount();
         account.login();
     }
+    
+    public static boolean isAthenaOnline() {
+        return (account != null && account.isConnected());
+    }
 
     public static WynntilsAccount getAccount() {
         return account;
@@ -259,7 +263,7 @@ public class WebManager {
      * Request a update to territories {@link ArrayList}
      */
     public static void updateTerritories(RequestHandler handler) {
-        if (apiUrls == null) return;
+        if (apiUrls == null || !isAthenaOnline()) return;
         String url = apiUrls.get("Athena") + "/cache/get/territoryList";
         handler.addRequest(new Request(url, "territory")
             .cacheTo(new File(API_CACHE_ROOT, "territories.json"))
@@ -350,7 +354,7 @@ public class WebManager {
      * @see LeaderboardProfile
      */
     public static void getLeaderboard(Consumer<HashMap<UUID, LeaderboardProfile>> onReceive) {
-        if (apiUrls == null) return;
+        if (apiUrls == null || !isAthenaOnline()) return;
         String url = apiUrls.get("Athena") + "/cache/get/leaderboard";
 
         handler.addAndDispatch(
@@ -375,7 +379,7 @@ public class WebManager {
      * @see ServerProfile
      */
     public static void getServerList(Consumer<HashMap<String, ServerProfile>> onReceive) {
-        if (apiUrls == null) return;
+        if (apiUrls == null || !isAthenaOnline()) return;
         String url = apiUrls.get("Athena") + "/cache/get/serverList";
 
         handler.addAndDispatch(

--- a/src/main/java/com/wynntils/webapi/account/WynntilsAccount.java
+++ b/src/main/java/com/wynntils/webapi/account/WynntilsAccount.java
@@ -44,6 +44,10 @@ public class WynntilsAccount {
     public String getToken() {
         return token;
     }
+    
+    public boolean isConnected() {
+        return ready;
+    }
 
     public HashMap<String, String> getEncodedConfigs() {
         return encodedConfigs;
@@ -150,12 +154,7 @@ public class WynntilsAccount {
     }
 
     public void uploadConfig(File f) {
-        if (!ready || configurationUploader == null)  {
-            if(!login()) return;
-
-            uploadConfig(f); // try again
-            return;
-        }
+        if (!ready || configurationUploader == null) return;
 
         configurationUploader.queueConfig(f);
     }


### PR DESCRIPTION
Some small changes to make the mod run more smoothly during Athena outages.

This adds some checks to see if the mod successfully authenticated with Athena, and if not, avoids sending additional requests. Importantly, attempting to upload the user's config files does not reattempt an Athena login if the previous logins failed--this would cause Minecraft to hang for a long time and seems unnecessary. I also added a small message warning the user of decreased functionality when joining Wynncraft after failing to connect to Athena.