### PR TITLE
Minor map features + small fixes

### DIFF
--- a/src/main/java/com/wynntils/core/framework/enums/wynntils/WynntilsSound.java
+++ b/src/main/java/com/wynntils/core/framework/enums/wynntils/WynntilsSound.java
@@ -6,7 +6,7 @@ package com.wynntils.core.framework.enums.wynntils;
 
 import com.wynntils.ModCore;
 import com.wynntils.Reference;
-import net.minecraft.client.Minecraft;
+import net.minecraft.client.audio.PositionedSoundRecord;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundEvent;
 
@@ -36,7 +36,7 @@ public enum WynntilsSound {
 
     public void play(float volume, float pitch) {
         ModCore.mc().addScheduledTask(() ->
-                Minecraft.getMinecraft().player.playSound(event, volume, pitch));
+                ModCore.mc().getSoundHandler().playSound(PositionedSoundRecord.getRecord(event, pitch, volume)));
     }
 
     public void play() {

--- a/src/main/java/com/wynntils/modules/map/configs/MapConfig.java
+++ b/src/main/java/com/wynntils/modules/map/configs/MapConfig.java
@@ -72,6 +72,9 @@ public class MapConfig extends SettingsClass {
     @Setting.Limitations.IntLimit(min = MiniMapOverlay.MIN_ZOOM, max = MiniMapOverlay.MAX_ZOOM, precision = 1)
     public int mapZoom = 30;
 
+    @Setting(displayName = "Hide in Non-Mapped Areas", description = "Should the minimap be hidden if the player is outside the map?", order = 14)
+    public boolean hideMinimapOutOfBounds = true;
+
     @Setting
     public Map<String, Boolean> enabledMapIcons = resetMapIcons(false);
 
@@ -199,7 +202,7 @@ public class MapConfig extends SettingsClass {
         @Setting(displayName = "Rainbow Path Transitioning", description = "How many blocks should loot run paths be shown in a colour before transitioning to a different colour?", order = 5)
         @Setting.Limitations.IntLimit(min = 1, max = 500)
         public int cycleDistance = 20;
-        
+
         @Setting(displayName = "Show Loot Run Path on Map", description = "Should the active lootrun path be shown on the map?", order = 6)
         public boolean displayLootrunOnMap = true;
 

--- a/src/main/java/com/wynntils/modules/map/configs/MapConfig.java
+++ b/src/main/java/com/wynntils/modules/map/configs/MapConfig.java
@@ -32,47 +32,50 @@ public class MapConfig extends SettingsClass {
     @Setting(displayName = "Show Compass Directions", description = "Should the cardinal directions be displayed on the minimap?\n\n§8Cardinal directions are the north, east, south, and west points on a compass.", order = 1)
     public boolean showCompass = true;
 
-    @Setting(displayName = "Enable Minimap", description = "Should a minimap be displayed?", order = 2)
+    @Setting(displayName = "Show Compass Distance", description = "Should the distance to the compass position be displayed on the minimap?", order = 2)
+    public boolean showCompassDistance = true;
+
+    @Setting(displayName = "Enable Minimap", description = "Should a minimap be displayed?", order = 3)
     public boolean enabled = true;
 
-    @Setting(displayName = "Minimap Shape", description = "Should the minimap be a square or a circle?", order = 3)
+    @Setting(displayName = "Minimap Shape", description = "Should the minimap be a square or a circle?", order = 4)
     public MapFormat mapFormat = MapFormat.CIRCLE;
 
-    @Setting(displayName = "Minimap Rotation", description = "Should the minimap be locked facing north or rotate based on the direction you're facing?", order = 4)
+    @Setting(displayName = "Minimap Rotation", description = "Should the minimap be locked facing north or rotate based on the direction you're facing?", order = 5)
     public boolean followPlayerRotation = true;
 
-    @Setting(displayName = "Minimap Size", description = "How large should the minimap be?", order = 5)
+    @Setting(displayName = "Minimap Size", description = "How large should the minimap be?", order = 6)
     @Setting.Limitations.IntLimit(min = 75, max = 200)
     public int mapSize = 100;
 
-    @Setting(displayName = "Minimap Coordinates", description = "Should your coordinates be displayed below the minimap?", order = 6)
+    @Setting(displayName = "Minimap Coordinates", description = "Should your coordinates be displayed below the minimap?", order = 7)
     public boolean showCoords = false;
 
-    @Setting(displayName = "Display Only North", description = "Should only north be displayed on the minimap?\n\n§8This has no effect if compass directions are disabled.", order = 7)
+    @Setting(displayName = "Display Only North", description = "Should only north be displayed on the minimap?\n\n§8This has no effect if compass directions are disabled.", order = 8)
     public boolean northOnly = false;
 
-    @Setting(displayName = "Display Minimap Icons", description = "Should map icons be displayed on the minimap?", order = 8)
+    @Setting(displayName = "Display Minimap Icons", description = "Should map icons be displayed on the minimap?", order = 9)
     public boolean minimapIcons = true;
 
-    @Setting(displayName = "Hide Completed Quest Icons", description = "Should map icons for completed quests be hidden?", order = 9)
+    @Setting(displayName = "Hide Completed Quest Icons", description = "Should map icons for completed quests be hidden?", order = 10)
     public boolean hideCompletedQuests = true;
 
-    @Setting(displayName = "Compass Beacon Colour", description = "What colour should the compass beacon be?", order = 10)
+    @Setting(displayName = "Compass Beacon Colour", description = "What colour should the compass beacon be?", order = 11)
     @Setting.Features.CustomColorFeatures(allowAlpha = true)
     public CustomColor compassBeaconColor = CommonColors.RED;
 
-    @Setting(displayName = "Map Blur", description = "Should the map be rendered using linear textures to avoid aliasing issues?", order = 11)
+    @Setting(displayName = "Map Blur", description = "Should the map be rendered using linear textures to avoid aliasing issues?", order = 12)
     public boolean renderUsingLinear = true;
 
-    @Setting(displayName = "Minimap Icons Size", description = "How big should minimap icons be?", order = 12)
+    @Setting(displayName = "Minimap Icons Size", description = "How big should minimap icons be?", order = 13)
     @Setting.Limitations.FloatLimit(min = 0.5f, max = 2f)
     public float minimapIconSizeMultiplier = 1f;
 
-    @Setting(displayName = "Minimap Zoom", description = "How zoomed out should the minimap be?", order = 13)
+    @Setting(displayName = "Minimap Zoom", description = "How zoomed out should the minimap be?", order = 14)
     @Setting.Limitations.IntLimit(min = MiniMapOverlay.MIN_ZOOM, max = MiniMapOverlay.MAX_ZOOM, precision = 1)
     public int mapZoom = 30;
 
-    @Setting(displayName = "Hide in Non-Mapped Areas", description = "Should the minimap be hidden if the player is outside the map?", order = 14)
+    @Setting(displayName = "Hide in Non-Mapped Areas", description = "Should the minimap be hidden if the player is outside the map?", order = 15)
     public boolean hideMinimapOutOfBounds = true;
 
     @Setting

--- a/src/main/java/com/wynntils/modules/map/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/map/events/ClientEvents.java
@@ -42,7 +42,7 @@ public class ClientEvents implements Listener {
         if (!MapConfig.INSTANCE.showCompassBeam || CompassManager.getCompassLocation() == null) return;
 
         Location compass = CompassManager.getCompassLocation();
-        BeaconManager.drawBeam(new Location(compass.getX(), compass.getY(), compass.getZ()), MapConfig.INSTANCE.compassBeaconColor);
+        BeaconManager.drawBeam(new Location(compass.getX(), compass.getY(), compass.getZ()), MapConfig.INSTANCE.compassBeaconColor, e.getPartialTicks());
     }
 
     @SubscribeEvent(priority = EventPriority.LOWEST)

--- a/src/main/java/com/wynntils/modules/map/managers/BeaconManager.java
+++ b/src/main/java/com/wynntils/modules/map/managers/BeaconManager.java
@@ -22,7 +22,7 @@ public class BeaconManager {
     private static final Tessellator tessellator = Tessellator.getInstance();
     private static final ResourceLocation beamResource = new ResourceLocation("textures/entity/beacon_beam.png");
 
-    public static void drawBeam(Location loc, CustomColor color) {
+    public static void drawBeam(Location loc, CustomColor color, float partialTicks) {
         RenderManager renderManager = Minecraft.getMinecraft().getRenderManager();
         if (renderManager.renderViewEntity == null) return;
 
@@ -41,6 +41,10 @@ public class BeaconManager {
 
         double maxDistance = Minecraft.getMinecraft().gameSettings.renderDistanceChunks * 16d;
         if (distance > maxDistance) {  // this will drag the beam to the visible area if outside of it
+            // partial ticks aren't factored into player pos, so if we're going to use it for rendering, we need to recalculate to account for partial ticks
+            Vec3d prevPosVec = new Vec3d(renderManager.renderViewEntity.prevPosX, renderManager.renderViewEntity.prevPosY, renderManager.renderViewEntity.prevPosZ);
+            playerVec = playerVec.subtract(prevPosVec).scale(partialTicks).add(prevPosVec);
+
             Vec3d delta = positionVec.subtract(playerVec).normalize();
             positionVec = playerVec.add(delta.x * maxDistance, delta.y * maxDistance, delta.z * maxDistance);
         }

--- a/src/main/java/com/wynntils/modules/map/overlays/MiniMapOverlay.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/MiniMapOverlay.java
@@ -77,7 +77,7 @@ public class MiniMapOverlay extends Overlay {
         float centerX = minX + ((maxX - minX)/2);
         float centerZ = minZ + ((maxZ - minZ)/2);
 
-        if (centerX > 1 || centerX < 0 || centerZ > 1 || centerZ < 0) return;
+        if (MapConfig.INSTANCE.hideMinimapOutOfBounds && (centerX > 1 || centerX < 0 || centerZ > 1 || centerZ < 0)) return;
 
         try {
             GlStateManager.enableAlpha();

--- a/src/main/java/com/wynntils/modules/map/overlays/MiniMapOverlay.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/MiniMapOverlay.java
@@ -6,9 +6,12 @@ package com.wynntils.modules.map.overlays;
 
 import com.wynntils.Reference;
 import com.wynntils.core.framework.overlays.Overlay;
+import com.wynntils.core.framework.rendering.ScreenRenderer;
 import com.wynntils.core.framework.rendering.SmartFontRenderer;
 import com.wynntils.core.framework.rendering.colors.CommonColors;
+import com.wynntils.core.framework.rendering.colors.CustomColor;
 import com.wynntils.core.framework.rendering.textures.Textures;
+import com.wynntils.core.utils.StringUtils;
 import com.wynntils.modules.map.MapModule;
 import com.wynntils.modules.map.configs.MapConfig;
 import com.wynntils.modules.map.instances.MapProfile;
@@ -246,8 +249,14 @@ public class MiniMapOverlay extends Overlay {
                         MapCompassIcon.pointer.renderAt(this, dx, dz, sizeMultiplier, 1f);
 
                         GlStateManager.popMatrix();
+
+                        if (MapConfig.INSTANCE.showCompassDistance)
+                            drawTextOverlay(this, dx, dz, StringUtils.integerToShortString(Math.round((float)Math.sqrt(distanceSq) / scaleFactor)) + "m");
                     } else if (rendering) {
                         compassIcon.renderAt(this, dx + halfMapSize, dz + halfMapSize, sizeMultiplier, scaleFactor);
+
+                        if (MapConfig.INSTANCE.showCompassDistance)
+                            drawTextOverlay(this, dx + halfMapSize, dz + halfMapSize, StringUtils.integerToShortString(Math.round((float)Math.sqrt(distanceSq) / scaleFactor)) + "m");
                     }
                 }
             }
@@ -328,6 +337,14 @@ public class MiniMapOverlay extends Overlay {
         } catch (Exception ex) {
             ex.printStackTrace();
         }
+    }
+
+    private static void drawTextOverlay(ScreenRenderer renderer, float x, float y, String text) {
+        ScreenRenderer.scale(0.8f);
+        float w = renderer.getStringWidth(text) / 2f + 3f, h = SmartFontRenderer.CHAR_HEIGHT / 2f + 2f;
+        renderer.drawRectF(new CustomColor(0f, 0f, 0f, 0.7f), x - w, y - h + 1f, x + w, y + h);
+        renderer.drawCenteredString(text, x, y - 3f, CommonColors.WHITE);
+        ScreenRenderer.resetScale();
     }
 
 }


### PR DESCRIPTION
This PR implements the following small map features:

* A config option is added that lets the minimap remain visible while in non-mapped areas, in case players want to use the compass in those areas.
* A config option is added that draws the distance to the compass position over the minimap icon.

Additionally, this PR fixes a couple small issues:

* The scaling algorithm for the compass beacon when it's too far away doesn't account for partial ticks, so it looks jittery while the player is moving.
* Many Wynntils sounds are played as positioned records, so they fade out if the player is moving while they play.