### PR TITLE
Scoreboard overhaul

### DIFF
--- a/src/main/java/com/wynntils/modules/chat/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/chat/events/ClientEvents.java
@@ -43,7 +43,8 @@ public class ClientEvents implements Listener {
         ITextComponent msg = e.getMessage();
         if (msg.getUnformattedText().startsWith("[Info] ") && ChatConfig.INSTANCE.filterWynncraftInfo) {
             e.setCanceled(true);
-        } else if (msg.getFormattedText().startsWith("\n                       " + TextFormatting.GOLD + TextFormatting.BOLD + "Welcome to Wynncraft!") && ChatConfig.INSTANCE.filterWynncraftInfo) {
+        } else if (msg.getFormattedText().startsWith("\n                       " + TextFormatting.GOLD + TextFormatting.BOLD + "Welcome to Wynncraft!") &&
+                !msg.getFormattedText().contains("n the Trade Market") && ChatConfig.INSTANCE.filterWynncraftInfo) {
             e.setCanceled(true);
         } else if (msg.getFormattedText().startsWith(TextFormatting.GRAY + "[You are now entering") && ChatConfig.INSTANCE.filterTerritoryEnter) {
             e.setCanceled(true);

--- a/src/main/java/com/wynntils/modules/utilities/UtilitiesModule.java
+++ b/src/main/java/com/wynntils/modules/utilities/UtilitiesModule.java
@@ -71,6 +71,7 @@ public class UtilitiesModule extends Module {
         registerOverlay(new ConsumableTimerOverlay(), Priority.NORMAL);
         registerOverlay(new PlayerInfoOverlay(), Priority.HIGHEST);
         registerOverlay(new ObjectivesOverlay(), Priority.NORMAL);
+        registerOverlay(new ScoreboardOverlay(), Priority.NORMAL);
 
         infoFormatter = new InfoFormatter();
         registerOverlay(new InfoOverlay._1(), Priority.NORMAL);
@@ -115,6 +116,7 @@ public class UtilitiesModule extends Module {
         registerSettings(OverlayConfig.GameUpdate.RedirectSystemMessages.class);
         registerSettings(OverlayConfig.GameUpdate.TerritoryChangeMessages.class);
         registerSettings(OverlayConfig.Objectives.class);
+        registerSettings(OverlayConfig.Scoreboard.class);
     }
 
     public static UtilitiesModule getModule() {

--- a/src/main/java/com/wynntils/modules/utilities/configs/OverlayConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/OverlayConfig.java
@@ -16,6 +16,7 @@ import com.wynntils.core.utils.Utils;
 import com.wynntils.core.utils.reference.EmeraldSymbols;
 import com.wynntils.modules.core.enums.OverlayRotation;
 import com.wynntils.modules.utilities.overlays.hud.ObjectivesOverlay;
+import com.wynntils.modules.utilities.overlays.hud.ScoreboardOverlay;
 import com.wynntils.modules.utilities.overlays.hud.TerritoryFeedOverlay;
 import net.minecraft.client.Minecraft;
 import net.minecraft.util.text.TextFormatting;
@@ -748,6 +749,39 @@ public class OverlayConfig extends SettingsClass {
             a,
             b,
             c
+        }
+    }
+
+    @SettingsInfo(name = "scoreboard_settings", displayPath = "Utilities/Overlays/Scoreboard")
+    public static class Scoreboard extends SettingsClass {
+        public static Scoreboard INSTANCE;
+
+        @Setting(displayName = "Enable Scoreboard Overlay", description = "Should the custom Wynntils scoreboard be used?", order = 0)
+        public boolean enableScoreboard = true;
+
+        @Setting(displayName = "Show Scoreboard Numbers", description = "Should the numbers on the right side of the scoreboard be shown?", order = 1)
+        public boolean showNumbers = false;
+
+        @Setting(displayName = "Show Scoreboard Title", description = "Should the title at the top of the scoreboard be shown?", order = 2)
+        public boolean showTitle = true;
+
+        @Setting(displayName = "Show Compass Reminder", description = "Should the compass text be removed from the tracked quest section?", order = 3)
+        public boolean showCompass = false;
+
+        @Setting(displayName = "Background Opacity", description = "How dark should the background box be?", order = 4)
+        @Setting.Limitations.IntLimit(min = 0, max = 100)
+        public int opacity = 20;
+
+        @Setting(displayName = "Background Color", description = "What color should the text shadow be?\n\n§aClick the coloured box to open the colour wheel.", order = 5)
+        public CustomColor backgroundColor = CustomColor.fromInt(0x000000, 0.2f);
+
+        @Override
+        public void onSettingChanged(String name) {
+            backgroundColor.setA(opacity/100f);
+
+            if (name.equals("enableScoreboard")) {
+                ScoreboardOverlay.enableCustomScoreboard(enableScoreboard);
+            }
         }
     }
 }

--- a/src/main/java/com/wynntils/modules/utilities/configs/OverlayConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/OverlayConfig.java
@@ -732,10 +732,6 @@ public class OverlayConfig extends SettingsClass {
 
         @Override
         public void onSettingChanged(String name) {
-            if (name.equals("enableObjectives")) {
-                ObjectivesOverlay.updateOverlayActivation();
-            }
-
             if (name.equals("hideOnInactivity")) {
                 ObjectivesOverlay.refreshAllTimestamps();
             }

--- a/src/main/java/com/wynntils/modules/utilities/configs/OverlayConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/OverlayConfig.java
@@ -705,7 +705,7 @@ public class OverlayConfig extends SettingsClass {
     public static class Objectives extends SettingsClass {
         public static Objectives INSTANCE;
 
-        @Setting(displayName = "Enable Objectives Overlay", description = "Should the sidebar scoreboard be replaced by this overlay?", order = 0)
+        @Setting(displayName = "Enable Objectives Overlay", description = "Should the sidebar scoreboard be replaced by this overlay?\n\n§8This overlay works best if the scoreboard overlay is enabled as well.", order = 0)
         public boolean enableObjectives = true;
 
         @Setting(displayName = "Hide on Inactivity", description = "Should the overlay be hidden unless the objective has been updated?", order = 1)

--- a/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
@@ -685,11 +685,13 @@ public class OverlayEvents implements Listener {
     @SubscribeEvent
     public void onServerLeave(WynncraftServerEvent.Leave e) {
         ObjectivesOverlay.restoreVanillaScoreboard();
+        ScoreboardOverlay.enableCustomScoreboard(false);
     }
 
     @SubscribeEvent
     public void onServerJoin(WynncraftServerEvent.Login e) {
         ObjectivesOverlay.updateOverlayActivation();
+        ScoreboardOverlay.enableCustomScoreboard(OverlayConfig.Scoreboard.INSTANCE.enableScoreboard);
     }
 
     @SubscribeEvent

--- a/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
@@ -684,13 +684,12 @@ public class OverlayEvents implements Listener {
 
     @SubscribeEvent
     public void onServerLeave(WynncraftServerEvent.Leave e) {
-        ObjectivesOverlay.restoreVanillaScoreboard();
         ScoreboardOverlay.enableCustomScoreboard(false);
+        ObjectivesOverlay.resetObjectives();
     }
 
     @SubscribeEvent
     public void onServerJoin(WynncraftServerEvent.Login e) {
-        ObjectivesOverlay.updateOverlayActivation();
         ScoreboardOverlay.enableCustomScoreboard(OverlayConfig.Scoreboard.INSTANCE.enableScoreboard);
     }
 
@@ -714,7 +713,6 @@ public class OverlayEvents implements Listener {
     @SubscribeEvent
     public void onDisplayObjective(PacketEvent<SPacketDisplayObjective> e) {
         ObjectivesOverlay.checkForSidebar(e.getPacket());
-        e.setCanceled(OverlayConfig.Objectives.INSTANCE.enableObjectives);
     }
 
     @SubscribeEvent
@@ -724,7 +722,7 @@ public class OverlayEvents implements Listener {
 
     @SubscribeEvent
     public void onUpdateScore(PacketEvent<SPacketUpdateScore> e) {
-        e.setCanceled(ObjectivesOverlay.checkObjectiveUpdate(e.getPacket()) && OverlayConfig.Objectives.INSTANCE.enableObjectives);
+        ObjectivesOverlay.checkObjectiveUpdate(e.getPacket());
     }
 
     @SubscribeEvent

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/ObjectivesOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/ObjectivesOverlay.java
@@ -28,7 +28,8 @@ import java.util.regex.Pattern;
 
 public class ObjectivesOverlay extends Overlay {
 
-    private static final Pattern OBJECTIVE_PATTERN = Pattern.compile("^[- ] (.*): *([0-9]+)/([0-9]+)$");
+    public static final Pattern OBJECTIVE_PATTERN = Pattern.compile("^[- ] (.*): *([0-9]+)/([0-9]+)$");
+
     private static final int WIDTH = 130;
     private static final int HEIGHT = 52;
     private static final int MAX_OBJECTIVES = 3;

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/ObjectivesOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/ObjectivesOverlay.java
@@ -4,6 +4,9 @@
 
 package com.wynntils.modules.utilities.overlays.hud;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.GuiOverlapEvent;
 import com.wynntils.core.framework.overlays.Overlay;
@@ -11,20 +14,14 @@ import com.wynntils.core.framework.rendering.SmartFontRenderer;
 import com.wynntils.core.framework.rendering.colors.CustomColor;
 import com.wynntils.core.framework.rendering.textures.Textures;
 import com.wynntils.modules.utilities.configs.OverlayConfig;
-import net.minecraft.client.Minecraft;
+
 import net.minecraft.network.play.server.SPacketDisplayObjective;
 import net.minecraft.network.play.server.SPacketScoreboardObjective;
 import net.minecraft.network.play.server.SPacketUpdateScore;
-import net.minecraft.scoreboard.ScoreObjective;
-import net.minecraft.scoreboard.Scoreboard;
 import net.minecraft.util.text.ChatType;
 import net.minecraft.util.text.TextFormatting;
-import net.minecraftforge.client.GuiIngameForge;
 import net.minecraftforge.client.event.ClientChatReceivedEvent;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
-
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class ObjectivesOverlay extends Overlay {
 
@@ -39,7 +36,6 @@ public class ObjectivesOverlay extends Overlay {
     private static long keepVisibleTimestamp;
     private static int objectivesPosition;
     private static int objectivesEnd;
-    private static boolean daily;
 
     public ObjectivesOverlay() {
         super("Objectives", WIDTH, HEIGHT, true, 1f, 1f, -1, -1, OverlayGrowFrom.BOTTOM_RIGHT);
@@ -61,7 +57,6 @@ public class ObjectivesOverlay extends Overlay {
         }
         objectivesPosition = 0;
         objectivesEnd = 0;
-        daily = false;
 
         // Sidebar scoreboard is removed
         removeAllObjectives();
@@ -129,19 +124,10 @@ public class ObjectivesOverlay extends Overlay {
 
             String text = TextFormatting.getTextWithoutFormattingCodes(updateScore.getPlayerName());
             if (text.matches("Objectives?:") || text.matches("Daily Objectives?:")) {
-                if (text.contains("Daily")) {
-                    daily = true;
-                } else {
-                    daily = false;
-                }
                 objectivesPosition = updateScore.getScoreValue();
                 return true;
             } else if (updateScore.getPlayerName().equals(TextFormatting.BLACK.toString())) {
                 objectivesEnd = updateScore.getScoreValue();
-                Scoreboard scoreboard = Minecraft.getMinecraft().world.getScoreboard();
-                Minecraft.getMinecraft().addScheduledTask(() -> {
-                    scoreboard.setObjectiveInDisplaySlot(1, scoreboard.getObjective(sidebarObjectiveName));
-                });
                 return true;
             }
 
@@ -160,55 +146,9 @@ public class ObjectivesOverlay extends Overlay {
         return false;
     }
 
-    public static void updateOverlayActivation() {
-        if (Reference.onWorld) {
-            Scoreboard scoreboard = Minecraft.getMinecraft().world.getScoreboard();
-            ScoreObjective scoreObjective = scoreboard.getObjective(sidebarObjectiveName);
-            if (OverlayConfig.Objectives.INSTANCE.enableObjectives) {
-                if (objectivesPosition != 0) {
-                    if (daily) {
-                        scoreboard.removeObjectiveFromEntity(TextFormatting.RED + "" + TextFormatting.BOLD + "Daily Objective" + (objectives[1] != null ? "s" : "") + ":", scoreObjective);
-                    } else {
-                        scoreboard.removeObjectiveFromEntity(TextFormatting.GREEN + "" + TextFormatting.BOLD + "Objective" + (objectives[1] != null ? "s" : "") + ":", scoreObjective);
-                    }
-                }
-                if (objectivesEnd != 0) {
-                    scoreboard.removeObjectiveFromEntity(TextFormatting.BLACK.toString(), scoreObjective);
-                } else {
-                    scoreboard.setObjectiveInDisplaySlot(1, null);
-                }
-                for (Objective objective : objectives) {
-                    if (objective != null && !objective.getOriginal().isEmpty()) {
-                        scoreboard.removeObjectiveFromEntity(objective.getOriginal(), scoreObjective);
-                    }
-                }
-            } else {
-                if (objectivesPosition != 0) {
-                    if (daily) {
-                        scoreboard.getOrCreateScore(TextFormatting.RED + "" + TextFormatting.BOLD + "Daily Objective" + (objectives[1] != null ? "s" : "") + ":", scoreObjective).setScorePoints(objectivesPosition);
-                    } else {
-                        scoreboard.getOrCreateScore(TextFormatting.GREEN + "" + TextFormatting.BOLD + "Objective" + (objectives[1] != null ? "s" : "") + ":", scoreObjective).setScorePoints(objectivesPosition);
-                    }
-                }
-                if (objectivesEnd != 0) {
-                    scoreboard.getOrCreateScore(TextFormatting.BLACK.toString(), scoreObjective).setScorePoints(objectivesEnd);
-                }
-                scoreboard.setObjectiveInDisplaySlot(1, scoreObjective);
-                for (int i = 0; i < objectives.length; i++) {
-                    Objective objective = objectives[i];
-                    if (objective != null && !objective.getOriginal().isEmpty()) {
-                        scoreboard.getOrCreateScore(objective.getOriginal(), scoreObjective).setScorePoints(objectivesPosition - 1 - i);
-                    }
-                }
-            }
-        }
-    }
-
-    public static void restoreVanillaScoreboard() {
+    public static void resetObjectives() {
         objectivesPosition = 0;
         objectivesEnd = 0;
-        daily = false;
-        GuiIngameForge.renderObjective = true;
     }
 
     public static void refreshVisibility() {

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/ScoreboardOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/ScoreboardOverlay.java
@@ -89,6 +89,7 @@ public class ScoreboardOverlay extends Overlay {
 
     private void removeObjectiveLines(List<Score> scores) {
         scores.removeIf(s -> TextFormatting.getTextWithoutFormattingCodes(s.getPlayerName()).matches(ObjectivesOverlay.OBJECTIVE_PATTERN.pattern()));
+        scores.removeIf(s -> TextFormatting.getTextWithoutFormattingCodes(s.getPlayerName()).matches("- All done"));
         scores.removeIf(s -> TextFormatting.getTextWithoutFormattingCodes(s.getPlayerName()).matches("(Daily )?Objectives?:"));
     }
 

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/ScoreboardOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/ScoreboardOverlay.java
@@ -1,0 +1,119 @@
+package com.wynntils.modules.utilities.overlays.hud;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.wynntils.Reference;
+import com.wynntils.core.framework.overlays.Overlay;
+import com.wynntils.core.framework.rendering.SmartFontRenderer;
+import com.wynntils.core.framework.rendering.colors.CommonColors;
+import com.wynntils.modules.utilities.configs.OverlayConfig;
+
+import net.minecraft.scoreboard.Score;
+import net.minecraft.scoreboard.ScoreObjective;
+import net.minecraft.scoreboard.ScorePlayerTeam;
+import net.minecraft.scoreboard.Scoreboard;
+import net.minecraft.util.text.TextFormatting;
+import net.minecraftforge.client.GuiIngameForge;
+import net.minecraftforge.client.event.RenderGameOverlayEvent;
+
+public class ScoreboardOverlay extends Overlay {
+
+    public ScoreboardOverlay() {
+        super("Scoreboard", 125, 60, true, 1, 0.5f, 0, 0, OverlayGrowFrom.MIDDLE_RIGHT);
+    }
+
+
+    @Override
+    public void render(RenderGameOverlayEvent.Pre event) {
+        if (!Reference.onWorld || !OverlayConfig.Scoreboard.INSTANCE.enableScoreboard ||
+                event.getType() != RenderGameOverlayEvent.ElementType.ALL) return;
+
+        ScoreObjective objective = mc.world.getScoreboard().getObjectiveInDisplaySlot(1); // sidebar objective
+        if (objective == null) return;
+
+        // get the 15 highest scores
+        Scoreboard scoreboard = objective.getScoreboard();
+        List<Score> scores = Lists.newArrayList(Iterables.filter(scoreboard.getSortedScores(objective), s -> s.getPlayerName() != null && !s.getPlayerName().startsWith("#")));
+        if (scores.size() > 15) scores = new ArrayList<Score>(scores.subList(0, 15));
+
+        // remove objective, compass lines, then remove unnecessary blanks
+        if (OverlayConfig.Objectives.INSTANCE.enableObjectives) removeObjectiveLines(scores);
+        if (!OverlayConfig.Scoreboard.INSTANCE.showCompass) removeCompassLines(scores);
+        trimBlankLines(scores);
+
+        // nothing to display
+        if (scores.isEmpty()) return;
+
+        // calculate width based on widest line
+        int width = fontRenderer.getStringWidth(objective.getDisplayName());
+        for (Score s : scores) {
+            ScorePlayerTeam team = scoreboard.getPlayersTeam(s.getPlayerName());
+            String line = ScorePlayerTeam.formatPlayerName(team, s.getPlayerName());
+            if (OverlayConfig.Scoreboard.INSTANCE.showNumbers) line += ": " + TextFormatting.RED + s.getScorePoints();
+            width = Math.max(width, fontRenderer.getStringWidth(line));
+        }
+
+        int height = scores.size() * fontRenderer.FONT_HEIGHT;
+        int yOffset = height/3;
+        int xOffset = -3 - width;
+
+        // Background box
+        if (OverlayConfig.Scoreboard.INSTANCE.opacity > 0) {
+            int titleOffset = OverlayConfig.Scoreboard.INSTANCE.showTitle ? fontRenderer.FONT_HEIGHT + 1 : 1;
+            drawRect(OverlayConfig.Scoreboard.INSTANCE.backgroundColor, xOffset - 2, yOffset, -1, yOffset - height - titleOffset);
+        }
+
+        // draw lines
+        int lineCount = 1;
+        for (Score s : scores) {
+            ScorePlayerTeam team = scoreboard.getPlayersTeam(s.getPlayerName());
+            String name = ScorePlayerTeam.formatPlayerName(team, s.getPlayerName());
+            String score = TextFormatting.RED + "" + s.getScorePoints();
+
+            // draw line, including score if enabled
+            int y = yOffset - (lineCount * fontRenderer.FONT_HEIGHT);
+            drawString(name, xOffset, y, CommonColors.WHITE,SmartFontRenderer.TextAlignment.LEFT_RIGHT, SmartFontRenderer.TextShadow.NONE);
+            if (OverlayConfig.Scoreboard.INSTANCE.showNumbers) drawString(score, -1 - fontRenderer.getStringWidth(score), y, CommonColors.WHITE, SmartFontRenderer.TextAlignment.LEFT_RIGHT, SmartFontRenderer.TextShadow.NONE);
+
+            lineCount++;
+            if (lineCount > scores.size() && OverlayConfig.Scoreboard.INSTANCE.showTitle) { // end of scores, draw title if enabled
+                String title = objective.getDisplayName();
+                drawString(title, xOffset + width/2 - fontRenderer.getStringWidth(title)/2, y - fontRenderer.FONT_HEIGHT, CommonColors.WHITE, SmartFontRenderer.TextAlignment.LEFT_RIGHT, SmartFontRenderer.TextShadow.NONE);
+            }
+        }
+
+    }
+
+    private void removeObjectiveLines(List<Score> scores) {
+        scores.removeIf(s -> TextFormatting.getTextWithoutFormattingCodes(s.getPlayerName()).matches(ObjectivesOverlay.OBJECTIVE_PATTERN.pattern()));
+        scores.removeIf(s -> TextFormatting.getTextWithoutFormattingCodes(s.getPlayerName()).matches("(Daily )?Objectives?:"));
+    }
+
+    private void removeCompassLines(List<Score> scores) {
+        scores.removeIf(s -> s.getPlayerName().matches(TextFormatting.LIGHT_PURPLE + "(Follow your compass|to reach that location)"));
+    }
+
+    private void trimBlankLines(List<Score> scores) {
+        List<Score> toRemove = new ArrayList<>();
+        for (int i = scores.size()-1; i >= 0; i--) {
+            Score score = scores.get(i);
+            if (!TextFormatting.getTextWithoutFormattingCodes(score.getPlayerName()).isEmpty()) continue;
+            if (i == 0 || TextFormatting.getTextWithoutFormattingCodes(scores.get(i-1).getPlayerName()).isEmpty())
+                toRemove.add(score);
+        }
+
+        scores.removeAll(toRemove);
+
+        // remove title spacer if title is disabled
+        if (!OverlayConfig.Scoreboard.INSTANCE.showTitle && !scores.isEmpty() && TextFormatting.getTextWithoutFormattingCodes(scores.get(scores.size()-1).getPlayerName()).isEmpty())
+            scores.remove(scores.size()-1);
+    }
+
+    public static void enableCustomScoreboard(boolean enabled) {
+        GuiIngameForge.renderObjective = !enabled;
+    }
+
+}


### PR DESCRIPTION
Adds a custom scoreboard overlay that replaces and mimics the vanilla scoreboard, with options to reposition, remove the numbers on the side, remove the title of the scoreboard, change the color/opacity of the background, and remove some unnecessary text from the default quest tracker.

This implementation also fixes the issues with the objective overlay. Instead of directly manipulating the scoreboard, which caused it to disappear when it shouldn't have, lines are individually removed while rendering, ensuring that everything else is always visible.

I also added a small change to the filter for the welcome messages, which now displays them if they contain info on market items being bought/sold.