### PR TITLE
Crowd-sourcing location/NPC detector

### DIFF
--- a/src/main/java/com/wynntils/core/utils/Utils.java
+++ b/src/main/java/com/wynntils/core/utils/Utils.java
@@ -47,8 +47,9 @@ import java.util.regex.Pattern;
 
 public class Utils {
 
-    @SuppressWarnings("unchecked")
     private static final DataParameter<String> NAME_KEY = ReflectionFields.Entity_CUSTOM_NAME.getValue(Entity.class);
+    private static final DataParameter<Boolean> NAME_VISIBLE_KEY = ReflectionFields.Entity_CUSTOM_NAME_VISIBLE.getValue(Entity.class);
+    private static final DataParameter<Boolean> ITEM_KEY = ReflectionFields.EntityItemFrame_ITEM.getValue(Entity.class);
     public static final Pattern CHAR_INFO_PAGE_TITLE = Pattern.compile("§c([0-9]+)§4 skill points? remaining");
     public static final Pattern SERVER_SELECTOR_TITLE = Pattern.compile("Wynncraft Servers(: Page \\d+)?");
 
@@ -396,6 +397,31 @@ public class Utils {
             }
         }
         return null;
+    }
+
+    public static boolean isNameVisibleFromMetadata(List <EntityDataManager.DataEntry<?>> dataManagerEntries) {
+        assert NAME_VISIBLE_KEY != null;
+        if (dataManagerEntries != null) {
+            for (EntityDataManager.DataEntry<?> entry : dataManagerEntries) {
+                if (NAME_VISIBLE_KEY.equals(entry.getKey())) {
+                    return (Boolean) entry.getValue();
+                }
+            }
+        }
+        // assume false if not specified
+        return false;
+    }
+
+    public static ItemStack getItemFromMetadata(List <EntityDataManager.DataEntry<?>> dataManagerEntries) {
+        assert ITEM_KEY != null;
+        if (dataManagerEntries != null) {
+            for (EntityDataManager.DataEntry<?> entry : dataManagerEntries) {
+                if (ITEM_KEY.equals(entry.getKey())) {
+                    return (ItemStack) entry.getValue();
+                }
+            }
+        }
+        return ItemStack.EMPTY;
     }
 
     // Alias if using already imported org.apache.commons.lang3.StringUtils

--- a/src/main/java/com/wynntils/core/utils/reflections/ReflectionFields.java
+++ b/src/main/java/com/wynntils/core/utils/reflections/ReflectionFields.java
@@ -14,6 +14,7 @@ import net.minecraft.client.gui.inventory.GuiScreenHorseInventory;
 import net.minecraft.client.model.ModelRenderer;
 import net.minecraft.client.renderer.RenderItem;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.item.EntityItemFrame;
 import net.minecraft.network.play.client.CPacketClientSettings;
 import net.minecraftforge.fml.common.eventhandler.Event;
 import net.minecraftforge.fml.relauncher.ReflectionHelper;
@@ -25,6 +26,8 @@ public enum ReflectionFields {
 
     GuiChest_lowerChestInventory(GuiChest.class, "lowerChestInventory", "field_147015_w"),
     Entity_CUSTOM_NAME(Entity.class, "CUSTOM_NAME", "field_184242_az"),
+    Entity_CUSTOM_NAME_VISIBLE(Entity.class, "CUSTOM_NAME_VISIBLE", "field_184233_aA"),
+    EntityItemFrame_ITEM(EntityItemFrame.class, "ITEM", "field_184525_c"),
     Event_phase(Event.class, "phase"),
     GuiScreen_buttonList(GuiScreen.class, "buttonList", "field_146292_n"),
     GuiScreenHorseInventory_horseEntity(GuiScreenHorseInventory.class, "horseEntity", "field_147034_x"),

--- a/src/main/java/com/wynntils/modules/core/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/core/events/ClientEvents.java
@@ -18,6 +18,7 @@ import com.wynntils.core.framework.instances.data.ActionBarData;
 import com.wynntils.core.framework.instances.data.CharacterData;
 import com.wynntils.core.framework.interfaces.Listener;
 import com.wynntils.core.utils.ItemUtils;
+import com.wynntils.core.utils.Utils;
 import com.wynntils.core.utils.objects.Location;
 import com.wynntils.core.utils.reflections.ReflectionFields;
 import com.wynntils.modules.core.instances.GatheringBake;
@@ -181,41 +182,26 @@ public class ClientEvents implements Listener {
         if (i == null) return;
 
         if (i instanceof EntityItemFrame) {
-            // We can't access the proper index so loop through all entries
-            for (EntityDataManager.DataEntry<?> next : e.getPacket().getDataManagerEntries()) {
-                if ((next.getValue() instanceof ItemStack)) {
-                    ItemStack item = (ItemStack)next.getValue();
-                    if (item.hasDisplayName()) {
-                        FrameworkManager.getEventBus().post(new LocationEvent.LabelFoundEvent(item.getDisplayName(), new Location(i), i));
-                    }
-                    return;
-                }
+            ItemStack item = Utils.getItemFromMetadata(e.getPacket().getDataManagerEntries());
+            if (item.hasDisplayName()) {
+                FrameworkManager.getEventBus().post(new LocationEvent.LabelFoundEvent(item.getDisplayName(), new Location(i), i));
             }
-            return;
         } else if (i instanceof EntityLiving) {
-            // We can't access the proper index so loop through all entries
-            for (EntityDataManager.DataEntry<?> next : e.getPacket().getDataManagerEntries()) {
-                if (!(next.getValue() instanceof String)) continue;
+            boolean visible = Utils.isNameVisibleFromMetadata(e.getPacket().getDataManagerEntries());
+            if (!visible) return;
 
-                String value = (String) next.getValue();
-                if (value == null || value.isEmpty()) return;
+            String value = Utils.getNameFromMetadata(e.getPacket().getDataManagerEntries());
+            if (value == null || value.isEmpty()) return;
 
-                FrameworkManager.getEventBus().post(new LocationEvent.EntityLabelFoundEvent(value, new Location(i), (EntityLiving) i));
-                return;
-            }
-
-            return;
+            FrameworkManager.getEventBus().post(new LocationEvent.EntityLabelFoundEvent(value, new Location(i), (EntityLiving) i));
         } else if (i instanceof EntityArmorStand) {
-            // We can't access the proper index so loop through all entries
-            for (EntityDataManager.DataEntry<?> next : e.getPacket().getDataManagerEntries()) {
-                if (!(next.getValue() instanceof String)) continue;
+            boolean visible = Utils.isNameVisibleFromMetadata(e.getPacket().getDataManagerEntries());
+            if (!visible) return;
 
-                String value = (String) next.getValue();
-                if (value == null || value.isEmpty()) return;
+            String value = Utils.getNameFromMetadata(e.getPacket().getDataManagerEntries());
+            if (value == null || value.isEmpty()) return;
 
-                FrameworkManager.getEventBus().post(new LocationEvent.LabelFoundEvent(value, new Location(i), i));
-                return;
-            }
+            FrameworkManager.getEventBus().post(new LocationEvent.LabelFoundEvent(value, new Location(i), i));
         }
     }
 

--- a/src/main/java/com/wynntils/modules/core/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/core/events/ClientEvents.java
@@ -21,7 +21,6 @@ import com.wynntils.core.utils.ItemUtils;
 import com.wynntils.core.utils.objects.Location;
 import com.wynntils.core.utils.reflections.ReflectionFields;
 import com.wynntils.modules.core.instances.GatheringBake;
-import com.wynntils.modules.core.instances.LabelBake;
 import com.wynntils.modules.core.instances.MainMenuButtons;
 import com.wynntils.modules.core.instances.TotemTracker;
 import com.wynntils.modules.core.managers.*;
@@ -45,7 +44,6 @@ import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.item.EntityArmorStand;
 import net.minecraft.entity.item.EntityItemFrame;
 import net.minecraft.entity.passive.AbstractHorse;
-import net.minecraft.entity.passive.EntityVillager;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.datasync.EntityDataManager;
@@ -124,17 +122,9 @@ public class ClientEvents implements Listener {
         }
     }
 
-    private static final Pattern GATHERING_STATUS = Pattern.compile("\\[\\+([0-9]*) [ⒸⒷⒿⓀ] (.*?) XP\\] \\[([0-9]*)%\\]");
-    private static final Pattern GATHERING_RESOURCE = Pattern.compile("\\[\\+([0-9]+) (.+)\\]");
-    private static final Pattern MOB_DAMAGE = DamageType.compileDamagePattern();
-
-    private static final Pattern MOB_LABEL = Pattern.compile("^.*\\[Lv. [0-9]+\\]$");
-    private static final Pattern HEALTH_LABEL = Pattern.compile("^\\[\\|+[0-9]+\\|+\\]$");
-    private static final Pattern TOTEM_LABEL = Pattern.compile("^[0-9]+s|\\+[0-9]+❤/s$");
-    private static final Pattern GATHERING_LABEL = Pattern.compile("^. [ⒸⒷⒿⓀ] .* Lv. Min: [0-9]+$");
-    private static final Pattern RESOURCE_LABEL = Pattern.compile("^(?:Right|Left)-Click for .*$");
-    private static final Pattern WYBEL_OWNER = Pattern.compile("^\\[.*\\]$");
-    private static final Pattern WYBEL_LEVEL = Pattern.compile("^Lv. [0-9]+.*$");
+    public static final Pattern GATHERING_STATUS = Pattern.compile("\\[\\+([0-9]*) [ⒸⒷⒿⓀ] (.*?) XP\\] \\[([0-9]*)%\\]");
+    public static final Pattern GATHERING_RESOURCE = Pattern.compile("\\[\\+([0-9]+) (.+)\\]");
+    public static final Pattern MOB_DAMAGE = DamageType.compileDamagePattern();
 
     // bake status
     private GatheringBake bakeStatus = null;
@@ -227,61 +217,6 @@ public class ClientEvents implements Listener {
                 return;
             }
         }
