### PR TITLE
Server selector displays server number properly

### DIFF
--- a/src/main/java/com/wynntils/modules/utilities/UtilitiesModule.java
+++ b/src/main/java/com/wynntils/modules/utilities/UtilitiesModule.java
@@ -52,6 +52,7 @@ public class UtilitiesModule extends Module {
         registerEvents(new ServerUptimeOverlay());
         registerEvents(new BankOverlay());
         registerEvents(new ServerSelectorOverlay());
+        registerEvents(new ServerNumberOverlay());
 
         // Real overlays
         registerOverlay(new WarTimerOverlay(), Priority.LOWEST);
@@ -122,7 +123,7 @@ public class UtilitiesModule extends Module {
     public GameUpdateOverlay getGameUpdateOverlay() {
         return gameUpdateOverlay;
     }
-    
+
     public ActionBarOverlay getActionBarOverlay() {
         return actionBarOverlay;
     }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ServerNumberOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ServerNumberOverlay.java
@@ -6,9 +6,7 @@ package com.wynntils.modules.utilities.overlays.inventories;
 
 import com.wynntils.core.events.custom.RenderEvent;
 import com.wynntils.core.framework.interfaces.Listener;
-import net.minecraft.client.Minecraft;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.text.TextComponentString;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ServerNumberOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ServerNumberOverlay.java
@@ -1,0 +1,39 @@
+/*
+ *  * Copyright © Wynntils - 2021.
+ */
+
+package com.wynntils.modules.utilities.overlays.inventories;
+
+import com.wynntils.core.events.custom.RenderEvent;
+import com.wynntils.core.framework.interfaces.Listener;
+import com.wynntils.modules.utilities.configs.UtilitiesConfig;
+import net.minecraft.client.Minecraft;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.text.TextFormatting;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+public class ServerNumberOverlay implements Listener {
+
+    @SubscribeEvent
+    public void onItemOverlay(RenderEvent.DrawItemOverlay event) {
+        if (!UtilitiesConfig.Items.INSTANCE.itemLevelOverlayOutsideGui && Minecraft.getMinecraft().currentScreen == null) return;
+
+        ItemStack serverStack = event.getStack();
+        String serverName = TextFormatting.getTextWithoutFormattingCodes(serverStack.getDisplayName());
+
+        assert serverName != null;
+        if (!serverName.startsWith("World")) return;
+        // If the "items" don't start with "World", assume we aren't in the server selector and just don't play with the numbers
+        // There is probably a better way to do this, but I can't get the container title "Wynncraft Servers" in this event, so here we are
+
+        // server number replacements
+        try {
+            int serverNumber = Integer.parseInt(serverName.replaceAll("[^0-9]+", ""));
+            event.setOverlayText(String.valueOf(serverNumber));
+        } catch (NumberFormatException ignored) {
+            // I know ignoring exceptions is probably not good, but I don't see a reason to throw some error or two into the user's logs
+            // This is only triggered when it scans for server names, looking for integers
+        }
+    }
+
+}

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ServerNumberOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ServerNumberOverlay.java
@@ -6,34 +6,31 @@ package com.wynntils.modules.utilities.overlays.inventories;
 
 import com.wynntils.core.events.custom.RenderEvent;
 import com.wynntils.core.framework.interfaces.Listener;
-import com.wynntils.modules.utilities.configs.UtilitiesConfig;
-import net.minecraft.client.Minecraft;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 public class ServerNumberOverlay implements Listener {
+
+    private static final Pattern WORLD_PATTERN = Pattern.compile("World (\\d+)?");
 
     @SubscribeEvent
     public void onItemOverlay(RenderEvent.DrawItemOverlay event) {
-        if (!UtilitiesConfig.Items.INSTANCE.itemLevelOverlayOutsideGui && Minecraft.getMinecraft().currentScreen == null) return;
 
         ItemStack serverStack = event.getStack();
         String serverName = TextFormatting.getTextWithoutFormattingCodes(serverStack.getDisplayName());
 
-        assert serverName != null;
-        if (!serverName.startsWith("World")) return;
-        // If the "items" don't start with "World", assume we aren't in the server selector and just don't play with the numbers
-        // There is probably a better way to do this, but I can't get the container title "Wynncraft Servers" in this event, so here we are
+        if (serverName == null) return;
 
-        // server number replacements
-        try {
-            int serverNumber = Integer.parseInt(serverName.replaceAll("[^0-9]+", ""));
-            event.setOverlayText(String.valueOf(serverNumber));
-        } catch (NumberFormatException ignored) {
-            // I know ignoring exceptions is probably not good, but I don't see a reason to throw some error or two into the user's logs
-            // This is only triggered when it scans for server names, looking for integers
-        }
+        // Check if item follows pattern "World #"
+        Matcher m = WORLD_PATTERN.matcher(serverName);
+        if (!m.lookingAt()) return;
+
+        int serverNumber = Integer.parseInt(serverName.replaceAll("[^0-9]+", ""));
+        event.setOverlayText(String.valueOf(serverNumber));
     }
 
 }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ServerNumberOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ServerNumberOverlay.java
@@ -6,7 +6,9 @@ package com.wynntils.modules.utilities.overlays.inventories;
 
 import com.wynntils.core.events.custom.RenderEvent;
 import com.wynntils.core.framework.interfaces.Listener;
+import net.minecraft.client.Minecraft;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.text.TextComponentString;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
@@ -15,7 +17,7 @@ import java.util.regex.Pattern;
 
 public class ServerNumberOverlay implements Listener {
 
-    private static final Pattern WORLD_PATTERN = Pattern.compile("World (\\d+)?");
+    private static final Pattern WORLD_PATTERN = Pattern.compile("World (\\d+)(?: \\(Recommended\\))?");
 
     @SubscribeEvent
     public void onItemOverlay(RenderEvent.DrawItemOverlay event) {
@@ -25,12 +27,11 @@ public class ServerNumberOverlay implements Listener {
 
         if (serverName == null) return;
 
-        // Check if item follows pattern "World #"
+        // Check if item follows pattern "World #" or "World # (Recommended)"
         Matcher m = WORLD_PATTERN.matcher(serverName);
-        if (!m.lookingAt()) return;
+        if (!m.matches()) return;
 
-        int serverNumber = Integer.parseInt(serverName.replaceAll("[^0-9]+", ""));
-        event.setOverlayText(String.valueOf(serverNumber));
+        event.setOverlayText(m.group(1));
     }
 
 }


### PR DESCRIPTION
Replaces the # of items display with actual server numbers, for servers above 64. Uses same method as the display item level feature, except it doesn't check if you're holding down a key. Tested on server 70, and also seems to not affect anything else in-game.