### PR TITLE
Display new or changed item identifications more clearly

### DIFF
--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemIdentificationOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemIdentificationOverlay.java
@@ -117,7 +117,7 @@ public class ItemIdentificationOverlay implements Listener {
         // Generating id lores
         Map<String, String> idLore = new HashMap<>();
 
-        double cumRelative = 0;
+        double relativeTotal = 0;
         int idAmount = 0;
         boolean hasNewId = false;
 
@@ -168,9 +168,9 @@ public class ItemIdentificationOverlay implements Listener {
                     if (id.getBaseValue() != currentValue) {
                         idLore.put(idName, lore + GOLD + " NEW");
                         hasNewId = true;
-                    } else {
-                        idLore.put(idName, lore);
+                        continue;
                     }
+                    idLore.put(idName, lore);
                     continue;
                 }
 
@@ -182,7 +182,7 @@ public class ItemIdentificationOverlay implements Listener {
                     continue;
                 }
 
-                cumRelative += result.getAmount();
+                relativeTotal += result.getAmount();
                 idAmount++;
             }
         }
@@ -316,12 +316,12 @@ public class ItemIdentificationOverlay implements Listener {
         String specialDisplay = "";
         if (hasNewId) {
             specialDisplay = GOLD + " NEW";
-        } else if (idAmount > 0 && cumRelative > 0) {
-            specialDisplay = " " + idType.getTitle(cumRelative/(double)idAmount);
+        } else if (idAmount > 0 && relativeTotal > 0) {
+            specialDisplay = " " + idType.getTitle(relativeTotal/(double)idAmount);
         }
 
         // check for item perfection
-        if (cumRelative/idAmount >= 1d && idType == IdentificationType.PERCENTAGES && !hasNewId) {
+        if (relativeTotal/idAmount >= 1d && idType == IdentificationType.PERCENTAGES && !hasNewId) {
             wynntils.setBoolean("isPerfect", true);
         }
 

--- a/src/main/java/com/wynntils/webapi/WebManager.java
+++ b/src/main/java/com/wynntils/webapi/WebManager.java
@@ -447,6 +447,7 @@ public class WebManager {
                     prof.getStatuses().values().forEach(IdentificationContainer::calculateMinMax);
                     citems.put(prof.getDisplayName(), prof);
                 }
+                citems.values().forEach(ItemProfile::registerIdTypes);
 
                 directItems = citems.values();
                 items = citems;

--- a/src/main/java/com/wynntils/webapi/WebManager.java
+++ b/src/main/java/com/wynntils/webapi/WebManager.java
@@ -447,6 +447,7 @@ public class WebManager {
                     prof.getStatuses().values().forEach(IdentificationContainer::calculateMinMax);
                     citems.put(prof.getDisplayName(), prof);
                 }
+
                 citems.values().forEach(ItemProfile::registerIdTypes);
 
                 directItems = citems.values();

--- a/src/main/java/com/wynntils/webapi/profiles/item/ItemProfile.java
+++ b/src/main/java/com/wynntils/webapi/profiles/item/ItemProfile.java
@@ -59,6 +59,10 @@ public class ItemProfile {
                        Map<String, Integer> defenseTypes, Map<String, IdentificationContainer> statuses,
                        ArrayList<MajorIdentification> majorIds, String restriction, String lore) {}
 
+    public void registerIdTypes() {
+        statuses.entrySet().forEach(e -> e.getValue().registerIdType(e.getKey()));
+    }
+
     public String getDisplayName() {
         return displayName;
     }

--- a/src/main/java/com/wynntils/webapi/profiles/item/objects/IdentificationContainer.java
+++ b/src/main/java/com/wynntils/webapi/profiles/item/objects/IdentificationContainer.java
@@ -4,11 +4,17 @@
 
 package com.wynntils.webapi.profiles.item.objects;
 
-import com.wynntils.core.utils.StringUtils;
-import com.wynntils.webapi.profiles.item.enums.IdentificationModifier;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.commons.lang3.math.Fraction;
 
+import com.wynntils.core.utils.StringUtils;
+import com.wynntils.webapi.profiles.item.enums.IdentificationModifier;
+
 public class IdentificationContainer {
+
+    private static Map<String, IdentificationModifier> typeMap = new HashMap<>();
 
     private IdentificationModifier type;
     private int baseValue;
@@ -31,6 +37,11 @@ public class IdentificationContainer {
 
         min = (int) Math.round(baseValue * (baseValue < 0 ? 1.3 : 0.3));
         max = (int) Math.round(baseValue * (baseValue < 0 ? 0.7 : 1.3));
+    }
+
+    public void registerIdType(String name) {
+        if (typeMap.containsKey(name)) return;
+        typeMap.put(name, type);
     }
 
     public IdentificationModifier getType() {
@@ -70,6 +81,10 @@ public class IdentificationContainer {
         }
 
         return StringUtils.capitalizeFirst(nameBuilder.toString());
+    }
+
+    public static IdentificationModifier getTypeFromName(String name) {
+        return typeMap.get(name);
     }
 
     public static class ReidentificationChances {


### PR DESCRIPTION
Currently, when an item gets new identifications, Wynntils will completely hide them until the API is updated to reflect the changes, often confusing players about the true nature of the items they own. This change aims to make it clearer to players which of their items have been changed and how, for completely new IDs and fixed IDs with new values.

![image](https://user-images.githubusercontent.com/3767283/104837823-fa5bd780-586b-11eb-9ef1-aea6888d52bc.png)
