### PR TITLE
Horse Improvements

### DIFF
--- a/src/main/java/com/wynntils/modules/utilities/managers/MountHorseManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/MountHorseManager.java
@@ -24,7 +24,7 @@ import java.util.List;
 public class MountHorseManager {
 
     public enum MountHorseStatus {
-        SUCCESS, ALREADY_RIDING, NO_HORSE, HORSE_TOO_FAR
+        SUCCESS, ALREADY_RIDING, NO_HORSE
     }
 
     private static final int searchRadius = 18;  // Search a bit further for message "too far" instead of "not found"
@@ -113,8 +113,6 @@ public class MountHorseManager {
                 return "You are already riding " + ridingEntityType;
             case NO_HORSE:
                 return "Your horse was unable to be found";
-            case HORSE_TOO_FAR:
-                return "Your horse is too far away";
             default:
                 return null;
         }

--- a/src/main/java/com/wynntils/modules/utilities/managers/MountHorseManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/MountHorseManager.java
@@ -71,16 +71,16 @@ public class MountHorseManager {
 
         int prev = mc.player.inventory.currentItem;
         boolean far = false;
-        if(playersHorse != null) {
+        if (playersHorse != null) {
             double maxDistance = player.canEntityBeSeen(playersHorse) ? 36.0D : 9.0D;
             far = player.getDistanceSq(playersHorse) > maxDistance;
         }
 
-        if(playersHorse == null || far) {
+        if (playersHorse == null || far) {
             mc.player.inventory.currentItem = horse.getInventorySlot();
             // No horse -> click to spawn; Horse too far -> despawn respawn
             mc.playerController.processRightClick(player, player.world, EnumHand.MAIN_HAND);
-            if(far) {
+            if (far) {
                 mc.playerController.processRightClick(player, player.world, EnumHand.MAIN_HAND);
             }
             mc.player.inventory.currentItem = prev;

--- a/src/main/java/com/wynntils/modules/utilities/managers/MountHorseManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/MountHorseManager.java
@@ -44,6 +44,12 @@ public class MountHorseManager {
         Minecraft mc = ModCore.mc();
         EntityPlayerSP player = mc.player;
 
+        HorseData horse = PlayerInfo.get(HorseData.class);
+
+        if (!horse.hasHorse() || horse.getInventorySlot() > 8 || !allowRetry) {
+            return MountHorseStatus.NO_HORSE;
+        }
+
         if (player.isRiding()) {
             return MountHorseStatus.ALREADY_RIDING;
         }
@@ -56,37 +62,28 @@ public class MountHorseManager {
         Entity playersHorse = null;
         String playerName = player.getName();
 
-        for (Entity horse : horses) {
-            if (isPlayersHorse(horse, playerName)) {
-                playersHorse = horse;
+        for (Entity h : horses) {
+            if (isPlayersHorse(h, playerName)) {
+                playersHorse = h;
                 break;
             }
         }
 
-        if (playersHorse == null) {
-            HorseData horse = PlayerInfo.get(HorseData.class);
+        int prev = mc.player.inventory.currentItem;
+        boolean far = playersHorse != null && player.getDistanceSq(playersHorse) > (player.canEntityBeSeen(playersHorse) ? 36.0D : 9.0D);
 
-            if (!horse.hasHorse() || horse.getInventorySlot() > 8 || !allowRetry) {
-                return MountHorseStatus.NO_HORSE;
-            }
-
-            int prev = mc.player.inventory.currentItem;
-
+        if(playersHorse == null || far) {
             mc.player.inventory.currentItem = horse.getInventorySlot();
+            // No horse -> click to spawn; Horse too far -> despawn respawn
             mc.playerController.processRightClick(player, player.world, EnumHand.MAIN_HAND);
+            if(far) {
+                mc.playerController.processRightClick(player, player.world, EnumHand.MAIN_HAND);
+            }
             mc.player.inventory.currentItem = prev;
-
             ClientEvents.isAwaitingHorseMount = true;
 
             return MountHorseStatus.SUCCESS;
         }
-
-        double maxDistance = player.canEntityBeSeen(playersHorse) ? 36.0D : 9.0D;
-        if (player.getDistanceSq(playersHorse) > maxDistance) {
-            return MountHorseStatus.HORSE_TOO_FAR;
-        }
-
-        int prev = mc.player.inventory.currentItem;
 
         mc.player.inventory.currentItem = 8; // swap to soul points to avoid any right-click conflicts
         mc.playerController.interactWithEntity(player, playersHorse, EnumHand.MAIN_HAND);

--- a/src/main/java/com/wynntils/modules/utilities/managers/MountHorseManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/MountHorseManager.java
@@ -70,7 +70,11 @@ public class MountHorseManager {
         }
 
         int prev = mc.player.inventory.currentItem;
-        boolean far = playersHorse != null && player.getDistanceSq(playersHorse) > (player.canEntityBeSeen(playersHorse) ? 36.0D : 9.0D);
+        boolean far = false;
+        if(playersHorse != null) {
+            double maxDistance = player.canEntityBeSeen(playersHorse) ? 36.0D : 9.0D;
+            far = player.getDistanceSq(playersHorse) > maxDistance;
+        }
 
         if(playersHorse == null || far) {
             mc.player.inventory.currentItem = horse.getInventorySlot();


### PR DESCRIPTION
Instead of returning an error when the horse is too far, now the horse is despawned and respawned.
Also moved the no horse check to the beginning of the function.
Because you can now successfully mount the horse even if it is far away, the HORSE_TOO_FAR in MountHorseStatus was removed, as well as its error message.

I am completely unaware if this actually affects anything with the network events and whatnot.