### PR TITLE
Don't show distance to compass marker on minimap while it is nearby.

### DIFF
--- a/src/main/java/com/wynntils/modules/map/overlays/MiniMapOverlay.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/MiniMapOverlay.java
@@ -254,9 +254,6 @@ public class MiniMapOverlay extends Overlay {
                             drawTextOverlay(this, dx, dz, StringUtils.integerToShortString(Math.round((float)Math.sqrt(distanceSq) / scaleFactor)) + "m");
                     } else if (rendering) {
                         compassIcon.renderAt(this, dx + halfMapSize, dz + halfMapSize, sizeMultiplier, scaleFactor);
-
-                        if (MapConfig.INSTANCE.showCompassDistance)
-                            drawTextOverlay(this, dx + halfMapSize, dz + halfMapSize, StringUtils.integerToShortString(Math.round((float)Math.sqrt(distanceSq) / scaleFactor)) + "m");
                     }
                 }
             }


### PR DESCRIPTION
This is unnecessary and only clobbers the minimap view. Instead only show it when the marker is off the minimap.