### PR TITLE
Block trades/duels if an item is held

### DIFF
--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -83,6 +83,9 @@ public class UtilitiesConfig extends SettingsClass {
     @Setting(displayName = "Shift-click Accessories", description = "Allow accessories to be shift-clicked on and off?")
     public boolean shiftClickAccessories = true;
 
+    @Setting(displayName = "Prevent Trades/Duels in Combat", description = "Should trade and duel requests be disabled while holding an item?")
+    public boolean preventTradesDuels = false;
+
     @Setting(upload = false)
     public String lastServerResourcePack = "";
 

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -897,9 +897,14 @@ public class ClientEvents implements Listener {
     @SubscribeEvent
     public void onShiftClickPlayer(PacketEvent<CPacketUseEntity> e) {
         if (!UtilitiesConfig.INSTANCE.preventTradesDuels) return;
+
         EntityPlayerSP player = ModCore.mc().player;
         Entity clicked = e.getPacket().getEntityFromWorld(player.world);
         if (!(clicked instanceof EntityPlayer)) return;
+
+        EntityPlayer ep = (EntityPlayer) clicked;
+        if (ep.getTeam() == null) return; // player model npc
+
         if (!player.isSneaking() || player.getHeldItemMainhand().isEmpty()) return;
         e.setCanceled(true);
     }

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -37,6 +37,7 @@ import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.GuiYesNo;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.passive.AbstractHorse;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
@@ -890,6 +891,16 @@ public class ClientEvents implements Listener {
         if (!e.getItemStack().hasDisplayName() || !e.getItemStack().getDisplayName().contains(TextFormatting.RED + "Potion of Healing")) return;
         if (e.getEntityPlayer().getHealth() != e.getEntityPlayer().getMaxHealth()) return;
 
+        e.setCanceled(true);
+    }
+
+    @SubscribeEvent
+    public void onShiftClickPlayer(PacketEvent<CPacketUseEntity> e) {
+        if (!UtilitiesConfig.INSTANCE.preventTradesDuels) return;
+        EntityPlayerSP player = ModCore.mc().player;
+        Entity clicked = e.getPacket().getEntityFromWorld(player.world);
+        if (!(clicked instanceof EntityPlayer)) return;
+        if (!player.isSneaking() || player.getHeldItemMainhand().isEmpty()) return;
         e.setCanceled(true);
     }
 


### PR DESCRIPTION
Blocks the player from making trade/duel requests without an empty hand if enabled. Does not interfere with the actual click (spells and melee attacks will still work fine). Useful to avoid accidentally opening GUIs in group fights, etc.