### PR TITLE
Add option to show messages in update ticker first

### DIFF
--- a/src/main/java/com/wynntils/modules/utilities/configs/OverlayConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/OverlayConfig.java
@@ -262,6 +262,9 @@ public class OverlayConfig extends SettingsClass {
         @Setting(displayName = "Invert Growth", description = "Should the way ticker messages appear be inverted?")
         public boolean invertGrowth = true;
 
+        @Setting(displayName = "Stack Before Growth Direction", description = "Should new messages appear before old messages in the direction of growth?")
+        public boolean stackBeforeGrowth = false;
+
         @Setting(displayName = "Max Message Length", description = "What should the maximum length of messages in the game-update-ticker be?\n\n§8Messages longer than this set value will be truncated. Set this to 0 for no maximum length.")
         @Setting.Limitations.IntLimit(min = 0, max = 100)
         public int messageMaxLength = 0;
@@ -314,10 +317,10 @@ public class OverlayConfig extends SettingsClass {
 
             @Setting(displayName = "Redirect Horse Messages", description = "Should messages related to your horse be redirected to the game update ticker?")
             public boolean redirectHorse = true;
-            
+
             @Setting(displayName = "Redirect Resource Pack Messages", description = "Should wynnpack and loading reasource pack messages be disabled or redirected (depending on whether you can see them in classs screen)?")
             public boolean redirectResourcePack = false;
-            
+
             @Setting(displayName = "Redirect Class Messages", description = "Should class messages be redirected to the game update ticker?")
             public boolean redirectClass = true;
 

--- a/src/main/java/com/wynntils/modules/utilities/configs/OverlayConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/OverlayConfig.java
@@ -262,7 +262,7 @@ public class OverlayConfig extends SettingsClass {
         @Setting(displayName = "Invert Growth", description = "Should the way ticker messages appear be inverted?")
         public boolean invertGrowth = true;
 
-        @Setting(displayName = "Stack Before Growth Direction", description = "Should new messages appear before old messages in the direction of growth?")
+        @Setting(displayName = "Stack Before Growth Direction", description = "Should new messages appear before old messages in the direction of growth, rather than adding onto each other?")
         public boolean stackBeforeGrowth = false;
 
         @Setting(displayName = "Max Message Length", description = "What should the maximum length of messages in the game-update-ticker be?\n\n§8Messages longer than this set value will be truncated. Set this to 0 for no maximum length.")

--- a/src/main/java/com/wynntils/modules/utilities/configs/OverlayConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/OverlayConfig.java
@@ -262,8 +262,8 @@ public class OverlayConfig extends SettingsClass {
         @Setting(displayName = "Invert Growth", description = "Should the way ticker messages appear be inverted?")
         public boolean invertGrowth = true;
 
-        @Setting(displayName = "Stack Before Growth Direction", description = "Should new messages appear before old messages in the direction of growth, rather than adding onto each other?")
-        public boolean stackBeforeGrowth = false;
+        @Setting(displayName = "New Messages Display Prominently", description = "Should new messages appear before old messages in the direction of growth, pushing older messages further away?")
+        public boolean newMessagesFirst = false;
 
         @Setting(displayName = "Max Message Length", description = "What should the maximum length of messages in the game-update-ticker be?\n\n§8Messages longer than this set value will be truncated. Set this to 0 for no maximum length.")
         @Setting.Limitations.IntLimit(min = 0, max = 100)

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/GameUpdateOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/GameUpdateOverlay.java
@@ -43,7 +43,8 @@ public class GameUpdateOverlay extends Overlay {
 
     @Override
     public void render(RenderGameOverlayEvent.Pre event) {
-        if (!Reference.onWorld || !PlayerInfo.get(CharacterData.class).isLoaded() || event.getType() != RenderGameOverlayEvent.ElementType.ALL) return;
+        if (!Reference.onWorld || !PlayerInfo.get(CharacterData.class).isLoaded() || event.getType() != RenderGameOverlayEvent.ElementType.ALL)
+            return;
         staticSize.y = LINE_HEIGHT * OverlayConfig.GameUpdate.INSTANCE.messageLimit;
 
         int lines = 0;
@@ -56,22 +57,29 @@ public class GameUpdateOverlay extends Overlay {
                 messages.remove();  // remove the message if the time has come
                 continue;
             }
-            if (lines > OverlayConfig.GameUpdate.INSTANCE.messageLimit) break;  // breaks the loop if the limit was reached
+            if (lines > OverlayConfig.GameUpdate.INSTANCE.messageLimit)
+                break;  // breaks the loop if the limit was reached
 
-            if (OverlayConfig.GameUpdate.INSTANCE.invertGrowth)
-                drawString(message.getMessage(),
-                        (OverlayConfig.GameUpdate.INSTANCE.rightToLeft ? 0 : -100),
-                        (-OverlayConfig.GameUpdate.INSTANCE.messageLimit * LINE_HEIGHT) + (LINE_HEIGHT * lines),
-                        alphaColor.setA(message.getRemainingTime() / 1000f),
-                        (OverlayConfig.GameUpdate.INSTANCE.rightToLeft ? SmartFontRenderer.TextAlignment.RIGHT_LEFT : SmartFontRenderer.TextAlignment.LEFT_RIGHT),
-                        OverlayConfig.GameUpdate.INSTANCE.textShadow);
-            else
-                drawString(message.getMessage(),
-                        (OverlayConfig.GameUpdate.INSTANCE.rightToLeft ? 0 : -100),
-                        -(LINE_HEIGHT * lines),
-                        alphaColor.setA(message.getRemainingTime() / 1000f),
-                        (OverlayConfig.GameUpdate.INSTANCE.rightToLeft ? SmartFontRenderer.TextAlignment.RIGHT_LEFT : SmartFontRenderer.TextAlignment.LEFT_RIGHT),
-                        OverlayConfig.GameUpdate.INSTANCE.textShadow);
+            int lineOffset;
+            if (OverlayConfig.GameUpdate.INSTANCE.stackBeforeGrowth) {
+                int messagesDisplayed = Math.min(messageQueue.size(), OverlayConfig.GameUpdate.INSTANCE.messageLimit);
+                lineOffset = (LINE_HEIGHT * (messagesDisplayed - lines));
+            } else {
+                lineOffset = (LINE_HEIGHT * lines);
+            }
+            int y;
+            if (OverlayConfig.GameUpdate.INSTANCE.invertGrowth) {
+                y = (-OverlayConfig.GameUpdate.INSTANCE.messageLimit * LINE_HEIGHT) + lineOffset;
+            } else {
+                y = -lineOffset;
+            }
+
+            drawString(message.getMessage(),
+                    (OverlayConfig.GameUpdate.INSTANCE.rightToLeft ? 0 : -100),
+                    y,
+                    alphaColor.setA(message.getRemainingTime() / 1000f),
+                    (OverlayConfig.GameUpdate.INSTANCE.rightToLeft ? SmartFontRenderer.TextAlignment.RIGHT_LEFT : SmartFontRenderer.TextAlignment.LEFT_RIGHT),
+                    OverlayConfig.GameUpdate.INSTANCE.textShadow);
 
             lines++;
         }
@@ -112,7 +120,7 @@ public class GameUpdateOverlay extends Overlay {
 
         private MessageContainer(String message) {
             this.message = message;
-            this.endTime = System.currentTimeMillis() + (long)(OverlayConfig.GameUpdate.INSTANCE.messageTimeLimit * 1000);
+            this.endTime = System.currentTimeMillis() + (long) (OverlayConfig.GameUpdate.INSTANCE.messageTimeLimit * 1000);
         }
 
         public long getRemainingTime() {

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/GameUpdateOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/GameUpdateOverlay.java
@@ -61,7 +61,7 @@ public class GameUpdateOverlay extends Overlay {
                 break;  // breaks the loop if the limit was reached
 
             int lineOffset;
-            if (OverlayConfig.GameUpdate.INSTANCE.stackBeforeGrowth) {
+            if (OverlayConfig.GameUpdate.INSTANCE.newMessagesFirst) {
                 int messagesDisplayed = Math.min(messageQueue.size(), OverlayConfig.GameUpdate.INSTANCE.messageLimit);
                 lineOffset = (LINE_HEIGHT * (messagesDisplayed - lines));  // display newest messages at bottommost / topmost slot
             } else {

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/GameUpdateOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/GameUpdateOverlay.java
@@ -63,9 +63,9 @@ public class GameUpdateOverlay extends Overlay {
             int lineOffset;
             if (OverlayConfig.GameUpdate.INSTANCE.stackBeforeGrowth) {
                 int messagesDisplayed = Math.min(messageQueue.size(), OverlayConfig.GameUpdate.INSTANCE.messageLimit);
-                lineOffset = (LINE_HEIGHT * (messagesDisplayed - lines));
+                lineOffset = (LINE_HEIGHT * (messagesDisplayed - lines));  // display newest messages at bottommost / topmost slot
             } else {
-                lineOffset = (LINE_HEIGHT * lines);
+                lineOffset = (LINE_HEIGHT * lines); // otherwise newest messages will come after existing messages
             }
             int y;
             if (OverlayConfig.GameUpdate.INSTANCE.invertGrowth) {


### PR DESCRIPTION
Simple option in the configuration to allow messages in the game update ticker to be displayed first rather than stack on top of each other.

I'll explain with a couple of videos (pay attention to the update ticker):

(option disabled) https://streamable.com/bt98d7
new messages appear below the old ones (in the direction of growth), which doesn't make much sense with my config

(option enabled) https://streamable.com/w8cuzh
new messages now appear first, with older messages being pushed away, which makes more sense