### PR TITLE
Identification improvements

### DIFF
--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -120,6 +120,9 @@ public class UtilitiesConfig extends SettingsClass {
         @Setting(displayName = "Show Item Identification Stars", description = "Should the star rating of an item's identifications be shown?")
         public boolean addStars = false;
 
+        @Setting(displayName = "Rainbow Perfect Items", description = "Should perfect items have rainbow names?")
+        public boolean rainbowPerfect = true;
+
         @Setting(displayName = "Categorize Identifications", description = "Should the identifications in an item's tooltip be categorized?")
         public boolean addSpacing = true;
 

--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -15,6 +15,8 @@ import com.wynntils.webapi.WebManager;
 import com.wynntils.webapi.profiles.item.ItemProfile;
 import com.wynntils.webapi.profiles.item.enums.ItemTier;
 
+import java.math.RoundingMode;
+import java.text.DecimalFormat;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -112,6 +114,9 @@ public class UtilitiesConfig extends SettingsClass {
         @Setting(displayName = "Show Advanced Identifications", description = "Should items show advanced identifications?", order = 0)
         public boolean enabled = true;
 
+        @Setting(displayName = "Advanced Identifications Decimal Places", description = "How many decimal places should advanced identifications have?\n\n§8 This requires your inventory to be reloaded to update. To do that, open the bank once.")
+        public IdentificationDecimalPlaces decimalPlaces = IdentificationDecimalPlaces.Zero;
+
         @Setting(displayName = "Show Item Identification Stars", description = "Should the star rating of an item's identifications be shown?")
         public boolean addStars = false;
 
@@ -129,6 +134,25 @@ public class UtilitiesConfig extends SettingsClass {
 
         @Setting(displayName = "Identification Price Guesses", description = "Should the guesses for prices of identifying unidentified items be displayed?\n\n§8 This requires your inventory to be reloaded to update. To do that, open the bank once.")
         public boolean showGuessesPrice = false;
+
+        public enum IdentificationDecimalPlaces {
+            Zero("0"),
+            One("0.0"),
+            Two("0.00"),
+            Three("0.000"),
+            Four("0.0000");
+
+            DecimalFormat df;
+
+            IdentificationDecimalPlaces(String format) {
+                df = new DecimalFormat(format);
+                df.setRoundingMode(RoundingMode.DOWN);
+            }
+
+            public String format(double number) {
+                return df.format(number);
+            }
+        }
 
     }
 

--- a/src/main/java/com/wynntils/modules/utilities/enums/IdentificationType.java
+++ b/src/main/java/com/wynntils/modules/utilities/enums/IdentificationType.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.utilities.enums;
 
+import com.wynntils.modules.utilities.configs.UtilitiesConfig;
 import com.wynntils.modules.utilities.instances.IdentificationResult;
 import com.wynntils.modules.utilities.interfaces.IIdentificationAnalyser;
 import com.wynntils.webapi.profiles.item.objects.IdentificationContainer;
@@ -17,9 +18,11 @@ public enum IdentificationType implements IIdentificationAnalyser {
 
         @Override
         public String getTitle(double specialAmount) {
+            String amountString = UtilitiesConfig.Identifications.INSTANCE.decimalPlaces.format(specialAmount * 100);
+
             int amount = normalize(specialAmount);
 
-            return amount != -1 ? getColor(amount) + "[" + amount + "%]" : GOLD + " NEW";
+            return amount != -1 ? getColor(amount) + "[" + amountString + "%]" : GOLD + " NEW";
         }
 
         @Override

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemIdentificationOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemIdentificationOverlay.java
@@ -323,7 +323,7 @@ public class ItemIdentificationOverlay implements Listener {
         }
 
         // check for item perfection
-        if (relativeTotal/idAmount >= 1d && idType == IdentificationType.PERCENTAGES && !hasNewId) {
+        if (relativeTotal/idAmount >= 1d && idType == IdentificationType.PERCENTAGES && !hasNewId && UtilitiesConfig.Identifications.INSTANCE.rainbowPerfect) {
             wynntils.setBoolean("isPerfect", true);
         }
 


### PR DESCRIPTION
Allows user to have 0-4 decimal points on ID percentages (default is 0).
Also adds an option to toggle rainbow names for perfect items.