### PR TITLE
Added decimal ID slider option, fixed rounding of values near color boundaries

### DIFF
--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -112,6 +112,10 @@ public class UtilitiesConfig extends SettingsClass {
         @Setting(displayName = "Show Advanced Identifications", description = "Should items show advanced identifications?", order = 0)
         public boolean enabled = true;
 
+        @Setting.Limitations.IntLimit(min = 0, max = 4)
+        @Setting(displayName = "Advanced Identifications Decimal Places", description = "How many decimal places should advanced identifications have?\n\n§8 This requires your inventory to be reloaded to update. To do that, open the bank once.")
+        public int decimalPlaces = 0;
+
         @Setting(displayName = "Show Item Identification Stars", description = "Should the star rating of an item's identifications be shown?")
         public boolean addStars = false;
 

--- a/src/main/java/com/wynntils/modules/utilities/enums/IdentificationType.java
+++ b/src/main/java/com/wynntils/modules/utilities/enums/IdentificationType.java
@@ -10,11 +10,8 @@ import com.wynntils.modules.utilities.interfaces.IIdentificationAnalyser;
 import com.wynntils.webapi.profiles.item.objects.IdentificationContainer;
 import org.apache.commons.lang3.math.Fraction;
 
-import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.DecimalFormat;
-import java.text.NumberFormat;
-import java.util.regex.Pattern;
 
 import static net.minecraft.util.text.TextFormatting.*;
 


### PR DESCRIPTION
Decimal ID slider:
This is just a slider that goes from 0-4 that decides how many decimals to display for your % ID's. Pretty self-explanatory, requires inventory reload, either by opening bank or tapping shift while hovering over an item.
Value rounding:
Since I changed up how the % id's work somewhat, I might as well just fix rounding to be more normal. Old version was truncate, new version rounds up at half. This ends up being more consistent as well, for different decimal settings. See linked example for how the colors may change:
[https://donkeyblaster69.tk/xbackbone/QOMa4/KAbUTEku18.png](https://donkeyblaster69.tk/xbackbone/QOMa4/KAbUTEku18.png)