-    }
-
-    @SubscribeEvent
-    public void onTestLabelFound(LocationEvent.LabelFoundEvent event) {
-        String label = TextFormatting.getTextWithoutFormattingCodes(event.getLabel());
-        Location location = event.getLocation();
-
-        Matcher m = MOB_LABEL.matcher(label);
-        if (m.find()) return;
-
-        Matcher m2 = HEALTH_LABEL.matcher(label);
-        if (m2.find()) return;
-
-        Matcher m3 = MOB_DAMAGE.matcher(label);
-        if (m3.find()) return;
-
-        Matcher m4 = GATHERING_STATUS.matcher(label);
-        if (m4.find()) return;
-
-        Matcher m5 = GATHERING_RESOURCE.matcher(label);
-        if (m5.find()) return;
-
-        Matcher m6 = TOTEM_LABEL.matcher(label);
-        if (m6.find()) return;
-
-        Matcher m7 = GATHERING_LABEL.matcher(label);
-        if (m7.find()) return;
-
-        Matcher m8 = RESOURCE_LABEL.matcher(label);
-        if (m8.find()) return;
-
-        Matcher m9 = WYBEL_OWNER.matcher(label);
-        if (m9.find()) return;
-
-        Matcher m10 = WYBEL_LEVEL.matcher(label);
-        if (m10.find()) return;
-
-        LabelBake.handleLabel(label, location);
-    }
-
-    @SubscribeEvent
-    public void onTestEntityLabelFound(LocationEvent.EntityLabelFoundEvent event) {
-        String name = TextFormatting.getTextWithoutFormattingCodes(event.getLabel());
-        Location location = event.getLocation();
-        Entity entity = event.getEntity();
-
-        Matcher m = MOB_LABEL.matcher(name);
-        if (m.find()) return;
-
-        Matcher m2 = HEALTH_LABEL.matcher(name);
-        if (m2.find()) return;
-
-        if (!(entity instanceof EntityVillager)) return;
-
-        LabelBake.handleNpc(name, location);
     }
 
     @SubscribeEvent

--- a/src/main/java/com/wynntils/modules/core/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/core/events/ClientEvents.java
@@ -128,11 +128,13 @@ public class ClientEvents implements Listener {
     private static final Pattern GATHERING_RESOURCE = Pattern.compile("\\[\\+([0-9]+) (.+)\\]");
     private static final Pattern MOB_DAMAGE = DamageType.compileDamagePattern();
 
-    private static final Pattern MOB_LABEL = Pattern.compile(".*\\[Lv. [0-9]+\\]$");
+    private static final Pattern MOB_LABEL = Pattern.compile("^.*\\[Lv. [0-9]+\\]$");
     private static final Pattern HEALTH_LABEL = Pattern.compile("^\\[\\|+[0-9]+\\|+\\]$");
     private static final Pattern TOTEM_LABEL = Pattern.compile("^[0-9]+s|\\+[0-9]+❤/s$");
     private static final Pattern GATHERING_LABEL = Pattern.compile("^. [ⒸⒷⒿⓀ] .* Lv. Min: [0-9]+$");
     private static final Pattern RESOURCE_LABEL = Pattern.compile("^(?:Right|Left)-Click for .*$");
+    private static final Pattern WYBEL_OWNER = Pattern.compile("^\\[.*\\]$");
+    private static final Pattern WYBEL_LEVEL = Pattern.compile("^Lv. [0-9]+.*$");
 
     // bake status
     private GatheringBake bakeStatus = null;
@@ -255,6 +257,12 @@ public class ClientEvents implements Listener {
 
         Matcher m8 = RESOURCE_LABEL.matcher(label);
         if (m8.find()) return;
+
+        Matcher m9 = WYBEL_OWNER.matcher(label);
+        if (m9.find()) return;
+
+        Matcher m10 = WYBEL_LEVEL.matcher(label);
+        if (m10.find()) return;
 
         LabelBake.handleLabel(label, location);
     }

--- a/src/main/java/com/wynntils/modules/core/instances/LabelBake.java
+++ b/src/main/java/com/wynntils/modules/core/instances/LabelBake.java
@@ -1,0 +1,182 @@
+/*
+ *  * Copyright © Wynntils - 2021.
+ */
+
+package com.wynntils.modules.core.instances;
+
+import com.wynntils.core.utils.objects.Location;
+
+import java.util.*;
+import java.util.function.BiPredicate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class LabelBake {
+    public static class LabelLocation {
+        private final int x;
+        private final int z;
+
+        public int getX() {
+            return x;
+        }
+
+        public int getZ() {
+            return z;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            LabelLocation that = (LabelLocation) o;
+
+            if (x != that.x) return false;
+            return z == that.z;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = x;
+            result = 31 * result + z;
+            return result;
+        }
+
+        public LabelLocation(int x, int z) {
+            this.x = x;
+            this.z = z;
+        }
+
+        public LabelLocation(Location location) {
+            this.x = (int) location.x;
+            this.z = (int) location.z;
+        }
+    }
+
+    public static class BakeCollector<K, V> {
+        private final Map<K, List<V>> map = new HashMap<>();
+        private final BiPredicate<K, List<V>> verifier;
+
+        public BakeCollector(BiPredicate<K, List<V>> verifier) {
+            this.verifier = verifier;
+        }
+
+        public void addAndVerify(K key, V value) {
+            List<V> values = map.get(key);
+            if (values == null) {
+                values = new LinkedList<>();
+                values.add(value);
+                map.put(key, values);
+            } else {
+                values.add(value);
+                if (verifier.test(key, values)) {
+                    // Finished baking, remove key
+                    map.remove(key);
+                }
+            }
+        }
+    }
+
+    private static final List<String> markers = Arrays.asList(
+            "Armour Merchant",
+            "Blacksmith",
+            "Click to go to your housing plot",
+            "Dungeon Scroll Merchant",
+            "Emerald Merchant",
+            "Item Identifier",
+            "Liquid Merchant",
+            "Party Finder",
+            "Potion Merchant",
+            "Powder Master",
+            "Scroll Merchant",
+            "Trade Market",
+            "Weapon Merchant",
+            "Ⓛ Alchemism Ⓛ",
+            "Ⓗ Armouring Ⓗ",
+            "Ⓐ Cooking Ⓐ",
+            "Ⓓ Jeweling Ⓓ",
+            "Ⓔ Scribing Ⓔ",
+            "Ⓕ Tailoring Ⓕ",
+            "Ⓖ Weaponsmithing Ⓖ",
+            "Ⓘ Woodworking Ⓘ");
+
+    private static final List<String> ignore = Arrays.asList(
+            "Buy & sell items",
+            "on the market",
+            "Looking for a group?",
+            "Accessories",
+            "Boots and Pants",
+            "Bows",
+            "Click for Options",
+            "Crafting Station",
+            "Food",
+            "Helmets and Chestplates",
+            "Potions",
+            "Scrolls",
+            "Spears and Daggers",
+            "Bows, Wands and Reliks",
+            "Left-Click to set up booth"
+            );
+
+    private static final Pattern WYBEL_OWNER = Pattern.compile("^(?:\\[.*\\])|(?:.*'s .*)$");
+    private static final Pattern WYBEL_LEVEL = Pattern.compile("^Lv. [0-9]+.*$");
+
+    private static final BakeCollector<LabelLocation, String> npcBaker = new BakeCollector<>(LabelBake::npcBakeVerifier);
+
+    private static boolean npcBakeVerifier(LabelLocation location, List<String> labels) {
+        if (labels.stream().anyMatch(x -> x.equals("NPC"))) {
+            String npcName = labels.stream().filter(x -> !x.equals("NPC")).findFirst().get();
+            System.out.println("NPC: " + npcName + ", " + location);
+            return true;
+        }
+        return false;
+    }
+
+    public static void handleLabel(String label, Location location) {
+        if (markers.stream().anyMatch(l -> l.equals(label))) {
+   //         System.out.println("MARKER: " + label + ", " + location);
+            return;
+        }
+        if (ignore.stream().anyMatch(l -> l.equals(label))) {
+    //        System.out.println("IGNORE: " + label + ", " + location);
+            return;
+        }
+
+        // bake shop
+        if (label.endsWith("'s Shop")) {
+            System.out.println("SHOP:" + label + ", " + location);
+            return;
+        }
+
+// bake wybel
+        Matcher m9 = WYBEL_OWNER.matcher(label);
+        if (m9.find()) {
+            System.out.println("MATCH WYB_OWN:" + label);
+            return;
+        }
+
+        Matcher m10 = WYBEL_LEVEL.matcher(label);
+        if (m10.find()) {
+            System.out.println("MATCH WYB_LEV:" + label);
+            return;
+        }
+
+        // bake npc
+        if (label.equals("NPC")) {
+    //        System.out.println("NPC_AT:" + label + ", " + location);
+            npcBaker.addAndVerify(new LabelLocation(location), label);
+            return;
+        }
+
+        System.out.println("OTHER: " + label + ", " + location);
+        npcBaker.addAndVerify(new LabelLocation(location), label);
+    }
+
+    public static void handleNpc(String label, Location location) {
+        if (!(label.equals("Sell, scrap and repair items") || label.equals("NPC"))) return;
+// bake NPC
+        npcBaker.addAndVerify(new LabelLocation(location), label);
+   //     System.out.println("BOT_AT: " + label + ", " + location);
+    }
+
+}

--- a/src/main/java/com/wynntils/modules/core/instances/LabelBake.java
+++ b/src/main/java/com/wynntils/modules/core/instances/LabelBake.java
@@ -77,6 +77,42 @@ public class LabelBake {
         }
     }
 
