### PR TITLE
Fix allowRetry

### DIFF
--- a/src/main/java/com/wynntils/modules/utilities/managers/MountHorseManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/MountHorseManager.java
@@ -35,6 +35,8 @@ public class MountHorseManager {
     private static final int remountTickDelay = 5;
     private static final int spawnAttempts = 8;
 
+    public static boolean ingamePrevention = false;
+
     public static boolean isPlayersHorse(Entity horse, String playerName) {
         return (horse instanceof AbstractHorse) && isPlayersHorse(horse.getCustomNameTag(), playerName);
     }
@@ -65,9 +67,15 @@ public class MountHorseManager {
     }
 
     private static void tryDelayedSpawnMount(Minecraft mc, HorseData horse, int attempts) {
+        if (ingamePrevention) {
+            ingamePrevention = false;
+            return;
+        }
+
         if (attempts <= 0) {
             String message = getMountHorseErrorMessage(MountHorseStatus.NO_HORSE);
             GameUpdateOverlay.queueMessage(TextFormatting.DARK_RED + message);
+            ingamePrevention = false;
             return;
         }
 
@@ -121,7 +129,11 @@ public class MountHorseManager {
                 tryDelayedSpawnMount(mc, horse, spawnAttempts);
                 return MountHorseStatus.SPAWNING;
             } else {
-                ClientEvents.isAwaitingHorseMount = true;
+                if (ingamePrevention) {
+                    ingamePrevention = false;
+                } else {
+                    ClientEvents.isAwaitingHorseMount = true;
+                }
                 return MountHorseStatus.SUCCESS;
             }
 

--- a/src/main/java/com/wynntils/modules/utilities/managers/MountHorseManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/MountHorseManager.java
@@ -64,6 +64,7 @@ public class MountHorseManager {
     public static MountHorseStatus mountHorse(boolean allowRetry) {
         Minecraft mc = ModCore.mc();
         EntityPlayerSP player = mc.player;
+        PlayerControllerMP playerController = mc.playerController;
 
         HorseData horse = PlayerInfo.get(HorseData.class);
 
@@ -77,7 +78,7 @@ public class MountHorseManager {
 
         Entity playersHorse = findHorseInRadius(mc);
 
-        int prev = mc.player.inventory.currentItem;
+        int prev = player.inventory.currentItem;
         boolean far = false;
         if (playersHorse != null) {
             double maxDistance = player.canEntityBeSeen(playersHorse) ? 36.0D : 9.0D;
@@ -89,15 +90,15 @@ public class MountHorseManager {
                 return MountHorseStatus.NO_HORSE;
             }
 
-            mc.player.inventory.currentItem = horse.getInventorySlot();
+            player.inventory.currentItem = horse.getInventorySlot();
             // No horse -> click to spawn; Horse too far -> despawn respawn
-            mc.playerController.processRightClick(player, player.world, EnumHand.MAIN_HAND);
-            mc.player.inventory.currentItem = prev;
+            playerController.processRightClick(player, player.world, EnumHand.MAIN_HAND);
+            player.inventory.currentItem = prev;
             if (far) {
                 new Delay(() -> {
-                    mc.player.inventory.currentItem = horse.getInventorySlot();
-                    mc.playerController.processRightClick(player, player.world, EnumHand.MAIN_HAND);
-                    mc.player.inventory.currentItem = prev;
+                    player.inventory.currentItem = horse.getInventorySlot();
+                    playerController.processRightClick(player, player.world, EnumHand.MAIN_HAND);
+                    player.inventory.currentItem = prev;
                 }, remountTickDelay);
             }
             ClientEvents.isAwaitingHorseMount = true;
@@ -105,9 +106,9 @@ public class MountHorseManager {
             return MountHorseStatus.SUCCESS;
         }
 
-        mc.player.inventory.currentItem = 8; // swap to soul points to avoid any right-click conflicts
-        mc.playerController.interactWithEntity(player, playersHorse, EnumHand.MAIN_HAND);
-        mc.player.inventory.currentItem = prev;
+        player.inventory.currentItem = 8; // swap to soul points to avoid any right-click conflicts
+        playerController.interactWithEntity(player, playersHorse, EnumHand.MAIN_HAND);
+        player.inventory.currentItem = prev;
         return MountHorseStatus.SUCCESS;
     }
 

--- a/src/main/java/com/wynntils/modules/utilities/managers/MountHorseManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/MountHorseManager.java
@@ -43,6 +43,24 @@ public class MountHorseManager {
         return defaultName.equals(horseName) || horseName.endsWith(customSuffix);
     }
 
+    private static Entity findHorseInRadius(Minecraft mc) {
+        EntityPlayerSP player = mc.player;
+
+        List<Entity> horses = mc.world.getEntitiesWithinAABB(AbstractHorse.class, new AxisAlignedBB(
+                player.posX - searchRadius, player.posY - searchRadius, player.posZ - searchRadius,
+                player.posX + searchRadius, player.posY + searchRadius, player.posZ + searchRadius
+        ));
+
+        String playerName = player.getName();
+
+        for (Entity h : horses) {
+            if (isPlayersHorse(h, playerName)) {
+                return h;
+            }
+        }
+        return null;
+    }
+
     public static MountHorseStatus mountHorse(boolean allowRetry) {
         Minecraft mc = ModCore.mc();
         EntityPlayerSP player = mc.player;
@@ -57,20 +75,7 @@ public class MountHorseManager {
             return MountHorseStatus.ALREADY_RIDING;
         }
 
-        List<Entity> horses = mc.world.getEntitiesWithinAABB(AbstractHorse.class, new AxisAlignedBB(
-                player.posX - searchRadius, player.posY - searchRadius, player.posZ - searchRadius,
-                player.posX + searchRadius, player.posY + searchRadius, player.posZ + searchRadius
-        ));
-
-        Entity playersHorse = null;
-        String playerName = player.getName();
-
-        for (Entity h : horses) {
-            if (isPlayersHorse(h, playerName)) {
-                playersHorse = h;
-                break;
-            }
-        }
+        Entity playersHorse = findHorseInRadius(mc);
 
         int prev = mc.player.inventory.currentItem;
         boolean far = false;

--- a/src/main/java/com/wynntils/modules/utilities/managers/MountHorseManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/MountHorseManager.java
@@ -46,7 +46,7 @@ public class MountHorseManager {
 
         HorseData horse = PlayerInfo.get(HorseData.class);
 
-        if (!horse.hasHorse() || horse.getInventorySlot() > 8 || !allowRetry) {
+        if (!horse.hasHorse() || horse.getInventorySlot() > 8) {
             return MountHorseStatus.NO_HORSE;
         }
 
@@ -77,6 +77,7 @@ public class MountHorseManager {
         }
 
         if (playersHorse == null || far) {
+            if(!allowRetry) return MountHorseStatus.NO_HORSE;
             mc.player.inventory.currentItem = horse.getInventorySlot();
             // No horse -> click to spawn; Horse too far -> despawn respawn
             mc.playerController.processRightClick(player, player.world, EnumHand.MAIN_HAND);

--- a/src/main/java/com/wynntils/modules/utilities/managers/MountHorseManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/MountHorseManager.java
@@ -77,7 +77,10 @@ public class MountHorseManager {
         }
 
         if (playersHorse == null || far) {
-            if(!allowRetry) return MountHorseStatus.NO_HORSE;
+            if (!allowRetry) {
+                return MountHorseStatus.NO_HORSE;
+            }
+            
             mc.player.inventory.currentItem = horse.getInventorySlot();
             // No horse -> click to spawn; Horse too far -> despawn respawn
             mc.playerController.processRightClick(player, player.world, EnumHand.MAIN_HAND);

--- a/src/main/java/com/wynntils/modules/utilities/managers/MountHorseManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/MountHorseManager.java
@@ -24,7 +24,7 @@ import java.util.List;
 public class MountHorseManager {
 
     public enum MountHorseStatus {
-        SUCCESS, ALREADY_RIDING, NO_HORSE, HORSE_TOO_FAR
+        SUCCESS, ALREADY_RIDING, NO_HORSE
     }
 
     private static final int searchRadius = 18;  // Search a bit further for message "too far" instead of "not found"
@@ -113,8 +113,6 @@ public class MountHorseManager {
                 return "You are already riding " + ridingEntityType;
             case NO_HORSE:
                 return "Your horse was unable to be found";
-            case HORSE_TOO_FAR:
-                return "Your horse is too far away";
             default:
                 return null;
         }

--- a/src/main/java/com/wynntils/modules/utilities/managers/MountHorseManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/MountHorseManager.java
@@ -63,7 +63,7 @@ public class MountHorseManager {
         return null;
     }
 
-    private static void tryDelayedSpawn(Minecraft mc, HorseData horse, int attempts, AtomicBoolean success) {
+    private static void tryDelayedSpawnMount(Minecraft mc, HorseData horse, int attempts, AtomicBoolean success) {
         if (attempts <= 0) {
             success.set(false);
             return;
@@ -77,8 +77,9 @@ public class MountHorseManager {
 
             if (findHorseInRadius(mc) != null) {
                 success.set(true);
+                ClientEvents.isAwaitingHorseMount = true;
             } else {
-                tryDelayedSpawn(mc, horse, attempts - 1, success);
+                tryDelayedSpawnMount(mc, horse, attempts - 1, success);
             }
         }, remountTickDelay);
     }

--- a/src/main/java/com/wynntils/modules/utilities/managers/MountHorseManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/MountHorseManager.java
@@ -13,6 +13,7 @@ import com.wynntils.modules.utilities.events.ClientEvents;
 import com.wynntils.modules.utilities.overlays.hud.GameUpdateOverlay;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
+import net.minecraft.client.multiplayer.PlayerControllerMP;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.EntityBoat;
 import net.minecraft.entity.passive.AbstractHorse;

--- a/src/main/java/com/wynntils/modules/utilities/managers/MountHorseManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/MountHorseManager.java
@@ -35,7 +35,7 @@ public class MountHorseManager {
     private static final int remountTickDelay = 5;
     private static final int spawnAttempts = 8;
 
-    public static boolean ingamePrevention = false;
+    private static boolean ingamePrevention = false;
 
     public static boolean isPlayersHorse(Entity horse, String playerName) {
         return (horse instanceof AbstractHorse) && isPlayersHorse(horse.getCustomNameTag(), playerName);
@@ -91,6 +91,10 @@ public class MountHorseManager {
             }
             tryDelayedSpawnMount(mc, horse, attempts - 1);
         }, remountTickDelay);
+    }
+
+    public static void preventNextMount() {
+        ingamePrevention = true;
     }
 
     public static MountHorseStatus mountHorse(boolean allowRetry) {

--- a/src/main/java/com/wynntils/modules/utilities/managers/MountHorseManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/MountHorseManager.java
@@ -71,16 +71,16 @@ public class MountHorseManager {
 
         int prev = mc.player.inventory.currentItem;
         boolean far = false;
-        if(playersHorse != null) {
+        if (playersHorse != null) {
             double maxDistance = player.canEntityBeSeen(playersHorse) ? 36.0D : 9.0D;
             far = player.getDistanceSq(playersHorse) > maxDistance;
         }
 
-        if(playersHorse == null || far) {
+        if (playersHorse == null || far) {
             mc.player.inventory.currentItem = horse.getInventorySlot();
             // No horse -> click to spawn; Horse too far -> despawn respawn
             mc.playerController.processRightClick(player, player.world, EnumHand.MAIN_HAND);
-            if(far) {
+            if (far) {
                 mc.playerController.processRightClick(player, player.world, EnumHand.MAIN_HAND);
             }
             mc.player.inventory.currentItem = prev;

--- a/src/main/java/com/wynntils/modules/utilities/managers/MountHorseManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/MountHorseManager.java
@@ -44,6 +44,12 @@ public class MountHorseManager {
         Minecraft mc = ModCore.mc();
         EntityPlayerSP player = mc.player;
 
+        HorseData horse = PlayerInfo.get(HorseData.class);
+
+        if (!horse.hasHorse() || horse.getInventorySlot() > 8 || !allowRetry) {
+            return MountHorseStatus.NO_HORSE;
+        }
+
         if (player.isRiding()) {
             return MountHorseStatus.ALREADY_RIDING;
         }
@@ -56,37 +62,28 @@ public class MountHorseManager {
         Entity playersHorse = null;
         String playerName = player.getName();
 
-        for (Entity horse : horses) {
-            if (isPlayersHorse(horse, playerName)) {
-                playersHorse = horse;
+        for (Entity h : horses) {
+            if (isPlayersHorse(h, playerName)) {
+                playersHorse = h;
                 break;
             }
         }
 
-        if (playersHorse == null) {
-            HorseData horse = PlayerInfo.get(HorseData.class);
+        int prev = mc.player.inventory.currentItem;
+        boolean far = playersHorse != null && player.getDistanceSq(playersHorse) > (player.canEntityBeSeen(playersHorse) ? 36.0D : 9.0D);
 
-            if (!horse.hasHorse() || horse.getInventorySlot() > 8 || !allowRetry) {
-                return MountHorseStatus.NO_HORSE;
-            }
-
-            int prev = mc.player.inventory.currentItem;
-
+        if(playersHorse == null || far) {
             mc.player.inventory.currentItem = horse.getInventorySlot();
+            // No horse -> click to spawn; Horse too far -> despawn respawn
             mc.playerController.processRightClick(player, player.world, EnumHand.MAIN_HAND);
+            if(far) {
+                mc.playerController.processRightClick(player, player.world, EnumHand.MAIN_HAND);
+            }
             mc.player.inventory.currentItem = prev;
-
             ClientEvents.isAwaitingHorseMount = true;
 
             return MountHorseStatus.SUCCESS;
         }
-
-        double maxDistance = player.canEntityBeSeen(playersHorse) ? 36.0D : 9.0D;
-        if (player.getDistanceSq(playersHorse) > maxDistance) {
-            return MountHorseStatus.HORSE_TOO_FAR;
-        }
-
-        int prev = mc.player.inventory.currentItem;
 
         mc.player.inventory.currentItem = 8; // swap to soul points to avoid any right-click conflicts
         mc.playerController.interactWithEntity(player, playersHorse, EnumHand.MAIN_HAND);

--- a/src/main/java/com/wynntils/modules/utilities/managers/MountHorseManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/MountHorseManager.java
@@ -87,9 +87,9 @@ public class MountHorseManager {
 
             if (findHorseInRadius(mc) != null) {
                 ClientEvents.isAwaitingHorseMount = true;
-            } else {
-                tryDelayedSpawnMount(mc, horse, attempts - 1);
+                return;
             }
+            tryDelayedSpawnMount(mc, horse, attempts - 1);
         }, remountTickDelay);
     }
 
@@ -128,14 +128,13 @@ public class MountHorseManager {
             if (far) {
                 tryDelayedSpawnMount(mc, horse, spawnAttempts);
                 return MountHorseStatus.SPAWNING;
-            } else {
-                if (ingamePrevention) {
-                    ingamePrevention = false;
-                } else {
-                    ClientEvents.isAwaitingHorseMount = true;
-                }
-                return MountHorseStatus.SUCCESS;
             }
+            if (ingamePrevention) {
+                ingamePrevention = false;
+            } else {
+                ClientEvents.isAwaitingHorseMount = true;
+            }
+            return MountHorseStatus.SUCCESS;
 
         }
 

--- a/src/main/java/com/wynntils/modules/utilities/managers/MountHorseManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/MountHorseManager.java
@@ -70,7 +70,11 @@ public class MountHorseManager {
         }
 
         int prev = mc.player.inventory.currentItem;
-        boolean far = playersHorse != null && player.getDistanceSq(playersHorse) > (player.canEntityBeSeen(playersHorse) ? 36.0D : 9.0D);
+        boolean far = false;
+        if(playersHorse != null) {
+            double maxDistance = player.canEntityBeSeen(playersHorse) ? 36.0D : 9.0D;
+            far = player.getDistanceSq(playersHorse) > maxDistance;
+        }
 
         if(playersHorse == null || far) {
             mc.player.inventory.currentItem = horse.getInventorySlot();

--- a/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
@@ -16,6 +16,7 @@ import com.wynntils.core.utils.reference.EmeraldSymbols;
 import com.wynntils.modules.utilities.UtilitiesModule;
 import com.wynntils.modules.utilities.configs.OverlayConfig;
 import com.wynntils.modules.utilities.instances.Toast;
+import com.wynntils.modules.utilities.managers.MountHorseManager;
 import com.wynntils.modules.utilities.overlays.hud.*;
 import com.wynntils.webapi.WebManager;
 import com.wynntils.webapi.profiles.item.enums.ItemTier;
@@ -182,6 +183,7 @@ public class OverlayEvents implements Listener {
                 case "There is no room for a horse.":
                     GameUpdateOverlay.queueMessage(DARK_RED + "There is no room for a horse.");
                     e.setCanceled(true);
+                    MountHorseManager.ingamePrevention = true;
                     return;
                 case "Since you interacted with your inventory, your horse has despawned.":
                     GameUpdateOverlay.queueMessage(LIGHT_PURPLE + "Horse despawned.");
@@ -190,6 +192,7 @@ public class OverlayEvents implements Listener {
                 case "Your horse is scared to come out right now, too many mobs are nearby.":
                     GameUpdateOverlay.queueMessage(DARK_RED + "Too many mobs nearby to spawn your horse");
                     e.setCanceled(true);
+                    MountHorseManager.ingamePrevention = true;
                     return;
             }
         }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
@@ -183,7 +183,7 @@ public class OverlayEvents implements Listener {
                 case "There is no room for a horse.":
                     GameUpdateOverlay.queueMessage(DARK_RED + "There is no room for a horse.");
                     e.setCanceled(true);
-                    MountHorseManager.ingamePrevention = true;
+                    MountHorseManager.preventNextMount();
                     return;
                 case "Since you interacted with your inventory, your horse has despawned.":
                     GameUpdateOverlay.queueMessage(LIGHT_PURPLE + "Horse despawned.");
@@ -192,7 +192,7 @@ public class OverlayEvents implements Listener {
                 case "Your horse is scared to come out right now, too many mobs are nearby.":
                     GameUpdateOverlay.queueMessage(DARK_RED + "Too many mobs nearby to spawn your horse");
                     e.setCanceled(true);
-                    MountHorseManager.ingamePrevention = true;
+                    MountHorseManager.preventNextMount();
                     return;
             }
         }


### PR DESCRIPTION
Thanks to @McPlayHD for mentioning the problem.  allowRetry was at the beginning, so when the horse spawned and the client event triggered for a second time it returned NO HORSE.  I moved that back into the null/far if statement.

Further testing revealed that there might need to be some modification to client events to actually get it to respawn, or maybe something else.  Current behavior is only despawning the horse on pressing the button which is in my opinion better than spitting out an error message, but I would prefer to get it to my original intention.

This PR is just to fix my original mistake.