### PR TITLE
Lootrun improvements

### DIFF
--- a/src/main/java/com/wynntils/core/utils/objects/CubicSplines.java
+++ b/src/main/java/com/wynntils/core/utils/objects/CubicSplines.java
@@ -171,6 +171,11 @@ public final class CubicSplines {
             points.addAll(index, copy);
         }
 
+        public void removePoints(Collection<? extends Point3d> removedPoints) {
+            dirty = true;
+            points.removeAll(removedPoints);
+        }
+
         public List<Location> getPoints() {
             return Collections.unmodifiableList(points);
         }

--- a/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
+++ b/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
@@ -362,24 +362,23 @@ public class ChatManager {
 
         // clickable coordinates
         if (ChatConfig.INSTANCE.clickableCoordinates && coordinateReg.matcher(in.getUnformattedText()).find()) {
-            String crdText;
-            Style style;
-            String command = "/compass ";
-            List<ITextComponent> crdMsg = new ArrayList<>();
 
+            ITextComponent temp = new TextComponentString("");
             for (ITextComponent texts: in.getSiblings()) {
                 Matcher m = coordinateReg.matcher(texts.getUnformattedText());
-                if (!m.find())  continue;
+                if (!m.find()) {
+                    temp.getSiblings().add(texts);
+                    continue;
+                }
 
                 // Most likely only needed during the Wynnter Fair for the message with how many more players are required to join.
                 // As far as i could find all other messages from the Wynnter Fair use text components properly.
                 if (m.start() > 0 && texts.getUnformattedText().charAt(m.start() - 1) == '§') continue;
 
-                int index = in.getSiblings().indexOf(texts);
-
-                crdText = texts.getUnformattedText();
-                style = texts.getStyle();
-                in.getSiblings().remove(texts);
+                String crdText = texts.getUnformattedText();
+                Style style = texts.getStyle();
+                String command = "/compass ";
+                List<ITextComponent> crdMsg = new ArrayList<>();
 
                 // Pre-text
                 ITextComponent preText = new TextComponentString(crdText.substring(0, m.start()));
@@ -403,9 +402,9 @@ public class ChatManager {
                 postText.setStyle(style.createShallowCopy());
                 crdMsg.add(postText);
 
-                in.getSiblings().addAll(index, crdMsg);
-                break;
+                temp.getSiblings().addAll(crdMsg);
             }
+            in = temp;
         }
 
         //powder manual

--- a/src/main/java/com/wynntils/modules/map/commands/CommandLootRun.java
+++ b/src/main/java/com/wynntils/modules/map/commands/CommandLootRun.java
@@ -260,6 +260,45 @@ public class CommandLootRun extends CommandBase implements IClientCommand {
                 sender.sendMessage(message);
                 return;
             }
+            case "addchest":
+            case "removechest": {
+                String command = args[0].toLowerCase(Locale.ROOT);
+                BlockPos pos;
+                if (args.length < 4) {
+                    pos = new BlockPos((int) ModCore.mc().player.posX, (int) ModCore.mc().player.posY, (int) ModCore.mc().player.posZ - 1);
+                } else {
+                    int x = 0, y = 0, z = 0;
+                    try {
+                        x = Integer.parseInt(args[1]);
+                        y = Integer.parseInt(args[2]);
+                        z = Integer.parseInt(args[3]);
+                    } catch (NumberFormatException e) {
+                        sender.sendMessage(new TextComponentString(RED + "Invalid coordinates!"));
+                        return;
+                    }
+                    pos = new BlockPos(x, y, z - 1); // offset z by one
+                }
+
+                ITextComponent message;
+                if (command.equals("addchest")) {
+                    if (LootRunManager.addChest(pos)) {
+                        message = new TextComponentString("Added chest at (" + pos.getX() + ", " + pos.getY() + ", " + (pos.getZ() + 1) + ")!");
+                        message.getStyle().setColor(GREEN);
+                    } else {
+                        message = new TextComponentString(RED + "You have no active or recording loot runs!");
+                    }
+                } else {
+                    if (LootRunManager.removeChest(pos)) {
+                        message = new TextComponentString("Removed chest at (" + pos.getX() + ", " + pos.getY() + ", " + (pos.getZ() + 1) + ")!");
+                        message.getStyle().setColor(GREEN);
+                    } else {
+                        message = new TextComponentString(RED + "You have no active or recording loot runs!");
+                    }
+                }
+
+                sender.sendMessage(message);
+                return;
+            }
             case "list": {
                 StringBuilder message = new StringBuilder(YELLOW.toString()).append("Stored loot runs:");
                 List<String> lootruns = LootRunManager.getStoredLootruns();
@@ -308,6 +347,7 @@ public class CommandLootRun extends CommandBase implements IClientCommand {
                     DARK_GRAY + "/lootrun " + RED + "record " + GRAY + "Start/Stop recording a new loot run\n" +
                     DARK_GRAY + "/lootrun " + RED + "undo " + GRAY + "Undo the recording loot run to your current position\n" +
                     DARK_GRAY + "/lootrun " + RED + "note " + GRAY + "Add or list notes to the active or recording loot run\n" +
+                    DARK_GRAY + "/lootrun " + RED + "addchest/removechest <x> <y> <z> " + GRAY + "Manually mark a chest in the active or recording loot run\n" +
                     DARK_GRAY + "/lootrun " + RED + "list " + GRAY + "List all saved lootruns\n" +
                     DARK_GRAY + "/lootrun " + RED + "folder " + GRAY + "Open the folder where lootruns are stored, for import\n" +
                     DARK_GRAY + "/lootrun " + RED + "clear " + GRAY + "Clears/Hide the currently loaded loot run and the loot run being recorded\n" +

--- a/src/main/java/com/wynntils/modules/map/configs/MapConfig.java
+++ b/src/main/java/com/wynntils/modules/map/configs/MapConfig.java
@@ -199,9 +199,12 @@ public class MapConfig extends SettingsClass {
         @Setting(displayName = "Rainbow Path Transitioning", description = "How many blocks should loot run paths be shown in a colour before transitioning to a different colour?", order = 5)
         @Setting.Limitations.IntLimit(min = 1, max = 500)
         public int cycleDistance = 20;
-        
-        @Setting(displayName = "Show Loot Run Path on Map", description = "Should the active lootrun path be shown on the map?", order = 6)
+
+        @Setting(displayName = "Show Loot Run Path on Map", description = "Should the active loot run path be shown on the map?", order = 6)
         public boolean displayLootrunOnMap = true;
+
+        @Setting(displayName = "Show Loot Run Notes", description = "Should notes from the active loot run be rendered?", order = 7)
+        public boolean showNotes = true;
 
         @Override
         public void onSettingChanged(String name) {

--- a/src/main/java/com/wynntils/modules/map/instances/LootRunNote.java
+++ b/src/main/java/com/wynntils/modules/map/instances/LootRunNote.java
@@ -1,0 +1,94 @@
+package com.wynntils.modules.map.instances;
+
+import com.wynntils.ModCore;
+import com.wynntils.core.framework.rendering.ScreenRenderer;
+import com.wynntils.core.framework.rendering.SmartFontRenderer;
+import com.wynntils.core.framework.rendering.colors.CustomColor;
+import com.wynntils.core.utils.StringUtils;
+import com.wynntils.core.utils.objects.Location;
+
+import net.minecraft.client.entity.EntityPlayerSP;
+import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.renderer.entity.RenderManager;
+
+import static net.minecraft.client.renderer.GlStateManager.*;
+
+public class LootRunNote {
+
+    private Location location;
+    private String note;
+
+    private static final ScreenRenderer renderer = new ScreenRenderer();
+
+    public LootRunNote(Location location, String note) {
+        this.location = location;
+        this.note = note;
+    }
+
+    public Location getLocation() {
+        return location;
+    }
+
+    public String getNote() {
+        return note;
+    }
+
+    public String getLocationString() {
+        return "(" + (int) location.x + ", " + (int) location.y + ", " + (int) location.z + ")";
+    }
+
+    public String getShortLocationString() {
+        return (int) location.x + "," + (int) location.y + "," + (int) location.z;
+    }
+
+    public void drawNote(CustomColor color) {
+        RenderManager render = ModCore.mc().getRenderManager();
+        FontRenderer fr = render.getFontRenderer();
+        EntityPlayerSP player = ModCore.mc().player;
+
+        if (player.getDistanceSq(location.x, location.y, location.z) > 4096f)
+            return; // only draw nametag when close
+
+        String[] lines = StringUtils.wrapTextBySize(note, 200);
+        int offsetY = -(fr.FONT_HEIGHT * lines.length) / 2;
+
+        for (String line : lines) {
+            drawNametag(line, color, (float) (location.x - render.viewerPosX), (float) (location.y - render.viewerPosY + 2), (float) (location.z - render.viewerPosZ), offsetY, render.playerViewY, render.playerViewX, render.options.thirdPersonView == 2);
+            offsetY += fr.FONT_HEIGHT;
+        }
+    }
+
+    private static void drawNametag(String input, CustomColor color, float x, float y, float z, int verticalShift, float viewerYaw, float viewerPitch, boolean isThirdPersonFrontal) {
+        pushMatrix();
+        {
+            ScreenRenderer.beginGL(0, 0); // we set to 0 because we don't want the ScreenRender to handle this thing
+            {
+                // positions
+                translate(x, y, z); // translates to the correct postion
+                glNormal3f(0.0F, 1.0F, 0.0F);
+                rotate(-viewerYaw, 0.0F, 1.0F, 0.0F);
+                rotate((float) (isThirdPersonFrontal ? -1 : 1) * viewerPitch, 1.0F, 0.0F, 0.0F);
+                scale(-0.025F, -0.025F, 0.025F);
+                disableLighting();
+
+                int middlePos = (int) renderer.getStringWidth(input) / 2;
+
+                // draws the label
+                renderer.drawString(input, -middlePos, verticalShift, color, SmartFontRenderer.TextAlignment.LEFT_RIGHT, SmartFontRenderer.TextShadow.NONE);
+
+                // renders twice to replace the areas that are overlaped by tile entities
+                enableDepth();
+                renderer.drawString(input, -middlePos, verticalShift, color, SmartFontRenderer.TextAlignment.LEFT_RIGHT, SmartFontRenderer.TextShadow.NONE);
+
+                // returns back to normal
+                enableDepth();
+                enableLighting();
+                disableBlend();
+                color(1.0f, 1.0f, 1.0f, 1.0f);
+            }
+            ScreenRenderer.endGL();
+        }
+        popMatrix();
+    }
+
+}

--- a/src/main/java/com/wynntils/modules/map/instances/LootRunPath.java
+++ b/src/main/java/com/wynntils/modules/map/instances/LootRunPath.java
@@ -70,6 +70,11 @@ public class LootRunPath {
         spline.addPoints(0, points);
     }
 
+    public void removePoints(Collection<? extends Point3d> points) {
+        changed();
+        spline.removePoints(points);
+    }
+
     public void addChest(BlockPos loc) {
         chests.add(loc.toImmutable());
     }

--- a/src/main/java/com/wynntils/modules/map/instances/LootRunPath.java
+++ b/src/main/java/com/wynntils/modules/map/instances/LootRunPath.java
@@ -87,6 +87,15 @@ public class LootRunPath {
         chests.add(loc.toImmutable());
     }
 
+    public void removeChest(BlockPos loc) {
+        for(BlockPos chest : chests) {
+            if (chest.equals(loc)) {
+                chests.remove(chest);
+                return;
+            }
+        }
+    }
+
     public void addNote(LootRunNote note) {
         notes.add(note);
     }

--- a/src/main/java/com/wynntils/modules/map/instances/LootRunPath.java
+++ b/src/main/java/com/wynntils/modules/map/instances/LootRunPath.java
@@ -26,6 +26,7 @@ public class LootRunPath {
 
     private CubicSplines.Spline3D spline;
     private Set<BlockPos> chests;
+    private Set<LootRunNote> notes;
 
     private transient List<LootRunPath.LootRunPathLocation> lastSmoothSample;
     private transient List<Vector3d> lastSmoothDerivative;
@@ -37,18 +38,25 @@ public class LootRunPath {
     private transient Long2ObjectMap<List<List<LootRunPath.LootRunPathLocation>>> lastRoughSampleByChunk;
     private transient Long2ObjectMap<List<List<Vector3d>>> lastRoughDerivativeByChunk;
 
-    public LootRunPath(Collection<? extends Point3d> points, Collection<? extends BlockPos> chests) {
+    public LootRunPath(Collection<? extends Point3d> points, Collection<? extends BlockPos> chests, Collection<LootRunNote> notes) {
         this.spline = new CubicSplines.Spline3D(points);
         this.chests = new LinkedHashSet<>(chests == null ? 11 : Math.max(2 * chests.size(), 11));
+        this.notes = new LinkedHashSet<>(notes == null ? 5 : notes.size());
+
         if (chests != null) {
             for (BlockPos pos : chests) {
                 this.chests.add(pos.toImmutable());
             }
         }
+        if (notes != null) {
+            for (LootRunNote note : notes) {
+                this.notes.add(note);
+            }
+        }
     }
 
     public LootRunPath() {
-        this(Collections.emptyList(), Collections.emptyList());
+        this(Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
     }
 
     public void addPoint(Point3d loc) {
@@ -77,6 +85,23 @@ public class LootRunPath {
 
     public void addChest(BlockPos loc) {
         chests.add(loc.toImmutable());
+    }
+
+    public void addNote(LootRunNote note) {
+        notes.add(note);
+    }
+
+    public void removeNote(String loc) {
+        for(LootRunNote note : notes) {
+            if (note.getShortLocationString().equals(loc)) {
+                notes.remove(note);
+                return;
+            }
+        }
+    }
+
+    public Set<LootRunNote> getNotes() {
+        return Collections.unmodifiableSet(notes);
     }
 
     public Set<BlockPos> getChests() {

--- a/src/main/java/com/wynntils/modules/map/managers/LootRunManager.java
+++ b/src/main/java/com/wynntils/modules/map/managers/LootRunManager.java
@@ -187,6 +187,29 @@ public class LootRunManager {
         recordingPath.addPoint(to);
     }
 
+    public static boolean undoMovement(double x, double y, double z) {
+        if (!isRecording()) return false;
+
+        Location to = new Location(x, y + .25d, z);
+        List<Location> recordedPoints = recordingPath.getPoints();
+        List<Location> removed = new ArrayList<>();
+        boolean pastInitial = false;
+        for (int i = recordedPoints.size() - 1; i >= 0; i--) {
+            if (i == 0) return false; // never found a point to rewind to
+
+            if (recordedPoints.get(i).distanceSquared(to) < 4d) {
+                if (pastInitial) break; // we've reached the player again
+            } else {
+                if (!pastInitial) pastInitial = true; // we've moved past the end of the path
+            }
+
+            removed.add(recordedPoints.get(i));
+        }
+
+        recordingPath.removePoints(removed);
+        return true;
+    }
+
     public static void addChest(BlockPos pos) {
         if (!isRecording()) return;
 

--- a/src/main/java/com/wynntils/modules/map/managers/LootRunManager.java
+++ b/src/main/java/com/wynntils/modules/map/managers/LootRunManager.java
@@ -219,10 +219,34 @@ public class LootRunManager {
         return true;
     }
 
-    public static void addChest(BlockPos pos) {
-        if (!isRecording()) return;
+    public static boolean addChest(BlockPos pos) {
+        if (isRecording()) {
+            recordingPath.addChest(pos);
+            return true;
+        }
 
-        recordingPath.addChest(pos);
+        if (activePath != null) {
+            activePath.addChest(pos);
+            if (activePathName != null) saveToFile(activePathName);
+            return true;
+        }
+
+        return false;
+    }
+
+    public static boolean removeChest(BlockPos pos) {
+        if (isRecording()) {
+            recordingPath.removeChest(pos);
+            return true;
+        }
+
+        if (activePath != null) {
+            activePath.removeChest(pos);
+            if (activePathName != null) saveToFile(activePathName);
+            return true;
+        }
+
+        return false;
     }
 
     public static boolean addNote(LootRunNote note) {


### PR DESCRIPTION
Adds several helpful commands for lootrunning:

/lootrun undo - Standing on a previous part of the lootrun path while recording and using this command will roll the recording back to the position you are on.
/lootrun note - Adds holographic text to the current lootrun where you are standing. Useful for explaining how to do certain chest puzzles.
/lootrun addchest/removechest - Manually adds or removes a marked chest from the lootrun. Useful for going back and adding chests on the route that weren't present during recording (someone else looting them, etc.)

Any lootruns recorded prior to this change will still work, and new lootruns will be compatible with previous versions of Wynntils.

![image](https://user-images.githubusercontent.com/3767283/106391055-43e60f80-63a0-11eb-984a-9fe73829163f.png)