+    public static class NpcBaker {
+        private final Map<LabelLocation, String> nameMap = new HashMap<>();
+        private final Map<LabelLocation, Location> locationMap = new HashMap<>();
+
+        public void registerNpcLocation(Location location) {
+            LabelLocation l = new LabelLocation(location);
+            String name = nameMap.get(l);
+            if (name != null) {
+                finalizeNpc(location, name);
+            } else {
+                locationMap.put(l, location);
+            }
+
+        }
+
+        public void registerName(String name, Location location) {
+            LabelLocation l = new LabelLocation(location);
+            Location orgLoc = locationMap.get(l);
+            if (orgLoc != null) {
+                finalizeNpc(orgLoc, name);
+            } else {
+                nameMap.put(l, name);
+            }
+        }
+
+        private void finalizeNpc(Location location, String name) {
+            System.out.println("NPC: " + name + ", " + location);
+            detectedNpcs.put(location, name);
+        }
+
+    }
+
+    private static final NpcBaker npcBaker = new NpcBaker();
+    private static final Map<Location, String> detectedNpcs = new HashMap<>();
+    private static final Map<Location, String> detectedServices = new HashMap<>();
+
     private static final List<String> markers = Arrays.asList(
             "Armour Merchant",
             "Blacksmith",
@@ -118,65 +154,58 @@ public class LabelBake {
             "Left-Click to set up booth"
             );
 
-    private static final Pattern WYBEL_OWNER = Pattern.compile("^(?:\\[.*\\])|(?:.*'s .*)$");
-    private static final Pattern WYBEL_LEVEL = Pattern.compile("^Lv. [0-9]+.*$");
 
-    private static final BakeCollector<LabelLocation, String> npcBaker = new BakeCollector<>(LabelBake::npcBakeVerifier);
 
     private static boolean npcBakeVerifier(LabelLocation location, List<String> labels) {
         if (labels.stream().anyMatch(x -> x.equals("NPC"))) {
             String npcName = labels.stream().filter(x -> !x.equals("NPC")).findFirst().get();
-            System.out.println("NPC: " + npcName + ", " + location);
             return true;
         }
         return false;
     }
 
+    public static void dumpDetectedLocations(String filename) {
+        for (Location key : detectedNpcs.keySet()) {
+            String name = detectedNpcs.get(key);
+            printInstance("NPC", name, key);
+        }
+
+        for (Location key : detectedServices.keySet()) {
+            String name = detectedServices.get(key);
+            printInstance("Service", name, key);
+        }
+    }
+
+    private static void printInstance(String type, String name, Location key) {
+        System.out.println(type + ": " + name + ": " + key);
+    }
+
     public static void handleLabel(String label, Location location) {
         if (markers.stream().anyMatch(l -> l.equals(label))) {
-   //         System.out.println("MARKER: " + label + ", " + location);
-            return;
-        }
-        if (ignore.stream().anyMatch(l -> l.equals(label))) {
-    //        System.out.println("IGNORE: " + label + ", " + location);
-            return;
-        }
-
-        // bake shop
-        if (label.endsWith("'s Shop")) {
-            System.out.println("SHOP:" + label + ", " + location);
+            System.out.println("MARKER: " + label + ", " + location);
+            detectedServices.put(location, label);
+            dumpDetectedLocations("");
             return;
         }
 
-// bake wybel
-        Matcher m9 = WYBEL_OWNER.matcher(label);
-        if (m9.find()) {
-            System.out.println("MATCH WYB_OWN:" + label);
-            return;
-        }
+        if (ignore.stream().anyMatch(l -> l.equals(label))) return;
 
-        Matcher m10 = WYBEL_LEVEL.matcher(label);
-        if (m10.find()) {
-            System.out.println("MATCH WYB_LEV:" + label);
-            return;
-        }
+        // Ignore shops
+        if (label.endsWith("'s Shop")) return;
 
-        // bake npc
         if (label.equals("NPC")) {
-    //        System.out.println("NPC_AT:" + label + ", " + location);
-            npcBaker.addAndVerify(new LabelLocation(location), label);
+            npcBaker.registerNpcLocation(location);
             return;
         }
 
-        System.out.println("OTHER: " + label + ", " + location);
-        npcBaker.addAndVerify(new LabelLocation(location), label);
+        // It might be an NPC name
+        npcBaker.registerName(label, location);
     }
 
     public static void handleNpc(String label, Location location) {
         if (!(label.equals("Sell, scrap and repair items") || label.equals("NPC"))) return;
-// bake NPC
-        npcBaker.addAndVerify(new LabelLocation(location), label);
-   //     System.out.println("BOT_AT: " + label + ", " + location);
+
+        npcBaker.registerNpcLocation(location);
     }
 
 }

