### PR TITLE
Add config option for disabling automatic update checks

### DIFF
--- a/src/main/java/com/wynntils/modules/core/config/CoreDBConfig.java
+++ b/src/main/java/com/wynntils/modules/core/config/CoreDBConfig.java
@@ -8,9 +8,12 @@ import com.wynntils.core.framework.enums.ClassType;
 import com.wynntils.core.framework.settings.annotations.Setting;
 import com.wynntils.core.framework.settings.annotations.SettingsInfo;
 import com.wynntils.core.framework.settings.instances.SettingsClass;
+import com.wynntils.core.utils.helpers.Delay;
 import com.wynntils.modules.core.enums.ScrollDirection;
 import com.wynntils.modules.core.enums.UpdateStream;
 import com.wynntils.webapi.WebManager;
+import net.minecraftforge.fml.common.Loader;
+import net.minecraftforge.fml.common.LoaderState;
 
 @SettingsInfo(name = "main", displayPath = "Core")
 public class CoreDBConfig extends SettingsClass {
@@ -33,6 +36,9 @@ public class CoreDBConfig extends SettingsClass {
             "§4Cutting Edge: §rThe mod will update whenever a new build is released. Cutting Edge builds will include features that are not yet in Stable versions and are currently in development but may also be less stable than Stable versions.", upload = false)
     public UpdateStream updateStream = UpdateStream.STABLE;
 
+    @Setting(displayName="Automatic Update Checks", description = "Should Wynntils automatically check for mod updates?", upload = false)
+    public boolean autoCheckUpdates = true;
+
     @Setting(displayName = "Scroll Direction", description = "Which direction should your mouse scroll for the page to scroll down?")
     public ScrollDirection scrollDirection = ScrollDirection.DOWN;
 
@@ -47,14 +53,16 @@ public class CoreDBConfig extends SettingsClass {
 
     @Setting(displayName = "Main Menu Wynncraft Button", description = "Should a button be added to the main menu that allows you to connect to Wynncraft directly?")
     public boolean addMainMenuButton = true;
-    
+
     @Setting(displayName = "Use Unicode Font", description = "Should Wynntils use the unicode font?")
     public boolean useUnicode = false;
 
     @Override
     public void onSettingChanged(String name) {
-        if (name.equals("updateStream")) {
-            WebManager.checkForUpdates();
+        // don't want to check for updates too early in the init process, since the config might not have finished
+        // loading yet and we want to respect the "autoCheckUpdates" option
+        if (name.equals("updateStream") && Loader.instance().hasReachedState(LoaderState.INITIALIZATION)) {
+            WebManager.checkForUpdates(true);
         }
     }
 }

--- a/src/main/java/com/wynntils/modules/core/instances/MainMenuButtons.java
+++ b/src/main/java/com/wynntils/modules/core/instances/MainMenuButtons.java
@@ -32,7 +32,7 @@ public class MainMenuButtons {
     private static final int WYNNCRAFT_BUTTON_ID = 3790627;
 
     private static WynncraftButton lastButton = null;
-    
+
     private static boolean alreadyLoaded = false;
 
     public static void addButtons(GuiMainMenu to, List<GuiButton> buttonList, boolean resize) {
@@ -43,7 +43,7 @@ public class MainMenuButtons {
             FMLClientHandler.instance().setupServerList();
 
             lastButton = new WynncraftButton(s, WYNNCRAFT_BUTTON_ID, to.width / 2 + 104, to.height / 4 + 48 + 24);
-            WebManager.checkForUpdates();
+            WebManager.checkForUpdates(true);
             UpdateOverlay.reset();
 
             buttonList.add(lastButton);

--- a/src/main/java/com/wynntils/modules/utilities/managers/KeyManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/KeyManager.java
@@ -47,7 +47,7 @@ public class KeyManager {
             ModCore.mc().gameSettings.gammaSetting = lastGamma;
         });
 
-        checkForUpdatesKey = CoreModule.getModule().registerKeyBinding("Check for Updates", Keyboard.KEY_L, "Wynntils", true, WebManager::checkForUpdates);
+        checkForUpdatesKey = CoreModule.getModule().registerKeyBinding("Check for Updates", Keyboard.KEY_L, "Wynntils", true, () -> WebManager.checkForUpdates(false));
 
         CoreModule.getModule().registerKeyBinding("Open Settings", Keyboard.KEY_P, "Wynntils", KeyConflictContext.IN_GAME, true, () -> ModCore.mc().displayGuiScreen(SettingsUI.getInstance(ModCore.mc().currentScreen)));
 

--- a/src/main/java/com/wynntils/webapi/WebManager.java
+++ b/src/main/java/com/wynntils/webapi/WebManager.java
@@ -11,6 +11,7 @@ import com.wynntils.Reference;
 import com.wynntils.core.events.custom.WynnGuildWarEvent;
 import com.wynntils.core.framework.FrameworkManager;
 import com.wynntils.core.utils.Utils;
+import com.wynntils.modules.core.config.CoreDBConfig;
 import com.wynntils.modules.core.overlays.UpdateOverlay;
 import com.wynntils.modules.map.MapModule;
 import com.wynntils.modules.map.overlays.objects.MapApiIcon;
@@ -135,10 +136,14 @@ public class WebManager {
             ignoringJoinUpdate = false;
             return;
         }
-        checkForUpdates();
+        checkForUpdates(true);
     }
 
-    public static void checkForUpdates() {
+    public static void checkForUpdates(boolean automatic) {
+        if (automatic && !CoreDBConfig.INSTANCE.autoCheckUpdates) {
+            return;
+        }
+
         if (Reference.developmentEnvironment) {
             Reference.LOGGER.info("An update check would have occurred, but you are in a development environment.");
             return;


### PR DESCRIPTION
I usually play on a custom build of Wynntils, and it's inconvenient having to click through an update screen every time I log into Wynncraft. This PR remedies the problem by adding a config option that disables automatic update checks.