--- a/src/main/java/com/wynntils/modules/map/MapModule.java
+++ b/src/main/java/com/wynntils/modules/map/MapModule.java
@@ -10,6 +10,7 @@ import com.wynntils.core.framework.instances.KeyHolder;
 import com.wynntils.core.framework.instances.Module;
 import com.wynntils.core.framework.interfaces.annotations.ModuleInfo;
 import com.wynntils.core.utils.Utils;
+import com.wynntils.modules.map.commands.CommandDetection;
 import com.wynntils.modules.map.commands.CommandLocate;
 import com.wynntils.modules.map.commands.CommandLootRun;
 import com.wynntils.modules.map.configs.MapConfig;
@@ -58,6 +59,7 @@ public class MapModule extends Module {
 
         registerCommand(new CommandLootRun());
         registerCommand(new CommandLocate());
+        registerCommand(new CommandDetection());
 
         registerKeyBinding("New Waypoint", Keyboard.KEY_B, "Wynntils", KeyConflictContext.IN_GAME, true, () -> {
             if (Reference.onWorld)

--- a/src/main/java/com/wynntils/modules/map/commands/CommandDetection.java
+++ b/src/main/java/com/wynntils/modules/map/commands/CommandDetection.java
@@ -91,7 +91,14 @@ public class CommandDetection extends CommandBase implements IClientCommand {
                 serviceCount++;
             }
 
-            sender.sendMessage(new TextComponentString("Wrote " + npcCount + " NPCs and " + serviceCount + " services to " + filename));
+            int otherCount = 0;
+            for (LabelBake.LabelLocation key : LabelBake.npcBaker.nameMap.keySet()) {
+                String name = LabelBake.npcBaker.nameMap.get(key);
+                printInstance(ps, "Other", name, new Location(key.getX(), 0, key.getZ()));
+                otherCount++;
+            }
+
+            sender.sendMessage(new TextComponentString("Wrote " + npcCount + " NPCs, " + serviceCount + " services and " + otherCount + " other to " + filename));
         } catch (FileNotFoundException e) {
             sender.sendMessage(new TextComponentString("Invalid filename"));
             e.printStackTrace();

--- a/src/main/java/com/wynntils/modules/map/commands/CommandDetection.java
+++ b/src/main/java/com/wynntils/modules/map/commands/CommandDetection.java
@@ -1,0 +1,77 @@
+/*
+ *  * Copyright © Wynntils - 2018 - 2021.
+ */
+
+package com.wynntils.modules.map.commands;
+
+import com.wynntils.modules.map.instances.LabelBake;
+import com.wynntils.webapi.WebManager;
+import com.wynntils.webapi.profiles.LocationProfile;
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.CommandException;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.command.WrongUsageException;
+import net.minecraft.server.MinecraftServer;
+import net.minecraftforge.client.IClientCommand;
+
+import java.util.*;
+
+public class CommandDetection extends CommandBase implements IClientCommand {
+    Map<String, List<LocationProfile>> mapFeatures = new HashMap<>();
+
+    public CommandDetection() {
+        for (LocationProfile location : WebManager.getNonIgnoredApiMarkers()) {
+            mapFeatures.put(getFeatureKey(location), getProfileList(location));
+        }
+        for (LocationProfile location : WebManager.getNpcLocations()) {
+            mapFeatures.put(getFeatureKey(location), Collections.singletonList(location));
+        }
+        for (LocationProfile location : WebManager.getMapLabels()) {
+            mapFeatures.put(getFeatureKey(location), Collections.singletonList(location));
+        }
+    }
+
+    private List<LocationProfile> getProfileList(LocationProfile location) {
+        List<LocationProfile> knownProfiles = mapFeatures.get(getFeatureKey(location));
+        if (knownProfiles == null) {
+            knownProfiles = new LinkedList<>();
+        }
+        knownProfiles.add(location);
+        return knownProfiles;
+    }
+
+    private String getFeatureKey(LocationProfile location) {
+        return location.getTranslatedName().replace(" ", "_");
+    }
+
+    @Override
+    public boolean allowUsageWithoutPrefix(ICommandSender sender, String message) {
+        return false;
+    }
+
+    @Override
+    public String getName() {
+        return "detection";
+    }
+
+    @Override
+    public String getUsage(ICommandSender sender) {
+        return "detection <output filename>";
+    }
+
+    @Override
+    public int getRequiredPermissionLevel() {
+        return 0;
+    }
+
+    @Override
+    public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException {
+        if (args.length == 0) {
+            throw new WrongUsageException("/" + getUsage(sender));
+        }
+
+        String filename = args[0];
+        LabelBake.dumpDetectedLocations(filename);
+    }
+
+}

--- a/src/main/java/com/wynntils/modules/map/commands/CommandDetection.java
+++ b/src/main/java/com/wynntils/modules/map/commands/CommandDetection.java
@@ -91,16 +91,23 @@ public class CommandDetection extends CommandBase implements IClientCommand {
                 serviceCount++;
             }
 
+            int dungeonCount = 0;
+            for (Location key : LabelBake.detectedDungeons.keySet()) {
+                String name = LabelBake.detectedDungeons.get(key);
+                printInstance(ps, "Dungeon", name, "...", key);
+                dungeonCount++;
+            }
+
             int otherCount = 0;
-            for (LabelBake.LabelLocation key : LabelBake.npcBaker.nameMap.keySet()) {
-                String name = LabelBake.npcBaker.nameMap.get(key);
-                String formattedName = LabelBake.npcBaker.formattedNameMap.get(key);
-                Location location = LabelBake.npcBaker.otherLocMap.get(key);
+            for (LabelBake.LabelLocation key : LabelBake.locationBaker.nameMap.keySet()) {
+                String name = LabelBake.locationBaker.nameMap.get(key);
+                String formattedName = LabelBake.locationBaker.formattedNameMap.get(key);
+                Location location = LabelBake.locationBaker.otherLocMap.get(key);
                 printInstance(ps, "Other", name, formattedName, location);
                 otherCount++;
             }
 
-            sender.sendMessage(new TextComponentString("Wrote " + npcCount + " NPCs, " + serviceCount + " services and " + otherCount + " other to " + filename));
+            sender.sendMessage(new TextComponentString("Wrote " + npcCount + " NPCs, " + serviceCount + " services, " + dungeonCount + " dungeons and " + otherCount + " other to " + filename));
         } catch (FileNotFoundException e) {
             sender.sendMessage(new TextComponentString("Invalid filename"));
             e.printStackTrace();

--- a/src/main/java/com/wynntils/modules/map/commands/CommandDetection.java
+++ b/src/main/java/com/wynntils/modules/map/commands/CommandDetection.java
@@ -80,21 +80,23 @@ public class CommandDetection extends CommandBase implements IClientCommand {
             int npcCount = 0;
             for (Location key : LabelBake.detectedNpcs.keySet()) {
                 String name = LabelBake.detectedNpcs.get(key);
-                printInstance(ps, "NPC", name, key);
+                printInstance(ps, "NPC", name, "...", key);
                 npcCount++;
             }
 
             int serviceCount = 0;
             for (Location key : LabelBake.detectedServices.keySet()) {
                 String name = LabelBake.detectedServices.get(key);
-                printInstance(ps, "Service", name, key);
+                printInstance(ps, "Service", name, "...", key);
                 serviceCount++;
             }
 
             int otherCount = 0;
             for (LabelBake.LabelLocation key : LabelBake.npcBaker.nameMap.keySet()) {
                 String name = LabelBake.npcBaker.nameMap.get(key);
-                printInstance(ps, "Other", name, new Location(key.getX(), 0, key.getZ()));
+                String formattedName = LabelBake.npcBaker.formattedNameMap.get(key);
+                Location location = LabelBake.npcBaker.otherLocMap.get(key);
+                printInstance(ps, "Other", name, formattedName, location);
                 otherCount++;
             }
 
@@ -105,9 +107,9 @@ public class CommandDetection extends CommandBase implements IClientCommand {
         }
     }
 
-    private void printInstance(PrintStream ps, String type, String name, Location key) {
+    private void printInstance(PrintStream ps, String type, String name, String formattedName, Location key) {
         // Write a CSV line
-        ps.println(type + ", " + name + ", " + (int) Math.round(key.x) + ", " + (int) Math.round(key.y) + ", " + (int) Math.round(key.z));
+        ps.println(type + ", " + name + ", " + formattedName + ", " + (int) Math.round(key.x) + ", " + (int) Math.round(key.y) + ", " + (int) Math.round(key.z));
     }
 
 }

--- a/src/main/java/com/wynntils/modules/map/commands/CommandDetection.java
+++ b/src/main/java/com/wynntils/modules/map/commands/CommandDetection.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.map.commands;
 
+import com.wynntils.core.utils.objects.Location;
 import com.wynntils.modules.map.instances.LabelBake;
 import com.wynntils.webapi.WebManager;
 import com.wynntils.webapi.profiles.LocationProfile;
@@ -12,8 +13,11 @@ import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.command.WrongUsageException;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.text.TextComponentString;
 import net.minecraftforge.client.IClientCommand;
 
+import java.io.FileNotFoundException;
+import java.io.PrintStream;
 import java.util.*;
 
 public class CommandDetection extends CommandBase implements IClientCommand {
@@ -71,7 +75,32 @@ public class CommandDetection extends CommandBase implements IClientCommand {
         }
 
         String filename = args[0];
-        LabelBake.dumpDetectedLocations(filename);
+
+        try (PrintStream ps = new PrintStream(filename)) {
+            int npcCount = 0;
+            for (Location key : LabelBake.detectedNpcs.keySet()) {
+                String name = LabelBake.detectedNpcs.get(key);
+                printInstance(ps, "NPC", name, key);
+                npcCount++;
+            }
+
+            int serviceCount = 0;
+            for (Location key : LabelBake.detectedServices.keySet()) {
+                String name = LabelBake.detectedServices.get(key);
+                printInstance(ps, "Service", name, key);
+                serviceCount++;
+            }
+
+            sender.sendMessage(new TextComponentString("Wrote " + npcCount + " NPCs and " + serviceCount + " services to " + filename));
+        } catch (FileNotFoundException e) {
+            sender.sendMessage(new TextComponentString("Invalid filename"));
+            e.printStackTrace();
+        }
+    }
+
+    private void printInstance(PrintStream ps, String type, String name, Location key) {
+        // Write a CSV line
+        ps.println(type + ", " + name + ", " + (int) Math.round(key.x) + ", " + (int) Math.round(key.y) + ", " + (int) Math.round(key.z));
     }
 
 }

--- a/src/main/java/com/wynntils/modules/map/commands/CommandDetection.java
+++ b/src/main/java/com/wynntils/modules/map/commands/CommandDetection.java
@@ -77,11 +77,18 @@ public class CommandDetection extends CommandBase implements IClientCommand {
         String filename = args[0];
 
         try (PrintStream ps = new PrintStream(filename)) {
-            int npcCount = 0;
-            for (Location key : LabelBake.detectedNpcs.keySet()) {
-                String name = LabelBake.detectedNpcs.get(key);
-                printInstance(ps, "NPC", name, "...", key);
-                npcCount++;
+
+            int bakedCount = 0;
+            for (LabelBake.BakerType type : LabelBake.BakerType.values()) {
+                Map<Location, String> m = LabelBake.locationBaker.detectedTypes.get(type);
+                for (Location key : m.keySet()) {
+                    String name = m.get(key);
+                    if (type == LabelBake.BakerType.BOOTH) {
+                        name = "Booth Shop"; // hide current owner
+                    }
+                    printInstance(ps, type.name(), name, "...", key);
+                    bakedCount++;
+                }
             }
 
             int serviceCount = 0;
@@ -89,13 +96,6 @@ public class CommandDetection extends CommandBase implements IClientCommand {
                 String name = LabelBake.detectedServices.get(key);
                 printInstance(ps, "Service", name, "...", key);
                 serviceCount++;
-            }
-
-            int dungeonCount = 0;
-            for (Location key : LabelBake.detectedDungeons.keySet()) {
-                String name = LabelBake.detectedDungeons.get(key);
-                printInstance(ps, "Dungeon", name, "...", key);
-                dungeonCount++;
             }
 
             int otherCount = 0;
@@ -107,7 +107,7 @@ public class CommandDetection extends CommandBase implements IClientCommand {
                 otherCount++;
             }
 
-            sender.sendMessage(new TextComponentString("Wrote " + npcCount + " NPCs, " + serviceCount + " services, " + dungeonCount + " dungeons and " + otherCount + " other to " + filename));
+            sender.sendMessage(new TextComponentString("Wrote " + bakedCount + " baked types, " + serviceCount + " services and " + otherCount + " other to " + filename));
         } catch (FileNotFoundException e) {
             sender.sendMessage(new TextComponentString("Invalid filename"));
             e.printStackTrace();

--- a/src/main/java/com/wynntils/modules/map/configs/MapConfig.java
+++ b/src/main/java/com/wynntils/modules/map/configs/MapConfig.java
@@ -242,6 +242,8 @@ public class MapConfig extends SettingsClass {
         @Setting(displayName = "Contribute Gathering Spots", description = "Should the mod send data about your collected gathering spots?\n\n§8Wynntils uses this data in order to place gathering spots on the map. Allowing the mod to send data is completely optional, and your contributions are always appreciated. Disabling this will still allow you to see gathering spots.", order = 1)
         public boolean allowGatheringSpot = true;
 
+        @Setting(displayName = "Enable Location Detection (Experimental)", description = "Should NPC/service detection be activated?", order = 8)
+        public boolean enableLocationDetection = false;
     }
 
     public enum MapFormat {

--- a/src/main/java/com/wynntils/modules/map/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/map/events/ClientEvents.java
@@ -141,9 +141,10 @@ public class ClientEvents implements Listener {
         GuildResourceManager.processAdvancements(event.getPacket());
     }
 
-
     @SubscribeEvent
-    public void onTestLabelFound(LocationEvent.LabelFoundEvent event) {
+    public void labelDetection(LocationEvent.LabelFoundEvent event) {
+        if (!MapConfig.Telemetry.INSTANCE.enableLocationDetection) return;
+
         String label = TextFormatting.getTextWithoutFormattingCodes(event.getLabel());
         Location location = event.getLocation();
 
@@ -181,7 +182,9 @@ public class ClientEvents implements Listener {
     }
 
     @SubscribeEvent
-    public void onTestEntityLabelFound(LocationEvent.EntityLabelFoundEvent event) {
+    public void labelDetectEntity(LocationEvent.EntityLabelFoundEvent event) {
+        if (!MapConfig.Telemetry.INSTANCE.enableLocationDetection) return;
+
         String name = TextFormatting.getTextWithoutFormattingCodes(event.getLabel());
         Location location = event.getLocation();
         Entity entity = event.getEntity();
@@ -196,5 +199,4 @@ public class ClientEvents implements Listener {
 
         LabelBake.handleNpc(name, location);
     }
-
 }

--- a/src/main/java/com/wynntils/modules/map/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/map/events/ClientEvents.java
@@ -7,10 +7,12 @@ package com.wynntils.modules.map.events;
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.GameEvent;
 import com.wynntils.core.events.custom.GuiOverlapEvent;
+import com.wynntils.core.events.custom.LocationEvent;
 import com.wynntils.core.events.custom.PacketEvent;
 import com.wynntils.core.framework.interfaces.Listener;
 import com.wynntils.core.framework.rendering.colors.CommonColors;
 import com.wynntils.core.utils.objects.Location;
+import com.wynntils.modules.map.instances.LabelBake;
 import com.wynntils.modules.core.managers.CompassManager;
 import com.wynntils.modules.map.MapModule;
 import com.wynntils.modules.map.configs.MapConfig;
@@ -26,15 +28,29 @@ import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.passive.EntityVillager;
 import net.minecraft.network.play.server.SPacketAdvancementInfo;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.client.event.RenderWorldLastEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.wynntils.modules.core.events.ClientEvents.*;
+
 public class ClientEvents implements Listener {
+    private static final Pattern MOB_LABEL = Pattern.compile("^.*\\[Lv. [0-9]+\\]$");
+    private static final Pattern HEALTH_LABEL = Pattern.compile("^\\[\\|+[0-9]+\\|+\\]$");
+    private static final Pattern TOTEM_LABEL = Pattern.compile("^[0-9]+s|\\+[0-9]+❤/s$");
+    private static final Pattern GATHERING_LABEL = Pattern.compile("^. [ⒸⒷⒿⓀ] .* Lv. Min: [0-9]+$");
+    private static final Pattern RESOURCE_LABEL = Pattern.compile("^(?:Right|Left)-Click for .*$");
+    private static final Pattern WYBEL_OWNER = Pattern.compile("^\\[.*\\]$");
+    private static final Pattern WYBEL_LEVEL = Pattern.compile("^Lv. [0-9]+.*$");
 
     BlockPos lastLocation = null;
 
@@ -123,6 +139,62 @@ public class ClientEvents implements Listener {
     public void receiveAdvancements(PacketEvent.Incoming<SPacketAdvancementInfo> event) {
         // can be done async without problems
         GuildResourceManager.processAdvancements(event.getPacket());
+    }
+
+
+    @SubscribeEvent
+    public void onTestLabelFound(LocationEvent.LabelFoundEvent event) {
+        String label = TextFormatting.getTextWithoutFormattingCodes(event.getLabel());
+        Location location = event.getLocation();
+
+        Matcher m = MOB_LABEL.matcher(label);
+        if (m.find()) return;
+
+        Matcher m2 = HEALTH_LABEL.matcher(label);
+        if (m2.find()) return;
+
+        Matcher m3 = MOB_DAMAGE.matcher(label);
+        if (m3.find()) return;
+
+        Matcher m4 = GATHERING_STATUS.matcher(label);
+        if (m4.find()) return;
+
+        Matcher m5 = GATHERING_RESOURCE.matcher(label);
+        if (m5.find()) return;
+
+        Matcher m6 = TOTEM_LABEL.matcher(label);
+        if (m6.find()) return;
+
+        Matcher m7 = GATHERING_LABEL.matcher(label);
+        if (m7.find()) return;
+
+        Matcher m8 = RESOURCE_LABEL.matcher(label);
+        if (m8.find()) return;
+
+        Matcher m9 = WYBEL_OWNER.matcher(label);
+        if (m9.find()) return;
+
+        Matcher m10 = WYBEL_LEVEL.matcher(label);
+        if (m10.find()) return;
+
+        LabelBake.handleLabel(label, location);
+    }
+
+    @SubscribeEvent
+    public void onTestEntityLabelFound(LocationEvent.EntityLabelFoundEvent event) {
+        String name = TextFormatting.getTextWithoutFormattingCodes(event.getLabel());
+        Location location = event.getLocation();
+        Entity entity = event.getEntity();
+
+        Matcher m = MOB_LABEL.matcher(name);
+        if (m.find()) return;
+
+        Matcher m2 = HEALTH_LABEL.matcher(name);
+        if (m2.find()) return;
+
+        if (!(entity instanceof EntityVillager)) return;
+
+        LabelBake.handleNpc(name, location);
     }
 
 }

--- a/src/main/java/com/wynntils/modules/map/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/map/events/ClientEvents.java
@@ -43,7 +43,7 @@ import static com.wynntils.modules.core.events.ClientEvents.*;
 public class ClientEvents implements Listener {
     private static final Pattern MOB_LABEL = Pattern.compile("^.*\\[Lv. [0-9]+\\]$");
     private static final Pattern HEALTH_LABEL = Pattern.compile("^\\[\\|+[0-9]+\\|+\\]$");
-    private static final Pattern TOTEM_LABEL = Pattern.compile("^§c[0-9]+s|\\+[0-9]+❤/s$");
+    private static final Pattern TOTEM_LABEL = Pattern.compile("^§c[0-9]+s|\\§c+[0-9]+❤/§7s$");
     private static final Pattern GATHERING_LABEL = Pattern.compile("^. [ⒸⒷⒿⓀ] .* Lv. Min: [0-9]+$");
     private static final Pattern RESOURCE_LABEL = Pattern.compile("^(?:Right|Left)-Click for .*$");
     private static final Pattern WYBEL_OWNER = Pattern.compile("^§7\\[.*\\]$");

--- a/src/main/java/com/wynntils/modules/map/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/map/events/ClientEvents.java
@@ -162,10 +162,7 @@ public class ClientEvents implements Listener {
         if (m5.find()) return;
 
         Matcher m6 = TOTEM_LABEL.matcher(formattedLabel);
-        if (m6.find()) {
-            System.out.println("Matching totem: " + formattedLabel);
-            return;
-        }
+        if (m6.find()) return;
 
         Matcher m7 = GATHERING_LABEL.matcher(label);
         if (m7.find()) return;
@@ -174,16 +171,10 @@ public class ClientEvents implements Listener {
         if (m8.find()) return;
 
         Matcher m9 = WYBEL_OWNER.matcher(formattedLabel);
-        if (m9.find()) {
-            System.out.println("Matching owner: " + formattedLabel);
-            return;
-        }
+        if (m9.find()) return;
 
         Matcher m10 = WYBEL_LEVEL.matcher(formattedLabel);
-        if (m10.find()) {
-            System.out.println("Matching wybel: " + formattedLabel);
-            return;
-        }
+        if (m10.find()) return;
 
 
         LabelBake.handleLabel(label, event.getLabel(), location);

--- a/src/main/java/com/wynntils/modules/map/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/map/events/ClientEvents.java
@@ -5,10 +5,7 @@
 package com.wynntils.modules.map.events;
 
 import com.wynntils.Reference;
-import com.wynntils.core.events.custom.GameEvent;
-import com.wynntils.core.events.custom.GuiOverlapEvent;
-import com.wynntils.core.events.custom.LocationEvent;
-import com.wynntils.core.events.custom.PacketEvent;
+import com.wynntils.core.events.custom.*;
 import com.wynntils.core.framework.interfaces.Listener;
 import com.wynntils.core.framework.rendering.colors.CommonColors;
 import com.wynntils.core.utils.objects.Location;
@@ -46,11 +43,11 @@ import static com.wynntils.modules.core.events.ClientEvents.*;
 public class ClientEvents implements Listener {
     private static final Pattern MOB_LABEL = Pattern.compile("^.*\\[Lv. [0-9]+\\]$");
     private static final Pattern HEALTH_LABEL = Pattern.compile("^\\[\\|+[0-9]+\\|+\\]$");
-    private static final Pattern TOTEM_LABEL = Pattern.compile("^[0-9]+s|\\+[0-9]+❤/s$");
+    private static final Pattern TOTEM_LABEL = Pattern.compile("^§c[0-9]+s|\\+[0-9]+❤/s$");
     private static final Pattern GATHERING_LABEL = Pattern.compile("^. [ⒸⒷⒿⓀ] .* Lv. Min: [0-9]+$");
     private static final Pattern RESOURCE_LABEL = Pattern.compile("^(?:Right|Left)-Click for .*$");
-    private static final Pattern WYBEL_OWNER = Pattern.compile("^\\[.*\\]$");
-    private static final Pattern WYBEL_LEVEL = Pattern.compile("^Lv. [0-9]+.*$");
+    private static final Pattern WYBEL_OWNER = Pattern.compile("^§7\\[.*\\]$");
+    private static final Pattern WYBEL_LEVEL = Pattern.compile("^§2Lv. §a[0-9]+.*$");
 
     BlockPos lastLocation = null;
 
@@ -145,7 +142,8 @@ public class ClientEvents implements Listener {
     public void labelDetection(LocationEvent.LabelFoundEvent event) {
         if (!MapConfig.Telemetry.INSTANCE.enableLocationDetection) return;
 
-        String label = TextFormatting.getTextWithoutFormattingCodes(event.getLabel());
+        String formattedLabel = event.getLabel();
+        String label = TextFormatting.getTextWithoutFormattingCodes(formattedLabel);
         Location location = event.getLocation();
 
         Matcher m = MOB_LABEL.matcher(label);
@@ -163,8 +161,11 @@ public class ClientEvents implements Listener {
         Matcher m5 = GATHERING_RESOURCE.matcher(label);
         if (m5.find()) return;
 
-        Matcher m6 = TOTEM_LABEL.matcher(label);
-        if (m6.find()) return;
+        Matcher m6 = TOTEM_LABEL.matcher(formattedLabel);
+        if (m6.find()) {
+            System.out.println("Matching totem: " + formattedLabel);
+            return;
+        }
 
         Matcher m7 = GATHERING_LABEL.matcher(label);
         if (m7.find()) return;
@@ -172,13 +173,20 @@ public class ClientEvents implements Listener {
         Matcher m8 = RESOURCE_LABEL.matcher(label);
         if (m8.find()) return;
 
-        Matcher m9 = WYBEL_OWNER.matcher(label);
-        if (m9.find()) return;
+        Matcher m9 = WYBEL_OWNER.matcher(formattedLabel);
+        if (m9.find()) {
+            System.out.println("Matching owner: " + formattedLabel);
+            return;
+        }
 
-        Matcher m10 = WYBEL_LEVEL.matcher(label);
-        if (m10.find()) return;
+        Matcher m10 = WYBEL_LEVEL.matcher(formattedLabel);
+        if (m10.find()) {
+            System.out.println("Matching wybel: " + formattedLabel);
+            return;
+        }
 
-        LabelBake.handleLabel(label, location);
+
+        LabelBake.handleLabel(label, event.getLabel(), location);
     }
 
     @SubscribeEvent
@@ -197,6 +205,12 @@ public class ClientEvents implements Listener {
 
         if (!(entity instanceof EntityVillager)) return;
 
-        LabelBake.handleNpc(name, location);
+        LabelBake.handleNpc(name, event.getLabel(), location);
     }
+
+    @SubscribeEvent
+    public void onWorldJoin(WynnWorldEvent.Join e) {
+        LabelBake.onWorldJoin(e);
+    }
+
 }

--- a/src/main/java/com/wynntils/modules/map/instances/LabelBake.java
+++ b/src/main/java/com/wynntils/modules/map/instances/LabelBake.java
@@ -86,7 +86,6 @@ public class LabelBake {
         // It might be an NPC name
         locationBaker.registerName(label, formattedLabel, location);
         String frm = formattedLabel.replace("§", "%");
-        System.out.println("LABEL: " + label + " " + location + " " + frm + "==" + formattedLabel);
     }
 
     public static void handleNpc(String label, String formattedLabel, Location location) {
@@ -137,8 +136,6 @@ public class LabelBake {
             LabelLocation l = new LabelLocation(location);
             String name = nameMap.get(l);
             if (name != null) {
-                String formattedName = formattedNameMap.get(l);
-                System.out.println(type + "(g): " + name + " as " + formattedName);
                 finalizeType(type, location, name);
                 nameMap.remove(l);
                 formattedNameMap.remove(l);

--- a/src/main/java/com/wynntils/modules/map/instances/LabelBake.java
+++ b/src/main/java/com/wynntils/modules/map/instances/LabelBake.java
@@ -52,13 +52,12 @@ public class LabelBake {
             "Left-Click to set up booth"
     );
 
-    private static final NpcBaker npcBaker = new NpcBaker();
+    public static final NpcBaker npcBaker = new NpcBaker();
     public static final Map<Location, String> detectedNpcs = new HashMap<>();
     public static final Map<Location, String> detectedServices = new HashMap<>();
 
     public static void handleLabel(String label, Location location) {
         if (MARKERS.stream().anyMatch(l -> l.equals(label))) {
-            System.out.println("MARKER: " + label + ", " + location);
             detectedServices.put(location, label);
             return;
         }
@@ -84,7 +83,7 @@ public class LabelBake {
     }
 
     public static class NpcBaker {
-        private final Map<LabelLocation, String> nameMap = new HashMap<>();
+        public final Map<LabelLocation, String> nameMap = new HashMap<>();
         private final Map<LabelLocation, Location> locationMap = new HashMap<>();
 
         public void registerNpcLocation(Location location) {
@@ -108,7 +107,6 @@ public class LabelBake {
         }
 
         private void finalizeNpc(Location location, String name) {
-            System.out.println("NPC: " + name + ", " + location);
             detectedNpcs.put(location, name);
         }
     }

--- a/src/main/java/com/wynntils/modules/map/instances/LabelBake.java
+++ b/src/main/java/com/wynntils/modules/map/instances/LabelBake.java
@@ -53,24 +53,8 @@ public class LabelBake {
     );
 
     private static final NpcBaker npcBaker = new NpcBaker();
-    private static final Map<Location, String> detectedNpcs = new HashMap<>();
-    private static final Map<Location, String> detectedServices = new HashMap<>();
-
-    public static void dumpDetectedLocations(String filename) {
-        for (Location key : detectedNpcs.keySet()) {
-            String name = detectedNpcs.get(key);
-            printInstance("NPC", name, key);
-        }
-
-        for (Location key : detectedServices.keySet()) {
-            String name = detectedServices.get(key);
-            printInstance("Service", name, key);
-        }
-    }
-
-    private static void printInstance(String type, String name, Location key) {
-        System.out.println(type + ": " + name + ": " + key);
-    }
+    public static final Map<Location, String> detectedNpcs = new HashMap<>();
+    public static final Map<Location, String> detectedServices = new HashMap<>();
 
     public static void handleLabel(String label, Location location) {
         if (MARKERS.stream().anyMatch(l -> l.equals(label))) {

--- a/src/main/java/com/wynntils/modules/map/instances/LabelBake.java
+++ b/src/main/java/com/wynntils/modules/map/instances/LabelBake.java
@@ -2,7 +2,7 @@
  *  * Copyright © Wynntils - 2021.
  */
 
-package com.wynntils.modules.core.instances;
+package com.wynntils.modules.map.instances;
 
 import com.wynntils.core.utils.objects.Location;
 

--- a/src/main/java/com/wynntils/modules/map/instances/LabelBake.java
+++ b/src/main/java/com/wynntils/modules/map/instances/LabelBake.java
@@ -7,11 +7,128 @@ package com.wynntils.modules.map.instances;
 import com.wynntils.core.utils.objects.Location;
 
 import java.util.*;
-import java.util.function.BiPredicate;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class LabelBake {
+
+    private static final List<String> MARKERS = Arrays.asList(
+            "Armour Merchant",
+            "Blacksmith",
+            "Click to go to your housing plot",
+            "Dungeon Scroll Merchant",
+            "Emerald Merchant",
+            "Item Identifier",
+            "Liquid Merchant",
+            "Party Finder",
+            "Potion Merchant",
+            "Powder Master",
+            "Scroll Merchant",
+            "Trade Market",
+            "Weapon Merchant",
+            "Ⓛ Alchemism Ⓛ",
+            "Ⓗ Armouring Ⓗ",
+            "Ⓐ Cooking Ⓐ",
+            "Ⓓ Jeweling Ⓓ",
+            "Ⓔ Scribing Ⓔ",
+            "Ⓕ Tailoring Ⓕ",
+            "Ⓖ Weaponsmithing Ⓖ",
+            "Ⓘ Woodworking Ⓘ"
+    );
+
+    private static final List<String> IGNORE = Arrays.asList(
+            "Buy & sell items",
+            "on the market",
+            "Looking for a group?",
+            "Accessories",
+            "Boots and Pants",
+            "Bows",
+            "Click for Options",
+            "Crafting Station",
+            "Food",
+            "Helmets and Chestplates",
+            "Potions",
+            "Scrolls",
+            "Spears and Daggers",
+            "Bows, Wands and Reliks",
+            "Left-Click to set up booth"
+    );
+
+    private static final NpcBaker npcBaker = new NpcBaker();
+    private static final Map<Location, String> detectedNpcs = new HashMap<>();
+    private static final Map<Location, String> detectedServices = new HashMap<>();
+
+    public static void dumpDetectedLocations(String filename) {
+        for (Location key : detectedNpcs.keySet()) {
+            String name = detectedNpcs.get(key);
+            printInstance("NPC", name, key);
+        }
+
+        for (Location key : detectedServices.keySet()) {
+            String name = detectedServices.get(key);
+            printInstance("Service", name, key);
+        }
+    }
+
+    private static void printInstance(String type, String name, Location key) {
+        System.out.println(type + ": " + name + ": " + key);
+    }
+
+    public static void handleLabel(String label, Location location) {
+        if (MARKERS.stream().anyMatch(l -> l.equals(label))) {
+            System.out.println("MARKER: " + label + ", " + location);
+            detectedServices.put(location, label);
+            return;
+        }
+
+        if (IGNORE.stream().anyMatch(l -> l.equals(label))) return;
+
+        // Ignore shops
+        if (label.endsWith("'s Shop")) return;
+
+        if (label.equals("NPC")) {
+            npcBaker.registerNpcLocation(location);
+            return;
+        }
+
+        // It might be an NPC name
+        npcBaker.registerName(label, location);
+    }
+
+    public static void handleNpc(String label, Location location) {
+        if (!(label.equals("Sell, scrap and repair items") || label.equals("NPC"))) return;
+
+        npcBaker.registerNpcLocation(location);
+    }
+
+    public static class NpcBaker {
+        private final Map<LabelLocation, String> nameMap = new HashMap<>();
+        private final Map<LabelLocation, Location> locationMap = new HashMap<>();
+
+        public void registerNpcLocation(Location location) {
+            LabelLocation l = new LabelLocation(location);
+            String name = nameMap.get(l);
+            if (name != null) {
+                finalizeNpc(location, name);
+            } else {
+                locationMap.put(l, location);
+            }
+        }
+
+        public void registerName(String name, Location location) {
+            LabelLocation l = new LabelLocation(location);
+            Location orgLoc = locationMap.get(l);
+            if (orgLoc != null) {
+                finalizeNpc(orgLoc, name);
+            } else {
+                nameMap.put(l, name);
+            }
+        }
+
+        private void finalizeNpc(Location location, String name) {
+            System.out.println("NPC: " + name + ", " + location);
+            detectedNpcs.put(location, name);
+        }
+    }
+
     public static class LabelLocation {
         private final int x;
         private final int z;
@@ -52,160 +169,4 @@ public class LabelBake {
             this.z = (int) location.z;
         }
     }
-
-    public static class BakeCollector<K, V> {
-        private final Map<K, List<V>> map = new HashMap<>();
-        private final BiPredicate<K, List<V>> verifier;
-
-        public BakeCollector(BiPredicate<K, List<V>> verifier) {
-            this.verifier = verifier;
-        }
-
-        public void addAndVerify(K key, V value) {
-            List<V> values = map.get(key);
-            if (values == null) {
-                values = new LinkedList<>();
-                values.add(value);
-                map.put(key, values);
-            } else {
-                values.add(value);
-                if (verifier.test(key, values)) {
-                    // Finished baking, remove key
-                    map.remove(key);
-                }
-            }
-        }
-    }
-
-    public static class NpcBaker {
-        private final Map<LabelLocation, String> nameMap = new HashMap<>();
-        private final Map<LabelLocation, Location> locationMap = new HashMap<>();
-
-        public void registerNpcLocation(Location location) {
-            LabelLocation l = new LabelLocation(location);
-            String name = nameMap.get(l);
-            if (name != null) {
-                finalizeNpc(location, name);
-            } else {
-                locationMap.put(l, location);
-            }
-
-        }
-
-        public void registerName(String name, Location location) {
-            LabelLocation l = new LabelLocation(location);
-            Location orgLoc = locationMap.get(l);
-            if (orgLoc != null) {
-                finalizeNpc(orgLoc, name);
-            } else {
-                nameMap.put(l, name);
-            }
-        }
-
-        private void finalizeNpc(Location location, String name) {
-            System.out.println("NPC: " + name + ", " + location);
-            detectedNpcs.put(location, name);
-        }
-
-    }
-
-    private static final NpcBaker npcBaker = new NpcBaker();
-    private static final Map<Location, String> detectedNpcs = new HashMap<>();
-    private static final Map<Location, String> detectedServices = new HashMap<>();
-
-    private static final List<String> markers = Arrays.asList(
-            "Armour Merchant",
-            "Blacksmith",
-            "Click to go to your housing plot",
-            "Dungeon Scroll Merchant",
-            "Emerald Merchant",
-            "Item Identifier",
-            "Liquid Merchant",
-            "Party Finder",
-            "Potion Merchant",
-            "Powder Master",
-            "Scroll Merchant",
-            "Trade Market",
-            "Weapon Merchant",
-            "Ⓛ Alchemism Ⓛ",
-            "Ⓗ Armouring Ⓗ",
-            "Ⓐ Cooking Ⓐ",
-            "Ⓓ Jeweling Ⓓ",
-            "Ⓔ Scribing Ⓔ",
-            "Ⓕ Tailoring Ⓕ",
-            "Ⓖ Weaponsmithing Ⓖ",
-            "Ⓘ Woodworking Ⓘ");
-
-    private static final List<String> ignore = Arrays.asList(
-            "Buy & sell items",
-            "on the market",
-            "Looking for a group?",
-            "Accessories",
-            "Boots and Pants",
-            "Bows",
-            "Click for Options",
-            "Crafting Station",
-            "Food",
-            "Helmets and Chestplates",
-            "Potions",
-            "Scrolls",
-            "Spears and Daggers",
-            "Bows, Wands and Reliks",
-            "Left-Click to set up booth"
-            );
-
-
-
-    private static boolean npcBakeVerifier(LabelLocation location, List<String> labels) {
-        if (labels.stream().anyMatch(x -> x.equals("NPC"))) {
-            String npcName = labels.stream().filter(x -> !x.equals("NPC")).findFirst().get();
-            return true;
-        }
-        return false;
-    }
-
-    public static void dumpDetectedLocations(String filename) {
-        for (Location key : detectedNpcs.keySet()) {
-            String name = detectedNpcs.get(key);
-            printInstance("NPC", name, key);
-        }
-
-        for (Location key : detectedServices.keySet()) {
-            String name = detectedServices.get(key);
-            printInstance("Service", name, key);
-        }
-    }
-
-    private static void printInstance(String type, String name, Location key) {
-        System.out.println(type + ": " + name + ": " + key);
-    }
-
-    public static void handleLabel(String label, Location location) {
-        if (markers.stream().anyMatch(l -> l.equals(label))) {
-            System.out.println("MARKER: " + label + ", " + location);
-            detectedServices.put(location, label);
-            dumpDetectedLocations("");
-            return;
-        }
-
-        if (ignore.stream().anyMatch(l -> l.equals(label))) return;
-
-        // Ignore shops
-        if (label.endsWith("'s Shop")) return;
-
-        if (label.equals("NPC")) {
-            npcBaker.registerNpcLocation(location);
-            return;
-        }
-
-        // It might be an NPC name
-        npcBaker.registerName(label, location);
-    }
-
-    public static void handleNpc(String label, Location location) {
-        if (!(label.equals("Sell, scrap and repair items") || label.equals("NPC"))) return;
-
-        npcBaker.registerNpcLocation(location);
-    }
-
 }


### PR DESCRIPTION
To counteract the bad quality of the location API provided by Wynncraft, I have written this location gathering mechanism. It needs to be enabled in the settings (map/telemetry). Then you can run around, and NPCs, services (like Blacksmith) and other locations will be automatically recorded. When you are done, you can dump all data as a CSV file using `/detection <filename>`.

My intention is to run around a lot myself (just for the fun of it!) but also to get help from more higher-level players to collection locations from the entire Wynncraft map. These will then be collected into a single master CSV file, which can be turned into json for Athena.