### PR TITLE
1.16 preparations

### DIFF
--- a/src/main/java/com/wynntils/McIf.java
+++ b/src/main/java/com/wynntils/McIf.java
@@ -4,6 +4,7 @@
 
 package com.wynntils;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.util.text.ITextComponent;
 
 /**
@@ -20,4 +21,9 @@ public class McIf {
     public static String getFormattedText(ITextComponent msg) {
         return msg.getFormattedText();
     }
+
+    public static Minecraft mc() {
+        return Minecraft.getMinecraft();
+    }
+
 }

--- a/src/main/java/com/wynntils/McIf.java
+++ b/src/main/java/com/wynntils/McIf.java
@@ -1,0 +1,9 @@
+package com.wynntils;
+
+import net.minecraft.util.text.ITextComponent;
+
+public class McIf {
+    public static String getUnformattedText(ITextComponent msg) {
+        return msg.getUnformattedText();
+    }
+}

--- a/src/main/java/com/wynntils/McIf.java
+++ b/src/main/java/com/wynntils/McIf.java
@@ -5,6 +5,7 @@
 package com.wynntils;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.WorldClient;
 import net.minecraft.util.text.ITextComponent;
 
 /**
@@ -24,6 +25,10 @@ public class McIf {
 
     public static Minecraft mc() {
         return Minecraft.getMinecraft();
+    }
+
+    public static WorldClient world() {
+        return mc().world;
     }
 
 }

--- a/src/main/java/com/wynntils/McIf.java
+++ b/src/main/java/com/wynntils/McIf.java
@@ -5,6 +5,7 @@
 package com.wynntils;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.client.multiplayer.WorldClient;
 import net.minecraft.util.text.ITextComponent;
 
@@ -29,6 +30,10 @@ public class McIf {
 
     public static WorldClient world() {
         return mc().world;
+    }
+
+    public static EntityPlayerSP player() {
+        return mc().player;
     }
 
 }

--- a/src/main/java/com/wynntils/McIf.java
+++ b/src/main/java/com/wynntils/McIf.java
@@ -1,7 +1,17 @@
+/*
+ *  * Copyright © Wynntils - 2021.
+ */
+
 package com.wynntils;
 
 import net.minecraft.util.text.ITextComponent;
 
+/**
+ * The Wynntils Minecraft Interface (MC IF).
+ *
+ * This class wraps all Minecraft functionality that we need but do not want to
+ * depend on directly, for instance due to version disparity.
+ */
 public class McIf {
     public static String getUnformattedText(ITextComponent msg) {
         return msg.getUnformattedText();

--- a/src/main/java/com/wynntils/McIf.java
+++ b/src/main/java/com/wynntils/McIf.java
@@ -6,4 +6,8 @@ public class McIf {
     public static String getUnformattedText(ITextComponent msg) {
         return msg.getUnformattedText();
     }
+
+    public static String getFormattedText(ITextComponent msg) {
+        return msg.getFormattedText();
+    }
 }

--- a/src/main/java/com/wynntils/McIf.java
+++ b/src/main/java/com/wynntils/McIf.java
@@ -8,6 +8,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.client.multiplayer.WorldClient;
 import net.minecraft.util.text.ITextComponent;
+import org.lwjgl.Sys;
 
 /**
  * The Wynntils Minecraft Interface (MC IF).
@@ -36,4 +37,8 @@ public class McIf {
         return mc().player;
     }
 
+    public static long getSystemTime()
+    {
+        return Minecraft.getSystemTime();
+    }
 }

--- a/src/main/java/com/wynntils/ModCore.java
+++ b/src/main/java/com/wynntils/ModCore.java
@@ -85,7 +85,7 @@ public class ModCore {
 
         // HeyZeer0: This will reload our cache if a texture or similar is applied
         // This also immediately loads it
-        ((SimpleReloadableResourceManager)Minecraft.getMinecraft().getResourceManager()).registerReloadListener(resourceManager -> {
+        ((SimpleReloadableResourceManager)McIf.mc().getResourceManager()).registerReloadListener(resourceManager -> {
             Textures.loadTextures();
             Mappings.loadMappings();
             MapApiIcon.resetApiMarkers();
@@ -113,7 +113,7 @@ public class ModCore {
     }
 
     public static Minecraft mc() {
-        return Minecraft.getMinecraft();
+        return McIf.mc();
     }
 
 }

--- a/src/main/java/com/wynntils/ModCore.java
+++ b/src/main/java/com/wynntils/ModCore.java
@@ -112,8 +112,4 @@ public class ModCore {
         FrameworkManager.getEventBus().post(new ClientEvent.Ready());
     }
 
-    public static Minecraft mc() {
-        return McIf.mc();
-    }
-
 }

--- a/src/main/java/com/wynntils/Reference.java
+++ b/src/main/java/com/wynntils/Reference.java
@@ -24,7 +24,7 @@ public class Reference {
     public static final String MINECRAFT_VERSIONS = "1.12,1.12.2";
     public static String VERSION = "";
     public static int BUILD_NUMBER = -1;
-    public static final File MOD_STORAGE_ROOT = new File(ModCore.mc().gameDir, MOD_ID);
+    public static final File MOD_STORAGE_ROOT = new File(McIf.mc().gameDir, MOD_ID);
     public static final File NATIVES_ROOT = new File(Reference.MOD_STORAGE_ROOT, "natives");
     public static final File PLATFORM_NATIVES_ROOT = new File(NATIVES_ROOT, Platform.RESOURCE_PREFIX);
     public static final Logger LOGGER = LogManager.getFormatterLogger(MOD_ID);
@@ -32,9 +32,9 @@ public class Reference {
     private static String userWorld = null;
 
     public static synchronized void setUserWorld(String uw) {
-        ServerData currentServer = ModCore.mc().getCurrentServerData();
+        ServerData currentServer = McIf.mc().getCurrentServerData();
         String lowerIP = currentServer == null || currentServer.serverIP == null ? null : currentServer.serverIP.toLowerCase(Locale.ROOT);
-        onServer = !ModCore.mc().isSingleplayer() && lowerIP != null && !currentServer.isOnLAN() && lowerIP.contains("wynncraft");
+        onServer = !McIf.mc().isSingleplayer() && lowerIP != null && !currentServer.isOnLAN() && lowerIP.contains("wynncraft");
         onServer &= lowerIP != null && !lowerIP.startsWith("beta.") || (!WebManager.blockHeroBetaCuttingEdge() && CoreDBConfig.INSTANCE.updateStream == UpdateStream.CUTTING_EDGE) || (!WebManager.blockHeroBetaStable() && CoreDBConfig.INSTANCE.updateStream == UpdateStream.STABLE);
         userWorld = uw;
 

--- a/src/main/java/com/wynntils/core/CoreManager.java
+++ b/src/main/java/com/wynntils/core/CoreManager.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.core;
 
+import com.wynntils.McIf;
 import com.wynntils.core.events.ClientEvents;
 import com.wynntils.core.framework.enums.wynntils.WynntilsConflictContext;
 import com.wynntils.core.framework.instances.PlayerInfo;
@@ -18,10 +19,10 @@ public class CoreManager {
     public static void preModules() {
         MinecraftForge.EVENT_BUS.register(new ClientEvents());
 
-        Minecraft.getMinecraft().gameSettings.keyBindForward.setKeyConflictContext(WynntilsConflictContext.ALLOW_MOVEMENTS);
-        Minecraft.getMinecraft().gameSettings.keyBindBack.setKeyConflictContext(WynntilsConflictContext.ALLOW_MOVEMENTS);
-        Minecraft.getMinecraft().gameSettings.keyBindRight.setKeyConflictContext(WynntilsConflictContext.ALLOW_MOVEMENTS);
-        Minecraft.getMinecraft().gameSettings.keyBindLeft.setKeyConflictContext(WynntilsConflictContext.ALLOW_MOVEMENTS);
+        McIf.mc().gameSettings.keyBindForward.setKeyConflictContext(WynntilsConflictContext.ALLOW_MOVEMENTS);
+        McIf.mc().gameSettings.keyBindBack.setKeyConflictContext(WynntilsConflictContext.ALLOW_MOVEMENTS);
+        McIf.mc().gameSettings.keyBindRight.setKeyConflictContext(WynntilsConflictContext.ALLOW_MOVEMENTS);
+        McIf.mc().gameSettings.keyBindLeft.setKeyConflictContext(WynntilsConflictContext.ALLOW_MOVEMENTS);
     }
 
     /**

--- a/src/main/java/com/wynntils/core/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/core/events/ClientEvents.java
@@ -5,6 +5,7 @@
 package com.wynntils.core.events;
 
 import com.mojang.authlib.GameProfile;
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.*;
 import com.wynntils.core.framework.FrameworkManager;
@@ -93,7 +94,7 @@ public class ClientEvents {
     public void triggerGameEvents(ClientChatReceivedEvent e) {
         if (e.getType() == ChatType.GAME_INFO) return;
 
-        String message = e.getMessage().getUnformattedText();
+        String message = McIf.getUnformattedText(e.getMessage());
 
         if (message.contains("\u27a4")) return;  // Whisper from a player
 
@@ -180,7 +181,7 @@ public class ClientEvents {
                 if (e.getPacket().getAction() == Action.UPDATE_DISPLAY_NAME) {
                     ITextComponent nameComponent = (ITextComponent) ReflectionMethods.SPacketPlayerListItem$AddPlayerData_getDisplayName.invoke(player);
                     if (nameComponent == null) continue;
-                    String name = nameComponent.getUnformattedText();
+                    String name = McIf.getUnformattedText(nameComponent);
                     String world = name.substring(name.indexOf("[") + 1, name.indexOf("]"));
 
                     if (world.equalsIgnoreCase(lastWorld)) continue;

--- a/src/main/java/com/wynntils/core/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/core/events/ClientEvents.java
@@ -65,7 +65,7 @@ public class ClientEvents {
     public void onScreenDraw(GuiScreenEvent.DrawScreenEvent.Post e) {
         if (!(e.getGui() instanceof GuiConnecting)) return;
 
-        e.getGui().drawCenteredString(Minecraft.getMinecraft().fontRenderer, statusMsg, e.getGui().width / 2, e.getGui().height / 2 - 20, 16777215);
+        e.getGui().drawCenteredString(McIf.mc().fontRenderer, statusMsg, e.getGui().width / 2, e.getGui().height / 2 - 20, 16777215);
     }
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)
@@ -223,7 +223,7 @@ public class ClientEvents {
         if (e.phase != TickEvent.Phase.END) return;
 
         ScreenRenderer.refresh();
-        if (!Reference.onServer || Minecraft.getMinecraft().player == null) return;
+        if (!Reference.onServer || McIf.mc().player == null) return;
 
         FrameworkManager.triggerHudTick(e);
         FrameworkManager.triggerKeyPress();
@@ -246,8 +246,8 @@ public class ClientEvents {
     public void checkSpellCast(TickEvent.ClientTickEvent e) {
         if (!Reference.onWorld) return;
 
-        int remainingHighlightTicks = ReflectionFields.GuiIngame_remainingHighlightTicks.getValue(Minecraft.getMinecraft().ingameGUI);
-        ItemStack highlightingItemStack = ReflectionFields.GuiIngame_highlightingItemStack.getValue(Minecraft.getMinecraft().ingameGUI);
+        int remainingHighlightTicks = ReflectionFields.GuiIngame_remainingHighlightTicks.getValue(McIf.mc().ingameGUI);
+        ItemStack highlightingItemStack = ReflectionFields.GuiIngame_highlightingItemStack.getValue(McIf.mc().ingameGUI);
 
         if (remainingHighlightTicks == 0 || highlightingItemStack.isEmpty()) {
             heldItem = "";

--- a/src/main/java/com/wynntils/core/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/core/events/ClientEvents.java
@@ -104,7 +104,7 @@ public class ClientEvents {
             isNextQuestCompleted = false;
 
             String questName = message.trim().replace("À", "");
-            if (e.getMessage().getFormattedText().contains(TextFormatting.GREEN.toString()))
+            if (McIf.getFormattedText(e.getMessage()).contains(TextFormatting.GREEN.toString()))
                 toDispatch = new GameEvent.QuestCompleted.MiniQuest(questName);
             else
                 toDispatch = new GameEvent.QuestCompleted(questName);

--- a/src/main/java/com/wynntils/core/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/core/events/ClientEvents.java
@@ -223,7 +223,7 @@ public class ClientEvents {
         if (e.phase != TickEvent.Phase.END) return;
 
         ScreenRenderer.refresh();
-        if (!Reference.onServer || McIf.mc().player == null) return;
+        if (!Reference.onServer || McIf.player() == null) return;
 
         FrameworkManager.triggerHudTick(e);
         FrameworkManager.triggerKeyPress();

--- a/src/main/java/com/wynntils/core/events/custom/WynnSocialEvent.java
+++ b/src/main/java/com/wynntils/core/events/custom/WynnSocialEvent.java
@@ -31,7 +31,7 @@ public class WynnSocialEvent extends Event {
     }
 
     public boolean isYou() {
-        return member.equalsIgnoreCase(McIf.mc().player.getName());
+        return member.equalsIgnoreCase(McIf.player().getName());
     }
 
     public static class Party extends WynnSocialEvent {

--- a/src/main/java/com/wynntils/core/events/custom/WynnSocialEvent.java
+++ b/src/main/java/com/wynntils/core/events/custom/WynnSocialEvent.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.core.events.custom;
 
+import com.wynntils.McIf;
 import com.wynntils.core.framework.instances.PlayerInfo;
 import com.wynntils.core.framework.instances.containers.PartyContainer;
 import com.wynntils.core.framework.instances.data.SocialData;
@@ -30,7 +31,7 @@ public class WynnSocialEvent extends Event {
     }
 
     public boolean isYou() {
-        return member.equalsIgnoreCase(Minecraft.getMinecraft().player.getName());
+        return member.equalsIgnoreCase(McIf.mc().player.getName());
     }
 
     public static class Party extends WynnSocialEvent {

--- a/src/main/java/com/wynntils/core/framework/FrameworkManager.java
+++ b/src/main/java/com/wynntils/core/framework/FrameworkManager.java
@@ -222,7 +222,7 @@ public class FrameworkManager {
         Random r = Utils.getRandom();
         if (r.nextBoolean()) return; // reduce spawn chances by half
 
-        EntityPlayerSP player = McIf.mc().player;
+        EntityPlayerSP player = McIf.player();
         for (double x = -10; x < 10; x++) {
             for (double y = -1; y < 6; y++) {
                 for (double z = -10; z < 10; z++) {

--- a/src/main/java/com/wynntils/core/framework/FrameworkManager.java
+++ b/src/main/java/com/wynntils/core/framework/FrameworkManager.java
@@ -5,7 +5,6 @@
 package com.wynntils.core.framework;
 
 import com.wynntils.McIf;
-import com.wynntils.ModCore;
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.WynncraftServerEvent;
 import com.wynntils.core.framework.entities.EntityManager;
@@ -24,7 +23,6 @@ import com.wynntils.core.framework.settings.instances.SettingsHolder;
 import com.wynntils.core.utils.Utils;
 import com.wynntils.core.utils.objects.Location;
 import com.wynntils.core.utils.reflections.ReflectionFields;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraftforge.client.event.GuiScreenEvent;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
@@ -96,12 +94,9 @@ public class FrameworkManager {
         if (info == null)
             return;
 
-        ModuleContainer mc = availableModules.get(info.name());
-
-        overlay.module = mc;
-
-        mc.registerSettings("overlay" + overlay.displayName, overlay);
-
+        ModuleContainer container = availableModules.get(info.name());
+        overlay.module = container;
+        container.registerSettings("overlay" + overlay.displayName, overlay);
         registeredOverlays.get(priority).add(overlay);
     }
 
@@ -146,7 +141,7 @@ public class FrameworkManager {
     }
 
     public static void triggerPreHud(RenderGameOverlayEvent.Pre e) {
-        if (Reference.onServer && !ModCore.mc().playerController.isSpectator()) {
+        if (Reference.onServer && !McIf.mc().playerController.isSpectator()) {
             if (e.getType() == RenderGameOverlayEvent.ElementType.AIR ||  // move it to somewhere else if you want, it seems pretty core to wynncraft tho..
                e.getType() == RenderGameOverlayEvent.ElementType.ARMOR) {
                 e.setCanceled(true);
@@ -187,7 +182,7 @@ public class FrameworkManager {
     }
 
     public static void triggerPostHud(RenderGameOverlayEvent.Post e) {
-        if (Reference.onServer && !ModCore.mc().playerController.isSpectator()) {
+        if (Reference.onServer && !McIf.mc().playerController.isSpectator()) {
             McIf.mc().profiler.startSection("posRenOverlay");
             for (List<Overlay> overlays : registeredOverlays.values()) {
                 for (Overlay overlay : overlays) {

--- a/src/main/java/com/wynntils/core/framework/FrameworkManager.java
+++ b/src/main/java/com/wynntils/core/framework/FrameworkManager.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.core.framework;
 
+import com.wynntils.McIf;
 import com.wynntils.ModCore;
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.WynncraftServerEvent;
@@ -152,7 +153,7 @@ public class FrameworkManager {
                 return;
             }
 
-            Minecraft.getMinecraft().profiler.startSection("preRenOverlay");
+            McIf.mc().profiler.startSection("preRenOverlay");
             for (List<Overlay> overlays : registeredOverlays.values()) {
                 for (Overlay overlay : overlays) {
                     if (!overlay.active) continue;
@@ -171,39 +172,39 @@ public class FrameworkManager {
                             continue;
                     }
                     if ((overlay.module == null || overlay.module.getModule().isActive()) && overlay.visible && overlay.active) {
-                        Minecraft.getMinecraft().profiler.startSection(overlay.displayName);
+                        McIf.mc().profiler.startSection(overlay.displayName);
                         ScreenRenderer.beginGL(overlay.position.getDrawingX(), overlay.position.getDrawingY());
                         overlay.render(e);
                         ScreenRenderer.endGL();
-                        Minecraft.getMinecraft().profiler.endSection();
+                        McIf.mc().profiler.endSection();
                     }
                 }
             }
-            Minecraft.getMinecraft().profiler.endSection();
+            McIf.mc().profiler.endSection();
 
-            Minecraft.getMinecraft().getTextureManager().bindTexture(ICONS);
+            McIf.mc().getTextureManager().bindTexture(ICONS);
         }
     }
 
     public static void triggerPostHud(RenderGameOverlayEvent.Post e) {
         if (Reference.onServer && !ModCore.mc().playerController.isSpectator()) {
-            Minecraft.getMinecraft().profiler.startSection("posRenOverlay");
+            McIf.mc().profiler.startSection("posRenOverlay");
             for (List<Overlay> overlays : registeredOverlays.values()) {
                 for (Overlay overlay : overlays) {
                     if (!overlay.active) continue;
 
                     if ((overlay.module == null || overlay.module.getModule().isActive()) && overlay.visible && overlay.active) {
-                        Minecraft.getMinecraft().profiler.startSection(overlay.displayName);
+                        McIf.mc().profiler.startSection(overlay.displayName);
 
                         ScreenRenderer.beginGL(overlay.position.getDrawingX(), overlay.position.getDrawingY());
                         overlay.render(e);
                         ScreenRenderer.endGL();
 
-                        Minecraft.getMinecraft().profiler.endSection();
+                        McIf.mc().profiler.endSection();
                     }
                 }
             }
-            Minecraft.getMinecraft().profiler.endSection();
+            McIf.mc().profiler.endSection();
         }
     }
 
@@ -226,7 +227,7 @@ public class FrameworkManager {
         Random r = Utils.getRandom();
         if (r.nextBoolean()) return; // reduce spawn chances by half
 
-        EntityPlayerSP player = Minecraft.getMinecraft().player;
+        EntityPlayerSP player = McIf.mc().player;
         for (double x = -10; x < 10; x++) {
             for (double y = -1; y < 6; y++) {
                 for (double z = -10; z < 10; z++) {

--- a/src/main/java/com/wynntils/core/framework/entities/EntityManager.java
+++ b/src/main/java/com/wynntils/core/framework/entities/EntityManager.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.core.framework.entities;
 
+import com.wynntils.McIf;
 import com.wynntils.core.framework.entities.instances.FakeEntity;
 import com.wynntils.core.utils.Utils;
 import net.minecraft.client.Minecraft;
@@ -46,7 +47,7 @@ public class EntityManager {
     public static void tickEntities() {
         if (entityList.isEmpty() && toSpawn.isEmpty()) return;
 
-        Minecraft.getMinecraft().profiler.startSection("fakeEntities");
+        McIf.mc().profiler.startSection("fakeEntities");
         {
             // adds all new entities to the set
             Iterator<FakeEntity> it = toSpawn.iterator();
@@ -55,10 +56,10 @@ public class EntityManager {
                 it.remove();
             }
 
-            RenderManager renderManager = Minecraft.getMinecraft().getRenderManager();
+            RenderManager renderManager = McIf.mc().getRenderManager();
             if (renderManager == null || renderManager.options == null) return;
 
-            EntityPlayerSP player = Minecraft.getMinecraft().player;
+            EntityPlayerSP player = McIf.mc().player;
             // ticks each entity
             it = entityList.iterator();
             while (it.hasNext()) {
@@ -70,15 +71,15 @@ public class EntityManager {
                     continue;
                 }
 
-                Minecraft.getMinecraft().profiler.startSection(next.getName());
+                McIf.mc().profiler.startSection(next.getName());
                 { // render
                     next.livingTicks += 1;
                     next.tick(Utils.getRandom(), player);
                 }
-                Minecraft.getMinecraft().profiler.endSection();
+                McIf.mc().profiler.endSection();
             }
         }
-        Minecraft.getMinecraft().profiler.endSection();
+        McIf.mc().profiler.endSection();
     }
 
     /**
@@ -90,7 +91,7 @@ public class EntityManager {
     public static void renderEntities(float partialTicks, RenderGlobal context) {
         if (entityList.isEmpty() && toSpawn.isEmpty()) return;
 
-        Minecraft.getMinecraft().profiler.startSection("fakeEntities");
+        McIf.mc().profiler.startSection("fakeEntities");
         {
             // adds all new entities to the set
             Iterator<FakeEntity> it = toSpawn.iterator();
@@ -99,16 +100,16 @@ public class EntityManager {
                 it.remove();
             }
 
-            RenderManager renderManager = Minecraft.getMinecraft().getRenderManager();
+            RenderManager renderManager = McIf.mc().getRenderManager();
             if (renderManager == null || renderManager.options == null) return;
 
-            EntityPlayerSP player = Minecraft.getMinecraft().player;
+            EntityPlayerSP player = McIf.mc().player;
             // ticks each entity
             it = entityList.iterator();
             while (it.hasNext()) {
                 FakeEntity next = it.next();
 
-                Minecraft.getMinecraft().profiler.startSection(next.getName());
+                McIf.mc().profiler.startSection(next.getName());
                 {
                     pushMatrix();
                     {
@@ -124,10 +125,10 @@ public class EntityManager {
                     }
                     popMatrix();
                 }
-                Minecraft.getMinecraft().profiler.endSection();
+                McIf.mc().profiler.endSection();
             }
         }
-        Minecraft.getMinecraft().profiler.endSection();
+        McIf.mc().profiler.endSection();
     }
 
 }

--- a/src/main/java/com/wynntils/core/framework/entities/EntityManager.java
+++ b/src/main/java/com/wynntils/core/framework/entities/EntityManager.java
@@ -59,7 +59,7 @@ public class EntityManager {
             RenderManager renderManager = McIf.mc().getRenderManager();
             if (renderManager == null || renderManager.options == null) return;
 
-            EntityPlayerSP player = McIf.mc().player;
+            EntityPlayerSP player = McIf.player();
             // ticks each entity
             it = entityList.iterator();
             while (it.hasNext()) {
@@ -103,7 +103,7 @@ public class EntityManager {
             RenderManager renderManager = McIf.mc().getRenderManager();
             if (renderManager == null || renderManager.options == null) return;
 
-            EntityPlayerSP player = McIf.mc().player;
+            EntityPlayerSP player = McIf.player();
             // ticks each entity
             it = entityList.iterator();
             while (it.hasNext()) {

--- a/src/main/java/com/wynntils/core/framework/enums/wynntils/WynntilsConflictContext.java
+++ b/src/main/java/com/wynntils/core/framework/enums/wynntils/WynntilsConflictContext.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.core.framework.enums.wynntils;
 
+import com.wynntils.McIf;
 import com.wynntils.core.framework.instances.GuiMovementScreen;
 import net.minecraft.client.Minecraft;
 import net.minecraftforge.client.settings.IKeyConflictContext;
@@ -18,7 +19,7 @@ public enum WynntilsConflictContext implements IKeyConflictContext {
     ALLOW_MOVEMENTS {
         @Override
         public boolean isActive() {
-            return Minecraft.getMinecraft().currentScreen == null || Minecraft.getMinecraft().currentScreen instanceof GuiMovementScreen;
+            return McIf.mc().currentScreen == null || McIf.mc().currentScreen instanceof GuiMovementScreen;
         }
 
         @Override

--- a/src/main/java/com/wynntils/core/framework/enums/wynntils/WynntilsSound.java
+++ b/src/main/java/com/wynntils/core/framework/enums/wynntils/WynntilsSound.java
@@ -4,7 +4,7 @@
 
 package com.wynntils.core.framework.enums.wynntils;
 
-import com.wynntils.ModCore;
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import net.minecraft.client.audio.PositionedSoundRecord;
 import net.minecraft.util.ResourceLocation;
@@ -34,8 +34,8 @@ public enum WynntilsSound {
     }
 
     public void play(float volume, float pitch) {
-        ModCore.mc().addScheduledTask(() ->
-                ModCore.mc().getSoundHandler().playSound(PositionedSoundRecord.getRecord(event, pitch, volume)));
+        McIf.mc().addScheduledTask(() ->
+                McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getRecord(event, pitch, volume)));
     }
 
     public void play() {

--- a/src/main/java/com/wynntils/core/framework/instances/GuiMovementScreen.java
+++ b/src/main/java/com/wynntils/core/framework/instances/GuiMovementScreen.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.core.framework.instances;
 
+import com.wynntils.McIf;
 import com.wynntils.core.framework.enums.wynntils.WynntilsConflictContext;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.settings.KeyBinding;
@@ -30,7 +31,7 @@ public class GuiMovementScreen extends GuiScreen {
         if (Keyboard.isCreated()) {
             while (Keyboard.next()) {
 
-                for (KeyBinding key : mc.gameSettings.keyBindings) {
+                for (KeyBinding key : McIf.mc().gameSettings.keyBindings) {
                     if (key.getKeyCode() != Keyboard.getEventKey() || key.getKeyConflictContext() != WynntilsConflictContext.ALLOW_MOVEMENTS) continue;
 
                     KeyBinding.setKeyBindState(Keyboard.getEventKey(), Keyboard.getEventKeyState());

--- a/src/main/java/com/wynntils/core/framework/instances/Module.java
+++ b/src/main/java/com/wynntils/core/framework/instances/Module.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.core.framework.instances;
 
+import com.wynntils.McIf;
 import com.wynntils.core.framework.FrameworkManager;
 import com.wynntils.core.framework.entities.interfaces.EntitySpawnCodition;
 import com.wynntils.core.framework.enums.Priority;
@@ -140,7 +141,7 @@ public abstract class Module {
     }
 
     public Minecraft getMinecraft() {
-        return Minecraft.getMinecraft();
+        return McIf.mc();
     }
 
     public Logger getLogger() {

--- a/src/main/java/com/wynntils/core/framework/instances/Module.java
+++ b/src/main/java/com/wynntils/core/framework/instances/Module.java
@@ -140,10 +140,6 @@ public abstract class Module {
         ClientCommandHandler.instance.registerCommand(command);
     }
 
-    public Minecraft getMinecraft() {
-        return McIf.mc();
-    }
-
     public Logger getLogger() {
         return logger;
     }

--- a/src/main/java/com/wynntils/core/framework/instances/containers/PartyContainer.java
+++ b/src/main/java/com/wynntils/core/framework/instances/containers/PartyContainer.java
@@ -61,7 +61,7 @@ public class PartyContainer {
     public void removeMember(String userName) {
         FrameworkManager.getEventBus().post(new WynnSocialEvent.Party.Leave(userName));
 
-        if (userName.equalsIgnoreCase(McIf.mc().player.getName())) {
+        if (userName.equalsIgnoreCase(McIf.player().getName())) {
             partyMembers.clear();
             owner = "";
             return;
@@ -78,7 +78,7 @@ public class PartyContainer {
     public void removeMembers(List<String> members) {
         members.forEach(userName -> FrameworkManager.getEventBus().post(new WynnSocialEvent.Party.Leave(userName)));
 
-        if (members.contains(McIf.mc().player.getName())) {
+        if (members.contains(McIf.player().getName())) {
             partyMembers.clear();
             owner = "";
             return;

--- a/src/main/java/com/wynntils/core/framework/instances/containers/PartyContainer.java
+++ b/src/main/java/com/wynntils/core/framework/instances/containers/PartyContainer.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.core.framework.instances.containers;
 
+import com.wynntils.McIf;
 import com.wynntils.core.events.custom.WynnSocialEvent;
 import com.wynntils.core.framework.FrameworkManager;
 import net.minecraft.client.Minecraft;
@@ -60,7 +61,7 @@ public class PartyContainer {
     public void removeMember(String userName) {
         FrameworkManager.getEventBus().post(new WynnSocialEvent.Party.Leave(userName));
 
-        if (userName.equalsIgnoreCase(Minecraft.getMinecraft().player.getName())) {
+        if (userName.equalsIgnoreCase(McIf.mc().player.getName())) {
             partyMembers.clear();
             owner = "";
             return;
@@ -77,7 +78,7 @@ public class PartyContainer {
     public void removeMembers(List<String> members) {
         members.forEach(userName -> FrameworkManager.getEventBus().post(new WynnSocialEvent.Party.Leave(userName)));
 
-        if (members.contains(Minecraft.getMinecraft().player.getName())) {
+        if (members.contains(McIf.mc().player.getName())) {
             partyMembers.clear();
             owner = "";
             return;

--- a/src/main/java/com/wynntils/core/framework/instances/containers/PlayerData.java
+++ b/src/main/java/com/wynntils/core/framework/instances/containers/PlayerData.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.core.framework.instances.containers;
 
+import com.wynntils.McIf;
 import com.wynntils.core.framework.instances.PlayerInfo;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
@@ -13,7 +14,7 @@ public class PlayerData {
     public PlayerData() { }
 
     public Minecraft getMinecraft() {
-        return Minecraft.getMinecraft();
+        return McIf.mc();
     }
 
     public EntityPlayerSP getPlayer() {

--- a/src/main/java/com/wynntils/core/framework/instances/containers/PlayerData.java
+++ b/src/main/java/com/wynntils/core/framework/instances/containers/PlayerData.java
@@ -6,19 +6,14 @@ package com.wynntils.core.framework.instances.containers;
 
 import com.wynntils.McIf;
 import com.wynntils.core.framework.instances.PlayerInfo;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
 
 public class PlayerData {
 
     public PlayerData() { }
 
-    public Minecraft getMinecraft() {
-        return McIf.mc();
-    }
-
     public EntityPlayerSP getPlayer() {
-        return getMinecraft().player;
+        return McIf.mc().player;
     }
 
     public <T extends PlayerData> T get(Class<T> clazz) {

--- a/src/main/java/com/wynntils/core/framework/instances/containers/PlayerData.java
+++ b/src/main/java/com/wynntils/core/framework/instances/containers/PlayerData.java
@@ -13,7 +13,7 @@ public class PlayerData {
     public PlayerData() { }
 
     public EntityPlayerSP getPlayer() {
-        return McIf.mc().player;
+        return McIf.player();
     }
 
     public <T extends PlayerData> T get(Class<T> clazz) {

--- a/src/main/java/com/wynntils/core/framework/instances/data/LocationData.java
+++ b/src/main/java/com/wynntils/core/framework/instances/data/LocationData.java
@@ -4,7 +4,7 @@
 
 package com.wynntils.core.framework.instances.data;
 
-import com.wynntils.ModCore;
+import com.wynntils.McIf;
 import com.wynntils.core.events.custom.WynnTerritoryChangeEvent;
 import com.wynntils.core.framework.FrameworkManager;
 import com.wynntils.core.framework.instances.containers.PlayerData;
@@ -27,7 +27,7 @@ public class LocationData extends PlayerData {
      * @param location the target location
      */
     public void setLocation(String location) {
-        ModCore.mc().addScheduledTask(() -> {
+        McIf.mc().addScheduledTask(() -> {
             FrameworkManager.getEventBus().post(new WynnTerritoryChangeEvent(this.location, location));
         });
 

--- a/src/main/java/com/wynntils/core/framework/instances/data/SpellData.java
+++ b/src/main/java/com/wynntils/core/framework/instances/data/SpellData.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.core.framework.instances.data;
 
+import com.wynntils.McIf;
 import com.wynntils.core.framework.instances.containers.PlayerData;
 import com.wynntils.core.utils.reflections.ReflectionFields;
 import net.minecraft.util.text.TextFormatting;
@@ -67,7 +68,7 @@ public class SpellData extends PlayerData {
 
         int level = get(CharacterData.class).getLevel();
         if (level <= 11) {
-            String subtitle = ReflectionFields.GuiIngame_displayedSubTitle.getValue(getMinecraft().ingameGUI);
+            String subtitle = ReflectionFields.GuiIngame_displayedSubTitle.getValue(McIf.mc().ingameGUI);
             return parseSpellFromTitle(subtitle);
         }
 

--- a/src/main/java/com/wynntils/core/framework/rendering/ScreenRenderer.java
+++ b/src/main/java/com/wynntils/core/framework/rendering/ScreenRenderer.java
@@ -9,7 +9,6 @@ import com.wynntils.core.framework.rendering.colors.CustomColor;
 import com.wynntils.core.framework.rendering.textures.Texture;
 import com.wynntils.core.utils.StringUtils;
 import com.wynntils.modules.core.config.CoreDBConfig;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.ScaledResolution;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.RenderHelper;
@@ -31,7 +30,6 @@ import static org.lwjgl.opengl.GL11.*;
 public class ScreenRenderer {
 
     public static SmartFontRenderer fontRenderer = null;
-    public static Minecraft mc;
     public static ScaledResolution screen = null;
     private static boolean rendering = false;
     private static float scale = 1.0f;
@@ -56,11 +54,10 @@ public class ScreenRenderer {
      * except {@link com.wynntils.core.events.ClientEvents#onTick(TickEvent.ClientTickEvent)} !
      */
     public static void refresh() {
-        mc = McIf.mc();
-        screen = new ScaledResolution(mc);
+        screen = new ScaledResolution(McIf.mc());
         if (fontRenderer == null) {
             fontRenderer = new SmartFontRenderer();
-            fontRenderer.onResourceManagerReload(mc.getResourceManager());
+            fontRenderer.onResourceManagerReload(McIf.mc().getResourceManager());
         }
         fontRenderer.setUnicodeFlag(CoreDBConfig.INSTANCE.useUnicode);
         if (itemRenderer == null)
@@ -340,7 +337,7 @@ public class ScreenRenderer {
 
         // Scissor test is in screen coordinates, so y is inverted and scale needs to be manually applied
         int scale = screen.getScaleFactor();
-        glScissor((x + drawingOrigin.x) * scale, mc.displayHeight - (y + drawingOrigin.y + height) * scale, width * scale, height * scale);
+        glScissor((x + drawingOrigin.x) * scale, McIf.mc().displayHeight - (y + drawingOrigin.y + height) * scale, width * scale, height * scale);
     }
 
     /**
@@ -359,7 +356,7 @@ public class ScreenRenderer {
 
         enableScissorTest();
         int scale = screen.getScaleFactor();
-        glScissor((x + drawingOrigin.x) * scale, 0, width * scale, mc.displayHeight);
+        glScissor((x + drawingOrigin.x) * scale, 0, width * scale, McIf.mc().displayHeight);
     }
 
     /**
@@ -371,7 +368,7 @@ public class ScreenRenderer {
 
         enableScissorTest();
         int scale = screen.getScaleFactor();
-        glScissor(0, mc.displayHeight - (y + drawingOrigin.y + height) * scale, mc.displayWidth, height * scale);
+        glScissor(0, McIf.mc().displayHeight - (y + drawingOrigin.y + height) * scale, McIf.mc().displayWidth, height * scale);
     }
 
     /**

--- a/src/main/java/com/wynntils/core/framework/rendering/ScreenRenderer.java
+++ b/src/main/java/com/wynntils/core/framework/rendering/ScreenRenderer.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.core.framework.rendering;
 
+import com.wynntils.McIf;
 import com.wynntils.core.framework.rendering.colors.CustomColor;
 import com.wynntils.core.framework.rendering.textures.Texture;
 import com.wynntils.core.utils.StringUtils;
@@ -55,7 +56,7 @@ public class ScreenRenderer {
      * except {@link com.wynntils.core.events.ClientEvents#onTick(TickEvent.ClientTickEvent)} !
      */
     public static void refresh() {
-        mc = Minecraft.getMinecraft();
+        mc = McIf.mc();
         screen = new ScaledResolution(mc);
         if (fontRenderer == null) {
             fontRenderer = new SmartFontRenderer();
@@ -63,7 +64,7 @@ public class ScreenRenderer {
         }
         fontRenderer.setUnicodeFlag(CoreDBConfig.INSTANCE.useUnicode);
         if (itemRenderer == null)
-            itemRenderer = Minecraft.getMinecraft().getRenderItem();
+            itemRenderer = McIf.mc().getRenderItem();
     }
 
     /** void beginGL

--- a/src/main/java/com/wynntils/core/framework/rendering/SmartFontRenderer.java
+++ b/src/main/java/com/wynntils/core/framework/rendering/SmartFontRenderer.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.core.framework.rendering;
 
+import com.wynntils.McIf;
 import com.wynntils.core.framework.rendering.colors.CommonColors;
 import com.wynntils.core.framework.rendering.colors.CustomColor;
 import com.wynntils.core.framework.rendering.colors.MinecraftChatColors;
@@ -32,7 +33,7 @@ public class SmartFontRenderer extends FontRenderer {
     }
 
     public SmartFontRenderer() {
-        super(Minecraft.getMinecraft().gameSettings, new ResourceLocation("textures/font/ascii.png"), Minecraft.getMinecraft().getTextureManager(), false);
+        super(McIf.mc().gameSettings, new ResourceLocation("textures/font/ascii.png"), McIf.mc().getTextureManager(), false);
     }
 
     public float drawString(String text, float x, float y, CustomColor customColor, TextAlignment alignment, TextShadow shadow) {

--- a/src/main/java/com/wynntils/core/framework/rendering/SpecialRendering.java
+++ b/src/main/java/com/wynntils/core/framework/rendering/SpecialRendering.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.core.framework.rendering;
 
+import com.wynntils.McIf;
 import com.wynntils.core.framework.rendering.colors.CommonColors;
 import com.wynntils.core.framework.rendering.colors.CustomColor;
 import com.wynntils.core.framework.rendering.math.MatrixMath;
@@ -32,7 +33,7 @@ public class SpecialRendering {
     };
 
     public static void renderGodRays(int x, int y, int z, double size, int rays, CustomColor color) {
-        float time = Minecraft.getSystemTime() / 50f;
+        float time = McIf.getSystemTime() / 50f;
         Random rand = new Random(142L);
 
         boolean isRainbow = color == CommonColors.RAINBOW;

--- a/src/main/java/com/wynntils/core/framework/rendering/WynnRenderItem.java
+++ b/src/main/java/com/wynntils/core/framework/rendering/WynnRenderItem.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.core.framework.rendering;
 
+import com.wynntils.McIf;
 import com.wynntils.core.events.custom.RenderEvent;
 import com.wynntils.core.framework.FrameworkManager;
 import com.wynntils.core.utils.reflections.ReflectionFields;
@@ -21,7 +22,7 @@ public class WynnRenderItem extends RenderItem {
 
     public static void inject() {
         if (instance != null) throw new IllegalStateException("Wynntils item renderer has already been installed!");
-        Minecraft mc = Minecraft.getMinecraft();
+        Minecraft mc = McIf.mc();
         instance = new WynnRenderItem(mc.getRenderItem(), mc.renderEngine, mc.getItemColors());
         // the resource manager reload listener for the item renderer merely invalidates the cache of the held item model mesher
         // since we're inheriting the one from the original item renderer and also not unregistering it as a reload listener, we don't need to register our own renderer as a listener

--- a/src/main/java/com/wynntils/core/framework/rendering/WynnRenderItem.java
+++ b/src/main/java/com/wynntils/core/framework/rendering/WynnRenderItem.java
@@ -22,11 +22,10 @@ public class WynnRenderItem extends RenderItem {
 
     public static void inject() {
         if (instance != null) throw new IllegalStateException("Wynntils item renderer has already been installed!");
-        Minecraft mc = McIf.mc();
-        instance = new WynnRenderItem(mc.getRenderItem(), mc.renderEngine, mc.getItemColors());
+        instance = new WynnRenderItem(McIf.mc().getRenderItem(), McIf.mc().renderEngine, McIf.mc().getItemColors());
         // the resource manager reload listener for the item renderer merely invalidates the cache of the held item model mesher
         // since we're inheriting the one from the original item renderer and also not unregistering it as a reload listener, we don't need to register our own renderer as a listener
-        ReflectionFields.Minecraft_renderItem.setValue(mc, instance);
+        ReflectionFields.Minecraft_renderItem.setValue(McIf.mc(), instance);
     }
 
     public static WynnRenderItem getInstance() {

--- a/src/main/java/com/wynntils/core/framework/rendering/textures/AssetsTexture.java
+++ b/src/main/java/com/wynntils/core/framework/rendering/textures/AssetsTexture.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.core.framework.rendering.textures;
 
+import com.wynntils.McIf;
 import com.wynntils.core.framework.enums.ActionResult;
 import net.minecraft.client.Minecraft;
 import net.minecraft.util.ResourceLocation;
@@ -27,8 +28,8 @@ public class AssetsTexture extends Texture {
         if (loaded) return ActionResult.ISSUE;
 
         try {
-            Minecraft.getMinecraft().getTextureManager().bindTexture(resourceLocation);
-            BufferedImage img = ImageIO.read(Minecraft.getMinecraft().getResourceManager().getResource(resourceLocation).getInputStream());
+            McIf.mc().getTextureManager().bindTexture(resourceLocation);
+            BufferedImage img = ImageIO.read(McIf.mc().getResourceManager().getResource(resourceLocation).getInputStream());
             width = img.getWidth();
             height = img.getHeight();
             loaded = true;
@@ -45,7 +46,7 @@ public class AssetsTexture extends Texture {
     public ActionResult unload() {
         if (!loaded) return ActionResult.ISSUE;
 
-        Minecraft.getMinecraft().getTextureManager().deleteTexture(resourceLocation);
+        McIf.mc().getTextureManager().deleteTexture(resourceLocation);
         loaded = false;
         return ActionResult.SUCCESS;
     }
@@ -54,7 +55,7 @@ public class AssetsTexture extends Texture {
     public ActionResult bind() {
         if (!loaded) return ActionResult.ERROR;
 
-        Minecraft.getMinecraft().getTextureManager().bindTexture(resourceLocation);
+        McIf.mc().getTextureManager().bindTexture(resourceLocation);
         return ActionResult.SUCCESS;
     }
 

--- a/src/main/java/com/wynntils/core/framework/rendering/textures/Mappings.java
+++ b/src/main/java/com/wynntils/core/framework/rendering/textures/Mappings.java
@@ -6,6 +6,7 @@ package com.wynntils.core.framework.rendering.textures;
 
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import net.minecraft.client.Minecraft;
 import net.minecraft.util.ResourceLocation;
@@ -32,7 +33,7 @@ public class Mappings {
                     if (!f.getType().isAssignableFrom(JsonObject.class)) continue;
 
                     ResourceLocation rc = new ResourceLocation(mainPath + f.getName() + ".json");
-                    f.set(null, new JsonParser().parse(IOUtils.toString(Minecraft.getMinecraft().getResourceManager().getResource(rc).getInputStream(), StandardCharsets.UTF_8)));
+                    f.set(null, new JsonParser().parse(IOUtils.toString(McIf.mc().getResourceManager().getResource(rc).getInputStream(), StandardCharsets.UTF_8)));
 
                 } catch (Exception ex) {
                     ex.printStackTrace();

--- a/src/main/java/com/wynntils/core/framework/settings/SettingsManager.java
+++ b/src/main/java/com/wynntils/core/framework/settings/SettingsManager.java
@@ -6,6 +6,7 @@ package com.wynntils.core.framework.settings;
 
 import com.google.gson.*;
 import com.google.gson.stream.JsonReader;
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.framework.instances.containers.ModuleContainer;
 import com.wynntils.core.framework.overlays.Overlay;
@@ -44,7 +45,7 @@ public class SettingsManager {
             if (!(obj instanceof Overlay))
                 return;
 
-        File f = new File(configFolder, Minecraft.getMinecraft().getSession().getPlayerID());
+        File f = new File(configFolder, McIf.mc().getSession().getPlayerID());
         if (!f.exists()) f.mkdirs();  // check if the users folder exists
 
         f = new File(f, m.getInfo().name() + "-" + (obj instanceof Overlay ? "overlay_" + ((Overlay)obj).displayName.toLowerCase(Locale.ROOT).replace(' ', '_') : info.name()) + ".config");
@@ -65,7 +66,7 @@ public class SettingsManager {
             if (!(obj instanceof Overlay))
                 return obj;
 
-        File f = new File(configFolder, Minecraft.getMinecraft().getSession().getPlayerID());
+        File f = new File(configFolder, McIf.mc().getSession().getPlayerID());
         if (!f.exists()) f.mkdirs();  // check if the users folder exists
 
         String configFile = m.getInfo().name() + "-" + (obj instanceof Overlay ? "overlay_" + ((Overlay)obj).displayName.toLowerCase(Locale.ROOT).replace(' ', '_') : info.name()) + ".config";

--- a/src/main/java/com/wynntils/core/framework/settings/ui/OverlayPositionsUI.java
+++ b/src/main/java/com/wynntils/core/framework/settings/ui/OverlayPositionsUI.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.core.framework.settings.ui;
 
+import com.wynntils.McIf;
 import com.wynntils.core.framework.FrameworkManager;
 import com.wynntils.core.framework.enums.MouseButton;
 import com.wynntils.core.framework.instances.containers.ModuleContainer;
@@ -109,8 +110,8 @@ public class OverlayPositionsUI extends UI {
 
     @Override
     public void onClose() {
-        mc.currentScreen = null;
-        mc.displayGuiScreen(parentScreen);
+        McIf.mc().currentScreen = null;
+        McIf.mc().displayGuiScreen(parentScreen);
     }
 
     @Override

--- a/src/main/java/com/wynntils/core/framework/settings/ui/SettingsUI.java
+++ b/src/main/java/com/wynntils/core/framework/settings/ui/SettingsUI.java
@@ -114,8 +114,8 @@ public class SettingsUI extends UI {
     public void onClose() {
         Keyboard.enableRepeatEvents(false);
 
-        mc.currentScreen = null;
-        mc.displayGuiScreen(parentScreen);
+        McIf.mc().currentScreen = null;
+        McIf.mc().displayGuiScreen(parentScreen);
     }
 
     @Override

--- a/src/main/java/com/wynntils/core/framework/settings/ui/SettingsUI.java
+++ b/src/main/java/com/wynntils/core/framework/settings/ui/SettingsUI.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.core.framework.settings.ui;
 
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.framework.FrameworkManager;
 import com.wynntils.core.framework.enums.MouseButton;
@@ -358,7 +359,7 @@ public class SettingsUI extends UI {
             hovering = mouseX >= position.getDrawingX() && mouseX <= position.getDrawingX()+width && mouseY >= position.getDrawingY() && mouseY <= position.getDrawingY()+height;
             if (visible && active && hovering) {
                 if (clickSound != null)
-                    Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(clickSound, 1f));
+                    McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(clickSound, 1f));
                 setCurrentSettingsPath(path);
             }
         }

--- a/src/main/java/com/wynntils/core/framework/ui/UI.java
+++ b/src/main/java/com/wynntils/core/framework/ui/UI.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.core.framework.ui;
 
+import com.wynntils.McIf;
 import com.wynntils.core.framework.enums.MouseButton;
 import com.wynntils.core.framework.rendering.ScreenRenderer;
 import com.wynntils.core.framework.rendering.textures.Textures;
@@ -145,7 +146,7 @@ public abstract class UI extends GuiScreen {
 
     public void show() {
         setupUI(this);
-        Minecraft.getMinecraft().displayGuiScreen(this);
+        McIf.mc().displayGuiScreen(this);
     }
 
     public static abstract class CommonUIFeatures {

--- a/src/main/java/com/wynntils/core/framework/ui/elements/GuiButtonImageBetter.java
+++ b/src/main/java/com/wynntils/core/framework/ui/elements/GuiButtonImageBetter.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.core.framework.ui.elements;
 
+import com.wynntils.McIf;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiButtonImage;
@@ -90,10 +91,10 @@ public class GuiButtonImageBetter extends GuiButtonImage {
     public static void setColour(boolean hovering, boolean enabled) {
         if (hovering) {
             highlightFixHovering.enabled = enabled;
-            highlightFixHovering.drawButton(Minecraft.getMinecraft(), Integer.MIN_VALUE, Integer.MIN_VALUE, 0);
+            highlightFixHovering.drawButton(McIf.mc(), Integer.MIN_VALUE, Integer.MIN_VALUE, 0);
         } else {
             highlightFixNoHovering.enabled = enabled;
-            highlightFixNoHovering.drawButton(Minecraft.getMinecraft(), 0, 0, 0);
+            highlightFixNoHovering.drawButton(McIf.mc(), 0, 0, 0);
         }
     }
 }

--- a/src/main/java/com/wynntils/core/framework/ui/elements/GuiButtonImageBetter.java
+++ b/src/main/java/com/wynntils/core/framework/ui/elements/GuiButtonImageBetter.java
@@ -71,7 +71,7 @@ public class GuiButtonImageBetter extends GuiButtonImage {
     }
 
     @Override
-    public void drawButton(Minecraft mc, int mouseX, int mouseY, float partialTicks) {
+    public void drawButton(Minecraft minecraft, int mouseX, int mouseY, float partialTicks) {
         setColour(this.highlight && mouseX >= scaledStartX && mouseY >= scaledStartY && mouseX < scaledEndX && mouseY < scaledEndY, this.enabled);
 
         if (scaleFactor != 1f) {
@@ -80,7 +80,7 @@ public class GuiButtonImageBetter extends GuiButtonImage {
             GlStateManager.scale(scaleFactor, scaleFactor, 1);
             GlStateManager.translate(scaleFromX, scaleFromY, 0);
         }
-        super.drawButton(mc, mouseX, mouseY, partialTicks);
+        super.drawButton(minecraft, mouseX, mouseY, partialTicks);
         if (scaleFactor != 1f) {
             GlStateManager.popMatrix();
         }

--- a/src/main/java/com/wynntils/core/framework/ui/elements/UIEClickZone.java
+++ b/src/main/java/com/wynntils/core/framework/ui/elements/UIEClickZone.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.core.framework.ui.elements;
 
+import com.wynntils.McIf;
 import com.wynntils.core.framework.enums.MouseButton;
 import com.wynntils.core.framework.ui.UI;
 import com.wynntils.core.framework.ui.UIElement;
@@ -44,7 +45,7 @@ public class UIEClickZone extends UIElement {
     public void click(boolean hovering, MouseButton button, UI ui) {
         if (active && hovering) {
             if (clickSound != null)
-                Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(clickSound, 1f));
+                McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(clickSound, 1f));
             if (onClick != null)
                 onClick.accept(ui, button);
         }
@@ -53,7 +54,7 @@ public class UIEClickZone extends UIElement {
         hovering = mouseX >= position.getDrawingX() && mouseX <= position.getDrawingX()+width && mouseY >= position.getDrawingY() && mouseY <= position.getDrawingY()+height;
         if (active && hovering) {
             if (clickSound != null)
-                Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(clickSound, 1f));
+                McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(clickSound, 1f));
             if (onClick != null)
                 onClick.accept(ui, button);
         }

--- a/src/main/java/com/wynntils/core/framework/ui/elements/UIEColorWheel.java
+++ b/src/main/java/com/wynntils/core/framework/ui/elements/UIEColorWheel.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.core.framework.ui.elements;
 
+import com.wynntils.McIf;
 import com.wynntils.core.framework.enums.MouseButton;
 import com.wynntils.core.framework.rendering.colors.CommonColors;
 import com.wynntils.core.framework.rendering.colors.CustomColor;
@@ -157,7 +158,7 @@ public class UIEColorWheel extends UIEClickZone {
                 color = toChange;
 
                 mc.displayGuiScreen(backGui);
-                Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(clickSound, 1f));
+                McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(clickSound, 1f));
                 onAccept.accept(color);
                 if (colorText == null) {
                     textBox.setText(formatColourName(color));
@@ -166,7 +167,7 @@ public class UIEColorWheel extends UIEClickZone {
                 }
             } else if (button == cancelButton) {
                 mc.displayGuiScreen(backGui);
-                Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(clickSound, 1f));
+                McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(clickSound, 1f));
             }
         }
 

--- a/src/main/java/com/wynntils/core/framework/ui/elements/UIEColorWheel.java
+++ b/src/main/java/com/wynntils/core/framework/ui/elements/UIEColorWheel.java
@@ -12,7 +12,6 @@ import com.wynntils.core.framework.rendering.colors.MinecraftChatColors;
 import com.wynntils.core.framework.rendering.textures.Textures;
 import com.wynntils.core.framework.ui.UI;
 import com.wynntils.modules.core.config.CoreDBConfig;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.audio.PositionedSoundRecord;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiPageButtonList;
@@ -112,7 +111,7 @@ public class UIEColorWheel extends UIEClickZone {
     public void click(int mouseX, int mouseY, MouseButton button, UI ui) {
         textBox.click(mouseX, mouseY, button, ui);
 
-        if (hovering) mc.displayGuiScreen(new ColorPickerGUI());
+        if (hovering) McIf.mc().displayGuiScreen(new ColorPickerGUI());
     }
 
     public void keyTyped(char c, int i, UI ui) {
@@ -157,7 +156,7 @@ public class UIEColorWheel extends UIEClickZone {
             if (button == applyButton) {
                 color = toChange;
 
-                mc.displayGuiScreen(backGui);
+                McIf.mc().displayGuiScreen(backGui);
                 McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(clickSound, 1f));
                 onAccept.accept(color);
                 if (colorText == null) {
@@ -166,7 +165,7 @@ public class UIEColorWheel extends UIEClickZone {
                     textBox.setText(colorText);
                 }
             } else if (button == cancelButton) {
-                mc.displayGuiScreen(backGui);
+                McIf.mc().displayGuiScreen(backGui);
                 McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(clickSound, 1f));
             }
         }
@@ -329,7 +328,7 @@ public class UIEColorWheel extends UIEClickZone {
             drawRectF(CommonColors.BLACK, (width/2f)-11, (height/2f)+94, (width/2f)+11, (height/2f)+116);  // current color back
             drawRectF(toChange, (width/2f)-10, (height/2f)+95, (width/2f)+10, (height/2f)+115);  // current color
 
-            drawCenteredString(mc.fontRenderer, "Click to pick a color!", (width/2), (height/2)-110, 0xFFFFFF);
+            drawCenteredString(McIf.mc().fontRenderer, "Click to pick a color!", (width/2), (height/2)-110, 0xFFFFFF);
 
             for (int i = 0; i < 16; ++i) {
                 int col = i / 8;

--- a/src/main/java/com/wynntils/core/utils/ServerUtils.java
+++ b/src/main/java/com/wynntils/core/utils/ServerUtils.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.core.utils;
 
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.utils.reflections.ReflectionFields;
 import net.minecraft.client.Minecraft;
@@ -61,7 +62,7 @@ public class ServerUtils {
      * @param unloadServerPack if false, disconnect without refreshing resources by unloading the server resource pack
      */
     public static void disconnect(boolean switchGui, boolean unloadServerPack) {
-        Minecraft mc = Minecraft.getMinecraft();
+        Minecraft mc = McIf.mc();
 
         WorldClient world = mc.world;
         if (world == null) return;
@@ -94,7 +95,7 @@ public class ServerUtils {
 
     private static class FakeResourcePackRepositoryHolder {
         // Will only be created by classloader when used
-        static final ResourcePackRepository instance = new ResourcePackRepository(Minecraft.getMinecraft().getResourcePackRepository().getDirResourcepacks(), null, null, null, Minecraft.getMinecraft().gameSettings) {
+        static final ResourcePackRepository instance = new ResourcePackRepository(McIf.mc().getResourcePackRepository().getDirResourcepacks(), null, null, null, McIf.mc().gameSettings) {
             @Override
             public void clearResourcePack() {
                 // Don't
@@ -103,11 +104,11 @@ public class ServerUtils {
     }
 
     public static synchronized void loadWorldWithoutUnloadingServerResourcePack(WorldClient world, String loadingMessage) {
-        ResourcePackRepository original = Minecraft.getMinecraft().getResourcePackRepository();
+        ResourcePackRepository original = McIf.mc().getResourcePackRepository();
 
-        ReflectionFields.Minecraft_resourcePackRepository.setValue(Minecraft.getMinecraft(), FakeResourcePackRepositoryHolder.instance);
-        Minecraft.getMinecraft().loadWorld(world, loadingMessage);
-        ReflectionFields.Minecraft_resourcePackRepository.setValue(Minecraft.getMinecraft(), original);
+        ReflectionFields.Minecraft_resourcePackRepository.setValue(McIf.mc(), FakeResourcePackRepositoryHolder.instance);
+        McIf.mc().loadWorld(world, loadingMessage);
+        ReflectionFields.Minecraft_resourcePackRepository.setValue(McIf.mc(), original);
     }
 
     public static ServerData getWynncraftServerData(boolean addNew) {

--- a/src/main/java/com/wynntils/core/utils/ServerUtils.java
+++ b/src/main/java/com/wynntils/core/utils/ServerUtils.java
@@ -62,7 +62,7 @@ public class ServerUtils {
      * @param unloadServerPack if false, disconnect without refreshing resources by unloading the server resource pack
      */
     public static void disconnect(boolean switchGui, boolean unloadServerPack) {
-        WorldClient world = McIf.mc().world;
+        WorldClient world = McIf.world();
         if (world == null) return;
 
         boolean singlePlayer = McIf.mc().isIntegratedServerRunning();

--- a/src/main/java/com/wynntils/core/utils/ServerUtils.java
+++ b/src/main/java/com/wynntils/core/utils/ServerUtils.java
@@ -62,30 +62,28 @@ public class ServerUtils {
      * @param unloadServerPack if false, disconnect without refreshing resources by unloading the server resource pack
      */
     public static void disconnect(boolean switchGui, boolean unloadServerPack) {
-        Minecraft mc = McIf.mc();
-
-        WorldClient world = mc.world;
+        WorldClient world = McIf.mc().world;
         if (world == null) return;
 
-        boolean singlePlayer = mc.isIntegratedServerRunning();
-        boolean realms = !singlePlayer && mc.isConnectedToRealms();
+        boolean singlePlayer = McIf.mc().isIntegratedServerRunning();
+        boolean realms = !singlePlayer && McIf.mc().isConnectedToRealms();
 
         world.sendQuittingDisconnectingPacket();
         if (unloadServerPack) {
-            mc.loadWorld(null);
+            McIf.mc().loadWorld(null);
         } else {
             loadWorldWithoutUnloadingServerResourcePack(null);
         }
 
         if (!switchGui) return;
         if (singlePlayer) {
-            mc.displayGuiScreen(new GuiMainMenu());
+            McIf.mc().displayGuiScreen(new GuiMainMenu());
         } else if (realms) {
             // Should not be possible because Wynntils will
             // never be running on the latest version of Minecraft
             new RealmsBridge().switchToRealms(new GuiMainMenu());
         } else {
-            mc.displayGuiScreen(new GuiMultiplayer(new GuiMainMenu()));
+            McIf.mc().displayGuiScreen(new GuiMultiplayer(new GuiMainMenu()));
         }
     }
 

--- a/src/main/java/com/wynntils/core/utils/Utils.java
+++ b/src/main/java/com/wynntils/core/utils/Utils.java
@@ -5,6 +5,7 @@
 package com.wynntils.core.utils;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.wynntils.McIf;
 import com.wynntils.ModCore;
 import com.wynntils.core.utils.reflections.ReflectionFields;
 import net.minecraft.client.Minecraft;
@@ -165,10 +166,10 @@ public class Utils {
      * @return the Scoreboard Team
      */
     public static ScorePlayerTeam createFakeScoreboard(String name, Team.CollisionRule rule) {
-        Scoreboard mc = Minecraft.getMinecraft().world.getScoreboard();
+        Scoreboard mc = McIf.mc().world.getScoreboard();
         if (mc.getTeam(name) != null) return mc.getTeam(name);
 
-        String player = Minecraft.getMinecraft().player.getName();
+        String player = McIf.mc().player.getName();
         if (mc.getPlayersTeam(player) != null) previousTeam = mc.getPlayersTeam(player).getName();
 
         ScorePlayerTeam team = mc.createTeam(name);
@@ -184,11 +185,11 @@ public class Utils {
      * @param name the scoreboard name
      */
     public static void removeFakeScoreboard(String name) {
-        Scoreboard mc = Minecraft.getMinecraft().world.getScoreboard();
+        Scoreboard mc = McIf.mc().world.getScoreboard();
         if (mc.getTeam(name) == null) return;
 
         mc.removeTeam(mc.getTeam(name));
-        if (previousTeam != null) mc.addPlayerToTeam(Minecraft.getMinecraft().player.getName(), previousTeam);
+        if (previousTeam != null) mc.addPlayerToTeam(McIf.mc().player.getName(), previousTeam);
     }
 
     /**
@@ -197,7 +198,7 @@ public class Utils {
      * @param screen the provided screen
      */
     public static void displayGuiScreen(GuiScreen screen) {
-        Minecraft mc = Minecraft.getMinecraft();
+        Minecraft mc = McIf.mc();
 
         GuiScreen oldScreen = mc.currentScreen;
 
@@ -213,7 +214,7 @@ public class Utils {
         mc.currentScreen = screen;
 
         if (screen != null) {
-            Minecraft.getMinecraft().setIngameNotInFocus();
+            McIf.mc().setIngameNotInFocus();
 
             ScaledResolution scaledresolution = new ScaledResolution(mc);
             int i = scaledresolution.getScaledWidth();

--- a/src/main/java/com/wynntils/core/utils/Utils.java
+++ b/src/main/java/com/wynntils/core/utils/Utils.java
@@ -168,7 +168,7 @@ public class Utils {
         Scoreboard scoreboard = McIf.world().getScoreboard();
         if (scoreboard.getTeam(name) != null) return scoreboard.getTeam(name);
 
-        String player = McIf.mc().player.getName();
+        String player = McIf.player().getName();
         if (scoreboard.getPlayersTeam(player) != null) previousTeam = scoreboard.getPlayersTeam(player).getName();
 
         ScorePlayerTeam team = scoreboard.createTeam(name);
@@ -188,7 +188,7 @@ public class Utils {
         if (scoreboard.getTeam(name) == null) return;
 
         scoreboard.removeTeam(scoreboard.getTeam(name));
-        if (previousTeam != null) scoreboard.addPlayerToTeam(McIf.mc().player.getName(), previousTeam);
+        if (previousTeam != null) scoreboard.addPlayerToTeam(McIf.player().getName(), previousTeam);
     }
 
     /**
@@ -318,7 +318,7 @@ public class Utils {
         urlComponent.getStyle().setUnderlined(true);
         text.appendSibling(urlComponent);
 
-        McIf.mc().player.sendMessage(text);
+        McIf.player().sendMessage(text);
     }
 
     public static String encodeUrl(String url) {

--- a/src/main/java/com/wynntils/core/utils/Utils.java
+++ b/src/main/java/com/wynntils/core/utils/Utils.java
@@ -6,7 +6,6 @@ package com.wynntils.core.utils;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.wynntils.McIf;
-import com.wynntils.ModCore;
 import com.wynntils.core.utils.reflections.ReflectionFields;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
@@ -166,16 +165,16 @@ public class Utils {
      * @return the Scoreboard Team
      */
     public static ScorePlayerTeam createFakeScoreboard(String name, Team.CollisionRule rule) {
-        Scoreboard mc = McIf.mc().world.getScoreboard();
-        if (mc.getTeam(name) != null) return mc.getTeam(name);
+        Scoreboard scoreboard = McIf.mc().world.getScoreboard();
+        if (scoreboard.getTeam(name) != null) return scoreboard.getTeam(name);
 
         String player = McIf.mc().player.getName();
-        if (mc.getPlayersTeam(player) != null) previousTeam = mc.getPlayersTeam(player).getName();
+        if (scoreboard.getPlayersTeam(player) != null) previousTeam = scoreboard.getPlayersTeam(player).getName();
 
-        ScorePlayerTeam team = mc.createTeam(name);
+        ScorePlayerTeam team = scoreboard.createTeam(name);
         team.setCollisionRule(rule);
 
-        mc.addPlayerToTeam(player, name);
+        scoreboard.addPlayerToTeam(player, name);
         return team;
     }
 
@@ -185,11 +184,11 @@ public class Utils {
      * @param name the scoreboard name
      */
     public static void removeFakeScoreboard(String name) {
-        Scoreboard mc = McIf.mc().world.getScoreboard();
-        if (mc.getTeam(name) == null) return;
+        Scoreboard scoreboard = McIf.mc().world.getScoreboard();
+        if (scoreboard.getTeam(name) == null) return;
 
-        mc.removeTeam(mc.getTeam(name));
-        if (previousTeam != null) mc.addPlayerToTeam(McIf.mc().player.getName(), previousTeam);
+        scoreboard.removeTeam(scoreboard.getTeam(name));
+        if (previousTeam != null) scoreboard.addPlayerToTeam(McIf.mc().player.getName(), previousTeam);
     }
 
     /**
@@ -198,9 +197,7 @@ public class Utils {
      * @param screen the provided screen
      */
     public static void displayGuiScreen(GuiScreen screen) {
-        Minecraft mc = McIf.mc();
-
-        GuiScreen oldScreen = mc.currentScreen;
+        GuiScreen oldScreen = McIf.mc().currentScreen;
 
         GuiOpenEvent event = new GuiOpenEvent(screen);
         if (MinecraftForge.EVENT_BUS.post(event)) return;
@@ -211,19 +208,19 @@ public class Utils {
             oldScreen.onGuiClosed();
         }
 
-        mc.currentScreen = screen;
+        McIf.mc().currentScreen = screen;
 
         if (screen != null) {
             McIf.mc().setIngameNotInFocus();
 
-            ScaledResolution scaledresolution = new ScaledResolution(mc);
+            ScaledResolution scaledresolution = new ScaledResolution(McIf.mc());
             int i = scaledresolution.getScaledWidth();
             int j = scaledresolution.getScaledHeight();
-            screen.setWorldAndResolution(mc, i, j);
-            mc.skipRenderWorld = false;
+            screen.setWorldAndResolution(McIf.mc(), i, j);
+            McIf.mc().skipRenderWorld = false;
         } else {
-            mc.getSoundHandler().resumeSounds();
-            mc.setIngameFocus();
+            McIf.mc().getSoundHandler().resumeSounds();
+            McIf.mc().setIngameFocus();
         }
     }
 
@@ -321,7 +318,7 @@ public class Utils {
         urlComponent.getStyle().setUnderlined(true);
         text.appendSibling(urlComponent);
 
-        ModCore.mc().player.sendMessage(text);
+        McIf.mc().player.sendMessage(text);
     }
 
     public static String encodeUrl(String url) {

--- a/src/main/java/com/wynntils/core/utils/Utils.java
+++ b/src/main/java/com/wynntils/core/utils/Utils.java
@@ -165,7 +165,7 @@ public class Utils {
      * @return the Scoreboard Team
      */
     public static ScorePlayerTeam createFakeScoreboard(String name, Team.CollisionRule rule) {
-        Scoreboard scoreboard = McIf.mc().world.getScoreboard();
+        Scoreboard scoreboard = McIf.world().getScoreboard();
         if (scoreboard.getTeam(name) != null) return scoreboard.getTeam(name);
 
         String player = McIf.mc().player.getName();
@@ -184,7 +184,7 @@ public class Utils {
      * @param name the scoreboard name
      */
     public static void removeFakeScoreboard(String name) {
-        Scoreboard scoreboard = McIf.mc().world.getScoreboard();
+        Scoreboard scoreboard = McIf.world().getScoreboard();
         if (scoreboard.getTeam(name) == null) return;
 
         scoreboard.removeTeam(scoreboard.getTeam(name));

--- a/src/main/java/com/wynntils/core/utils/helpers/CommandResponse.java
+++ b/src/main/java/com/wynntils/core/utils/helpers/CommandResponse.java
@@ -55,7 +55,7 @@ public class CommandResponse {
     public void executeCommand() {
         FrameworkManager.getEventBus().register(this);
 
-        Minecraft.getMinecraft().player.sendChatMessage(command);
+        McIf.mc().player.sendChatMessage(command);
     }
 
     @SubscribeEvent

--- a/src/main/java/com/wynntils/core/utils/helpers/CommandResponse.java
+++ b/src/main/java/com/wynntils/core/utils/helpers/CommandResponse.java
@@ -62,7 +62,7 @@ public class CommandResponse {
     public void onMessageReceive(ClientChatReceivedEvent e) {
         if (e.getType() != chatType) return;
 
-        String message = formattedText ? e.getMessage().getFormattedText() : McIf.getUnformattedText(e.getMessage());
+        String message = formattedText ? McIf.getFormattedText(e.getMessage()) : McIf.getUnformattedText(e.getMessage());
         Matcher matcher = regex.matcher(message);
 
         if (!matcher.find()) return;

--- a/src/main/java/com/wynntils/core/utils/helpers/CommandResponse.java
+++ b/src/main/java/com/wynntils/core/utils/helpers/CommandResponse.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.core.utils.helpers;
 
+import com.wynntils.McIf;
 import com.wynntils.core.framework.FrameworkManager;
 import net.minecraft.client.Minecraft;
 import net.minecraft.util.text.ChatType;
@@ -61,7 +62,7 @@ public class CommandResponse {
     public void onMessageReceive(ClientChatReceivedEvent e) {
         if (e.getType() != chatType) return;
 
-        String message = formattedText ? e.getMessage().getFormattedText() : e.getMessage().getUnformattedText();
+        String message = formattedText ? e.getMessage().getFormattedText() : McIf.getUnformattedText(e.getMessage());
         Matcher matcher = regex.matcher(message);
 
         if (!matcher.find()) return;

--- a/src/main/java/com/wynntils/core/utils/helpers/CommandResponse.java
+++ b/src/main/java/com/wynntils/core/utils/helpers/CommandResponse.java
@@ -55,7 +55,7 @@ public class CommandResponse {
     public void executeCommand() {
         FrameworkManager.getEventBus().register(this);
 
-        McIf.mc().player.sendChatMessage(command);
+        McIf.player().sendChatMessage(command);
     }
 
     @SubscribeEvent

--- a/src/main/java/com/wynntils/core/utils/helpers/RainbowText.java
+++ b/src/main/java/com/wynntils/core/utils/helpers/RainbowText.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.core.utils.helpers;
 
+import com.wynntils.McIf;
 import net.minecraft.client.Minecraft;
 
 public class RainbowText {
@@ -18,7 +19,7 @@ public class RainbowText {
     public static String makeRainbow(String input, boolean bold) {
         StringBuilder sb = new StringBuilder();
 
-        int offset = (int) Math.floor(Minecraft.getSystemTime() / 80.0) % colors.length;
+        int offset = (int) Math.floor(McIf.getSystemTime() / 80.0) % colors.length;
 
         for (int i = 0; i < input.length(); i++) {
             int color = (i + colors.length - offset) % colors.length;

--- a/src/main/java/com/wynntils/modules/chat/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/chat/events/ClientEvents.java
@@ -45,12 +45,12 @@ public class ClientEvents implements Listener {
         ITextComponent msg = e.getMessage();
         if (McIf.getUnformattedText(msg).startsWith("[Info] ") && ChatConfig.INSTANCE.filterWynncraftInfo) {
             e.setCanceled(true);
-        } else if (msg.getFormattedText().startsWith("\n                       " + TextFormatting.GOLD + TextFormatting.BOLD + "Welcome to Wynncraft!") &&
-                !msg.getFormattedText().contains("n the Trade Market") && ChatConfig.INSTANCE.filterWynncraftInfo) {
+        } else if (McIf.getFormattedText(msg).startsWith("\n                       " + TextFormatting.GOLD + TextFormatting.BOLD + "Welcome to Wynncraft!") &&
+                !McIf.getFormattedText(msg).contains("n the Trade Market") && ChatConfig.INSTANCE.filterWynncraftInfo) {
             e.setCanceled(true);
-        } else if (msg.getFormattedText().startsWith(TextFormatting.GRAY + "[You are now entering") && ChatConfig.INSTANCE.filterTerritoryEnter) {
+        } else if (McIf.getFormattedText(msg).startsWith(TextFormatting.GRAY + "[You are now entering") && ChatConfig.INSTANCE.filterTerritoryEnter) {
             e.setCanceled(true);
-        } else if (msg.getFormattedText().startsWith(TextFormatting.GRAY + "[You are now leaving") && ChatConfig.INSTANCE.filterTerritoryEnter) {
+        } else if (McIf.getFormattedText(msg).startsWith(TextFormatting.GRAY + "[You are now leaving") && ChatConfig.INSTANCE.filterTerritoryEnter) {
             e.setCanceled(true);
         }
     }

--- a/src/main/java/com/wynntils/modules/chat/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/chat/events/ClientEvents.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.chat.events;
 
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.WynnWorldEvent;
 import com.wynntils.core.events.custom.WynncraftServerEvent;
@@ -42,7 +43,7 @@ public class ClientEvents implements Listener {
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onChatReceived(ClientChatReceivedEvent e) {
         ITextComponent msg = e.getMessage();
-        if (msg.getUnformattedText().startsWith("[Info] ") && ChatConfig.INSTANCE.filterWynncraftInfo) {
+        if (McIf.getUnformattedText(msg).startsWith("[Info] ") && ChatConfig.INSTANCE.filterWynncraftInfo) {
             e.setCanceled(true);
         } else if (msg.getFormattedText().startsWith("\n                       " + TextFormatting.GOLD + TextFormatting.BOLD + "Welcome to Wynncraft!") &&
                 !msg.getFormattedText().contains("n the Trade Market") && ChatConfig.INSTANCE.filterWynncraftInfo) {

--- a/src/main/java/com/wynntils/modules/chat/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/chat/events/ClientEvents.java
@@ -81,7 +81,7 @@ public class ClientEvents implements Listener {
 
     @SubscribeEvent
     public void onWynnLogin(WynncraftServerEvent.Login e) {
-        ReflectionFields.GuiIngame_persistantChatGUI.setValue(Minecraft.getMinecraft().ingameGUI, new ChatOverlay());
+        ReflectionFields.GuiIngame_persistantChatGUI.setValue(McIf.mc().ingameGUI, new ChatOverlay());
         TranslationManager.init();
     }
 

--- a/src/main/java/com/wynntils/modules/chat/instances/ChatTab.java
+++ b/src/main/java/com/wynntils/modules/chat/instances/ChatTab.java
@@ -4,12 +4,12 @@
 
 package com.wynntils.modules.chat.instances;
 
+import com.wynntils.McIf;
 import com.wynntils.core.utils.objects.Pair;
 import net.minecraft.client.gui.ChatLine;
 import net.minecraft.util.text.ITextComponent;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -134,7 +134,7 @@ public class ChatTab implements Comparable<ChatTab> {
     }
 
     public boolean regexMatches(ITextComponent msg) {
-        return regexFinder.matcher(msg.getFormattedText()).find();
+        return regexFinder.matcher(McIf.getFormattedText(msg)).find();
     }
 
     public Pair<Integer, Integer> getCurrentXAxis() {

--- a/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
+++ b/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.chat.managers;
 
+import com.wynntils.McIf;
 import com.wynntils.ModCore;
 import com.wynntils.core.framework.enums.PowderManualChapter;
 import com.wynntils.core.utils.StringUtils;
@@ -121,11 +122,11 @@ public class ChatManager {
         }
 
         // popup sound
-        if (in.getUnformattedText().contains(" requires your ") && in.getUnformattedText().contains(" skill to be at least "))
+        if (McIf.getUnformattedText(in).contains(" requires your ") && McIf.getUnformattedText(in).contains(" skill to be at least "))
             ModCore.mc().player.playSound(popOffSound, 1f, 1f);
 
         // wynnic and gavellian translator
-        if (StringUtils.hasWynnic(in.getUnformattedText()) || StringUtils.hasGavellian(in.getUnformattedText())) {
+        if (StringUtils.hasWynnic(McIf.getUnformattedText(in)) || StringUtils.hasGavellian(McIf.getUnformattedText(in))) {
             List<ITextComponent> newTextComponents = new ArrayList<>();
             boolean capital = false;
             boolean isGuildOrParty = Pattern.compile(TabManager.DEFAULT_GUILD_REGEX.replace("&", "§")).matcher(original.getFormattedText()).find() || Pattern.compile(TabManager.DEFAULT_PARTY_REGEX.replace("&", "§")).matcher(original.getFormattedText()).find();
@@ -135,7 +136,7 @@ public class ChatManager {
             boolean translateIntoHover = !ChatConfig.INSTANCE.translateIntoChat;
             ITextComponent currentTranslatedComponents = new TextComponentString("");
             List<ITextComponent> currentOldComponents = new ArrayList<>();
-            if (foundEndTimestamp && !in.getSiblings().get(ChatConfig.INSTANCE.addTimestampsToChat ? 3 : 0).getUnformattedText().contains("/") && !isGuildOrParty) {
+            if (foundEndTimestamp && !McIf.getUnformattedText(in.getSiblings().get(ChatConfig.INSTANCE.addTimestampsToChat ? 3 : 0)).contains("/") && !isGuildOrParty) {
                 foundStart = true;
             }
             for (ITextComponent component : in) {
@@ -145,7 +146,7 @@ public class ChatManager {
                 String currentNonTranslated = "";
                 StringBuilder oldText = new StringBuilder();
                 StringBuilder number = new StringBuilder();
-                for (char character : component.getUnformattedText().toCharArray()) {
+                for (char character : McIf.getUnformattedText(component).toCharArray()) {
                     if (StringUtils.isWynnicNumber(character)) {
                         if (previousTranslated) {
                             toAdd += currentNonTranslated;
@@ -298,14 +299,14 @@ public class ChatManager {
                 }
                 if (!foundStart) {
                     if (foundEndTimestamp) {
-                        if (in.getSiblings().get(ChatConfig.INSTANCE.addTimestampsToChat ? 3 : 0).getUnformattedText().contains("/")) {
-                            foundStart = component.getUnformattedText().contains(":");
+                        if (McIf.getUnformattedText(in.getSiblings().get(ChatConfig.INSTANCE.addTimestampsToChat ? 3 : 0)).contains("/")) {
+                            foundStart = McIf.getUnformattedText(component).contains(":");
                         } else if (isGuildOrParty) {
-                            foundStart = component.getUnformattedText().contains("]");
+                            foundStart = McIf.getUnformattedText(component).contains("]");
                         }
                     } else if (component.getUnformattedComponentText().contains("] ")) {
                         foundEndTimestamp = true;
-                        if (!in.getSiblings().get(ChatConfig.INSTANCE.addTimestampsToChat ? 3 : 0).getUnformattedText().contains("/") && !isGuildOrParty) {
+                        if (!McIf.getUnformattedText(in.getSiblings().get(ChatConfig.INSTANCE.addTimestampsToChat ? 3 : 0)).contains("/") && !isGuildOrParty) {
                             foundStart = true;
                         }
                     }
@@ -343,7 +344,7 @@ public class ChatManager {
         }
 
         // clickable trade messages
-        if (ChatConfig.INSTANCE.clickableTradeMessage && tradeReg.matcher(in.getUnformattedText()).find()) {
+        if (ChatConfig.INSTANCE.clickableTradeMessage && tradeReg.matcher(McIf.getUnformattedText(in)).find()) {
             for (ITextComponent textComponent : in.getSiblings()) {
                 if (textComponent.getUnformattedComponentText().startsWith("/")) {
                     String command = textComponent.getUnformattedComponentText();
@@ -356,7 +357,7 @@ public class ChatManager {
         }
 
         // clickable duel messages
-        if (ChatConfig.INSTANCE.clickableDuelMessage && duelReg.matcher(in.getUnformattedText()).find()) {
+        if (ChatConfig.INSTANCE.clickableDuelMessage && duelReg.matcher(McIf.getUnformattedText(in)).find()) {
             for (ITextComponent textComponent : in.getSiblings()) {
                 if (textComponent.getUnformattedComponentText().startsWith("/")) {
                     String command = textComponent.getUnformattedComponentText();
@@ -369,7 +370,7 @@ public class ChatManager {
         }
 
         // clickable coordinates
-        if (ChatConfig.INSTANCE.clickableCoordinates && coordinateReg.matcher(in.getUnformattedText()).find()) {
+        if (ChatConfig.INSTANCE.clickableCoordinates && coordinateReg.matcher(McIf.getUnformattedText(in)).find()) {
 
             ITextComponent temp = new TextComponentString("");
             for (ITextComponent texts : in) {
@@ -383,9 +384,9 @@ public class ChatManager {
 
                 // Most likely only needed during the Wynnter Fair for the message with how many more players are required to join.
                 // As far as i could find all other messages from the Wynnter Fair use text components properly.
-                if (m.start() > 0 && texts.getUnformattedText().charAt(m.start() - 1) == '§') continue;
+                if (m.start() > 0 && McIf.getUnformattedText(texts).charAt(m.start() - 1) == '§') continue;
 
-                String crdText = texts.getUnformattedText();
+                String crdText = McIf.getUnformattedText(texts);
                 Style style = texts.getStyle();
                 String command = "/compass ";
                 List<ITextComponent> crdMsg = new ArrayList<>();
@@ -418,7 +419,7 @@ public class ChatManager {
         }
 
         //powder manual
-        if (ChatConfig.INSTANCE.customPowderManual && in.getUnformattedText().equals("                         Powder Manual")) {
+        if (ChatConfig.INSTANCE.customPowderManual && McIf.getUnformattedText(in).equals("                         Powder Manual")) {
             List<ITextComponent> chapterSelect = new ArrayList<ITextComponent>();
 
             ITextComponent offset = new TextComponentString("\n               "); //to center chapter select
@@ -447,7 +448,7 @@ public class ChatManager {
     }
 
     private static boolean translateMessage(ITextComponent in) {
-        if (!in.getUnformattedText().startsWith(TranslationManager.TRANSLATED_PREFIX)) {
+        if (!McIf.getUnformattedText(in).startsWith(TranslationManager.TRANSLATED_PREFIX)) {
             String formatted = in.getFormattedText();
             Matcher chatMatcher = translationPatternChat.matcher(formatted);
             if (chatMatcher.find()) {
@@ -498,7 +499,7 @@ public class ChatManager {
             String match = "\\b(" + ModCore.mc().player.getName() + (ChatConfig.INSTANCE.mentionNames.length() > 0 ? "|" + ChatConfig.INSTANCE.mentionNames.replace(",", "|") : "") + ")\\b";
             Pattern pattern = Pattern.compile(match, Pattern.CASE_INSENSITIVE);
 
-            Matcher looseMatcher = pattern.matcher(in.getUnformattedText());
+            Matcher looseMatcher = pattern.matcher(McIf.getUnformattedText(in));
 
             if (looseMatcher.find()) {
                 boolean hasMention = false;
@@ -776,7 +777,7 @@ public class ChatManager {
     public static Pair<Boolean, ITextComponent> applyToDialogue(ITextComponent component) {
         List<ITextComponent> siblings = component.getSiblings();
         List<ITextComponent> dialogue = new ArrayList<>();
-        if (inDialogue && component.getUnformattedText().equals(lastChat)) {
+        if (inDialogue && McIf.getUnformattedText(component).equals(lastChat)) {
             inDialogue = false;
             int max = Math.max(0, siblings.size() - newMessageCount);
             for (int i = max; i < siblings.size(); i++) {
@@ -803,25 +804,25 @@ public class ChatManager {
 
         // Very very long string of À's get sent in place of dialogue initially
         String chat = "";
-        if (component.getUnformattedText().contains("ÀÀÀÀ")) {
+        if (McIf.getUnformattedText(component).contains("ÀÀÀÀ")) {
             inDialogue = true;
             lineCount = 0;
             for (int componentIndex = siblings.size() - 1; componentIndex >= 0; componentIndex--) {
                 ITextComponent componentSibling = siblings.get(componentIndex);
-                if (componentSibling.getUnformattedText().matches("À*\n")) {
+                if (McIf.getUnformattedText(componentSibling).matches("À*\n")) {
                     dialogue.add(0, componentSibling);
                     lineCount++;
                 } else {
                     break;
                 }
             }
-            chat = siblings.subList(0, siblings.size() - lineCount).stream().map(ITextComponent::getUnformattedText).collect(Collectors.joining());
+            chat = siblings.subList(0, siblings.size() - lineCount).stream().map(McIf::getUnformattedText).collect(Collectors.joining());
             chat = chat.substring(0, chat.length() - 1);
         } else if (inDialogue) {
             if (siblings.size() < lineCount) {
                 return new Pair<>(false, component);
             }
-            chat = siblings.subList(0, siblings.size() - lineCount).stream().map(ITextComponent::getUnformattedText).collect(Collectors.joining());
+            chat = siblings.subList(0, siblings.size() - lineCount).stream().map(McIf::getUnformattedText).collect(Collectors.joining());
             chat = chat.substring(0, chat.length() - 1);
             dialogue = new ArrayList<>(siblings.subList(siblings.size() - lineCount, siblings.size()));
             if (!chat.equals(lastChat) && !dialogue.equals(last)) {

--- a/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
+++ b/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
@@ -129,7 +129,7 @@ public class ChatManager {
         if (StringUtils.hasWynnic(McIf.getUnformattedText(in)) || StringUtils.hasGavellian(McIf.getUnformattedText(in))) {
             List<ITextComponent> newTextComponents = new ArrayList<>();
             boolean capital = false;
-            boolean isGuildOrParty = Pattern.compile(TabManager.DEFAULT_GUILD_REGEX.replace("&", "§")).matcher(original.getFormattedText()).find() || Pattern.compile(TabManager.DEFAULT_PARTY_REGEX.replace("&", "§")).matcher(original.getFormattedText()).find();
+            boolean isGuildOrParty = Pattern.compile(TabManager.DEFAULT_GUILD_REGEX.replace("&", "§")).matcher(McIf.getFormattedText(original)).find() || Pattern.compile(TabManager.DEFAULT_PARTY_REGEX.replace("&", "§")).matcher(McIf.getFormattedText(original)).find();
             boolean foundStart = false;
             boolean foundEndTimestamp = !ChatConfig.INSTANCE.addTimestampsToChat;
             boolean previousTranslated = false;
@@ -331,7 +331,7 @@ public class ChatManager {
         }
 
         // clickable party invites
-        if (ChatConfig.INSTANCE.clickablePartyInvites && inviteReg.matcher(in.getFormattedText()).find()) {
+        if (ChatConfig.INSTANCE.clickablePartyInvites && inviteReg.matcher(McIf.getFormattedText(in)).find()) {
             for (ITextComponent textComponent : in.getSiblings()) {
                 if (textComponent.getUnformattedComponentText().startsWith("/")) {
                     String command = textComponent.getUnformattedComponentText();
@@ -449,7 +449,7 @@ public class ChatManager {
 
     private static boolean translateMessage(ITextComponent in) {
         if (!McIf.getUnformattedText(in).startsWith(TranslationManager.TRANSLATED_PREFIX)) {
-            String formatted = in.getFormattedText();
+            String formatted = McIf.getFormattedText(in);
             Matcher chatMatcher = translationPatternChat.matcher(formatted);
             if (chatMatcher.find()) {
                 if (!TranslationConfig.INSTANCE.translatePlayerChat) return false;
@@ -504,7 +504,7 @@ public class ChatManager {
             if (looseMatcher.find()) {
                 boolean hasMention = false;
 
-                boolean isGuildOrParty = Pattern.compile(TabManager.DEFAULT_GUILD_REGEX.replace("&", "§")).matcher(original.getFormattedText()).find() || Pattern.compile(TabManager.DEFAULT_PARTY_REGEX.replace("&", "§")).matcher(original.getFormattedText()).find();
+                boolean isGuildOrParty = Pattern.compile(TabManager.DEFAULT_GUILD_REGEX.replace("&", "§")).matcher(McIf.getFormattedText(original)).find() || Pattern.compile(TabManager.DEFAULT_PARTY_REGEX.replace("&", "§")).matcher(McIf.getFormattedText(original)).find();
                 boolean foundStart = false;
                 boolean foundEndTimestamp = !ChatConfig.INSTANCE.addTimestampsToChat;
 

--- a/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
+++ b/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
@@ -485,7 +485,7 @@ public class ChatManager {
             } catch (InterruptedException e) {
                 // ignore
             }
-            Minecraft.getMinecraft().addScheduledTask(() ->
+            McIf.mc().addScheduledTask(() ->
                     ChatOverlay.getChat().printChatMessage(new TextComponentString(TranslationManager.TRANSLATED_PREFIX + prefix + translatedMsg + suffix)));
         });
     }
@@ -495,7 +495,7 @@ public class ChatManager {
     }
 
     public static boolean processUserMention(ITextComponent in, ITextComponent original) {
-        if (ChatConfig.INSTANCE.allowChatMentions && in != null && Minecraft.getMinecraft().player != null) {
+        if (ChatConfig.INSTANCE.allowChatMentions && in != null && McIf.mc().player != null) {
             String match = "\\b(" + ModCore.mc().player.getName() + (ChatConfig.INSTANCE.mentionNames.length() > 0 ? "|" + ChatConfig.INSTANCE.mentionNames.replace(",", "|") : "") + ")\\b";
             Pattern pattern = Pattern.compile(match, Pattern.CASE_INSENSITIVE);
 
@@ -887,7 +887,7 @@ public class ChatManager {
 
         @Override
         public void run() {
-            Minecraft.getMinecraft().player.sendMessage(chapterText);
+            McIf.mc().player.sendMessage(chapterText);
         }
 
     }

--- a/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
+++ b/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
@@ -5,7 +5,6 @@
 package com.wynntils.modules.chat.managers;
 
 import com.wynntils.McIf;
-import com.wynntils.ModCore;
 import com.wynntils.core.framework.enums.PowderManualChapter;
 import com.wynntils.core.utils.StringUtils;
 import com.wynntils.core.utils.helpers.TextAction;
@@ -16,7 +15,6 @@ import com.wynntils.modules.questbook.enums.AnalysePosition;
 import com.wynntils.modules.questbook.managers.QuestManager;
 import com.wynntils.modules.utilities.configs.TranslationConfig;
 import com.wynntils.webapi.services.TranslationManager;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.audio.PositionedSoundRecord;
 import net.minecraft.init.SoundEvents;
 import net.minecraft.util.ResourceLocation;
@@ -123,7 +121,7 @@ public class ChatManager {
 
         // popup sound
         if (McIf.getUnformattedText(in).contains(" requires your ") && McIf.getUnformattedText(in).contains(" skill to be at least "))
-            ModCore.mc().player.playSound(popOffSound, 1f, 1f);
+            McIf.mc().player.playSound(popOffSound, 1f, 1f);
 
         // wynnic and gavellian translator
         if (StringUtils.hasWynnic(McIf.getUnformattedText(in)) || StringUtils.hasGavellian(McIf.getUnformattedText(in))) {
@@ -496,7 +494,7 @@ public class ChatManager {
 
     public static boolean processUserMention(ITextComponent in, ITextComponent original) {
         if (ChatConfig.INSTANCE.allowChatMentions && in != null && McIf.mc().player != null) {
-            String match = "\\b(" + ModCore.mc().player.getName() + (ChatConfig.INSTANCE.mentionNames.length() > 0 ? "|" + ChatConfig.INSTANCE.mentionNames.replace(",", "|") : "") + ")\\b";
+            String match = "\\b(" + McIf.mc().player.getName() + (ChatConfig.INSTANCE.mentionNames.length() > 0 ? "|" + ChatConfig.INSTANCE.mentionNames.replace(",", "|") : "") + ")\\b";
             Pattern pattern = Pattern.compile(match, Pattern.CASE_INSENSITIVE);
 
             Matcher looseMatcher = pattern.matcher(McIf.getUnformattedText(in));
@@ -558,7 +556,7 @@ public class ChatManager {
                     components.add(afterComponent);
                 }
                 if (hasMention) {
-                    ModCore.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.BLOCK_NOTE_PLING, 1.0F));
+                    McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.BLOCK_NOTE_PLING, 1.0F));
                     in.getSiblings().clear();
                     in.getSiblings().addAll(components);
 

--- a/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
+++ b/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
@@ -121,7 +121,7 @@ public class ChatManager {
 
         // popup sound
         if (McIf.getUnformattedText(in).contains(" requires your ") && McIf.getUnformattedText(in).contains(" skill to be at least "))
-            McIf.mc().player.playSound(popOffSound, 1f, 1f);
+            McIf.player().playSound(popOffSound, 1f, 1f);
 
         // wynnic and gavellian translator
         if (StringUtils.hasWynnic(McIf.getUnformattedText(in)) || StringUtils.hasGavellian(McIf.getUnformattedText(in))) {
@@ -493,8 +493,8 @@ public class ChatManager {
     }
 
     public static boolean processUserMention(ITextComponent in, ITextComponent original) {
-        if (ChatConfig.INSTANCE.allowChatMentions && in != null && McIf.mc().player != null) {
-            String match = "\\b(" + McIf.mc().player.getName() + (ChatConfig.INSTANCE.mentionNames.length() > 0 ? "|" + ChatConfig.INSTANCE.mentionNames.replace(",", "|") : "") + ")\\b";
+        if (ChatConfig.INSTANCE.allowChatMentions && in != null && McIf.player() != null) {
+            String match = "\\b(" + McIf.player().getName() + (ChatConfig.INSTANCE.mentionNames.length() > 0 ? "|" + ChatConfig.INSTANCE.mentionNames.replace(",", "|") : "") + ")\\b";
             Pattern pattern = Pattern.compile(match, Pattern.CASE_INSENSITIVE);
 
             Matcher looseMatcher = pattern.matcher(McIf.getUnformattedText(in));
@@ -885,7 +885,7 @@ public class ChatManager {
 
         @Override
         public void run() {
-            McIf.mc().player.sendMessage(chapterText);
+            McIf.player().sendMessage(chapterText);
         }
 
     }

--- a/src/main/java/com/wynntils/modules/chat/managers/HeldItemChatManager.java
+++ b/src/main/java/com/wynntils/modules/chat/managers/HeldItemChatManager.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.chat.managers;
 
+import com.wynntils.McIf;
 import com.wynntils.core.framework.instances.PlayerInfo;
 import com.wynntils.core.framework.instances.data.CharacterData;
 import com.wynntils.core.framework.instances.data.InventoryData;
@@ -46,29 +47,28 @@ public class HeldItemChatManager {
     }
 
     private static ITextComponent getMessage() {
-        Minecraft mc = McIf.mc();
         if (
             !ChatConfig.INSTANCE.heldItemChat ||
-            mc.player == null || mc.world == null ||
-            mc.player.inventory.mainInventory.get(6).getItem() != Items.COMPASS ||
-            mc.player.inventory.mainInventory.get(7).getItem() != Items.WRITTEN_BOOK ||
-            mc.player.inventory.mainInventory.get(8).getItem() != Items.NETHER_STAR &&
-            mc.player.inventory.mainInventory.get(8).getItem() != Item.getItemFromBlock(Blocks.SNOW_LAYER) ||
+            McIf.mc().player == null || McIf.mc().world == null ||
+            McIf.mc().player.inventory.mainInventory.get(6).getItem() != Items.COMPASS ||
+            McIf.mc().player.inventory.mainInventory.get(7).getItem() != Items.WRITTEN_BOOK ||
+            McIf.mc().player.inventory.mainInventory.get(8).getItem() != Items.NETHER_STAR &&
+            McIf.mc().player.inventory.mainInventory.get(8).getItem() != Item.getItemFromBlock(Blocks.SNOW_LAYER) ||
             !PlayerInfo.get(CharacterData.class).isLoaded()
         ) {
             reset();
             return null;
         }
 
-        if (lastHolding != mc.player.inventory.currentItem) {
-            lastHolding = mc.player.inventory.currentItem;
+        if (lastHolding != McIf.mc().player.inventory.currentItem) {
+            lastHolding = McIf.mc().player.inventory.currentItem;
             startedHolding = System.currentTimeMillis();
             return null;
         }
 
         if (System.currentTimeMillis() < startedHolding + DISPLAY_TIME) return null;
 
-        switch (mc.player.inventory.currentItem) {
+        switch (McIf.mc().player.inventory.currentItem) {
             case 6: return getCompassMessage();
             // case 7: return getQuestBookMessage();
             case 8: return getSoulPointsMessage();

--- a/src/main/java/com/wynntils/modules/chat/managers/HeldItemChatManager.java
+++ b/src/main/java/com/wynntils/modules/chat/managers/HeldItemChatManager.java
@@ -49,26 +49,26 @@ public class HeldItemChatManager {
     private static ITextComponent getMessage() {
         if (
             !ChatConfig.INSTANCE.heldItemChat ||
-            McIf.mc().player == null || McIf.world() == null ||
-            McIf.mc().player.inventory.mainInventory.get(6).getItem() != Items.COMPASS ||
-            McIf.mc().player.inventory.mainInventory.get(7).getItem() != Items.WRITTEN_BOOK ||
-            McIf.mc().player.inventory.mainInventory.get(8).getItem() != Items.NETHER_STAR &&
-            McIf.mc().player.inventory.mainInventory.get(8).getItem() != Item.getItemFromBlock(Blocks.SNOW_LAYER) ||
+            McIf.player() == null || McIf.world() == null ||
+            McIf.player().inventory.mainInventory.get(6).getItem() != Items.COMPASS ||
+            McIf.player().inventory.mainInventory.get(7).getItem() != Items.WRITTEN_BOOK ||
+            McIf.player().inventory.mainInventory.get(8).getItem() != Items.NETHER_STAR &&
+            McIf.player().inventory.mainInventory.get(8).getItem() != Item.getItemFromBlock(Blocks.SNOW_LAYER) ||
             !PlayerInfo.get(CharacterData.class).isLoaded()
         ) {
             reset();
             return null;
         }
 
-        if (lastHolding != McIf.mc().player.inventory.currentItem) {
-            lastHolding = McIf.mc().player.inventory.currentItem;
+        if (lastHolding != McIf.player().inventory.currentItem) {
+            lastHolding = McIf.player().inventory.currentItem;
             startedHolding = System.currentTimeMillis();
             return null;
         }
 
         if (System.currentTimeMillis() < startedHolding + DISPLAY_TIME) return null;
 
-        switch (McIf.mc().player.inventory.currentItem) {
+        switch (McIf.player().inventory.currentItem) {
             case 6: return getCompassMessage();
             // case 7: return getQuestBookMessage();
             case 8: return getSoulPointsMessage();
@@ -124,8 +124,8 @@ public class HeldItemChatManager {
 
         double compassX = compass.getX();
         double compassZ = compass.getZ();
-        double playerX = McIf.mc().player.posX;
-        double playerZ = McIf.mc().player.posZ;
+        double playerX = McIf.player().posX;
+        double playerZ = McIf.player().posZ;
 
         int distance = MathHelper.floor(MathHelper.sqrt((compassX - playerX) * (compassX - playerX) + (compassZ - playerZ) * (compassZ - playerZ)));
 
@@ -193,7 +193,7 @@ public class HeldItemChatManager {
             ChatConfig.INSTANCE.saveSettings(ChatModule.getModule());
 
             ITextComponent message = new TextComponentString("Enable §bMod options > Chat > Held Item Chat Messages§r to undo (or click this)");
-            McIf.mc().player.sendMessage(TextAction.withStaticEvent(message, OnUnhideClick.class));
+            McIf.player().sendMessage(TextAction.withStaticEvent(message, OnUnhideClick.class));
         }
     }
 

--- a/src/main/java/com/wynntils/modules/chat/managers/HeldItemChatManager.java
+++ b/src/main/java/com/wynntils/modules/chat/managers/HeldItemChatManager.java
@@ -49,7 +49,7 @@ public class HeldItemChatManager {
     private static ITextComponent getMessage() {
         if (
             !ChatConfig.INSTANCE.heldItemChat ||
-            McIf.mc().player == null || McIf.mc().world == null ||
+            McIf.mc().player == null || McIf.world() == null ||
             McIf.mc().player.inventory.mainInventory.get(6).getItem() != Items.COMPASS ||
             McIf.mc().player.inventory.mainInventory.get(7).getItem() != Items.WRITTEN_BOOK ||
             McIf.mc().player.inventory.mainInventory.get(8).getItem() != Items.NETHER_STAR &&

--- a/src/main/java/com/wynntils/modules/chat/managers/HeldItemChatManager.java
+++ b/src/main/java/com/wynntils/modules/chat/managers/HeldItemChatManager.java
@@ -46,7 +46,7 @@ public class HeldItemChatManager {
     }
 
     private static ITextComponent getMessage() {
-        Minecraft mc = Minecraft.getMinecraft();
+        Minecraft mc = McIf.mc();
         if (
             !ChatConfig.INSTANCE.heldItemChat ||
             mc.player == null || mc.world == null ||
@@ -124,8 +124,8 @@ public class HeldItemChatManager {
 
         double compassX = compass.getX();
         double compassZ = compass.getZ();
-        double playerX = Minecraft.getMinecraft().player.posX;
-        double playerZ = Minecraft.getMinecraft().player.posZ;
+        double playerX = McIf.mc().player.posX;
+        double playerZ = McIf.mc().player.posZ;
 
         int distance = MathHelper.floor(MathHelper.sqrt((compassX - playerX) * (compassX - playerX) + (compassZ - playerZ) * (compassZ - playerZ)));
 
@@ -193,7 +193,7 @@ public class HeldItemChatManager {
             ChatConfig.INSTANCE.saveSettings(ChatModule.getModule());
 
             ITextComponent message = new TextComponentString("Enable §bMod options > Chat > Held Item Chat Messages§r to undo (or click this)");
-            Minecraft.getMinecraft().player.sendMessage(TextAction.withStaticEvent(message, OnUnhideClick.class));
+            McIf.mc().player.sendMessage(TextAction.withStaticEvent(message, OnUnhideClick.class));
         }
     }
 

--- a/src/main/java/com/wynntils/modules/chat/overlays/ChatOverlay.java
+++ b/src/main/java/com/wynntils/modules/chat/overlays/ChatOverlay.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.chat.overlays;
 
+import com.wynntils.McIf;
 import com.wynntils.core.events.custom.ChatEvent;
 import com.wynntils.core.framework.FrameworkManager;
 import com.wynntils.core.utils.objects.Pair;
@@ -140,7 +141,7 @@ public class ChatOverlay extends GuiNewChat {
 
     public void printChatMessageWithOptionalDeletion(ITextComponent chatComponent, int chatLineId) {
         setChatLine(chatComponent, chatLineId, mc.ingameGUI.getUpdateCounter(), false, false);
-        LOGGER.info("[CHAT] " + chatComponent.getUnformattedText().replaceAll("\r", "\\\\r").replaceAll("\n", "\\\\n"));
+        LOGGER.info("[CHAT] " + McIf.getUnformattedText(chatComponent).replaceAll("\r", "\\\\r").replaceAll("\n", "\\\\n"));
     }
 
     public void printUnloggedChatMessage(ITextComponent chatComponent) {

--- a/src/main/java/com/wynntils/modules/chat/overlays/ChatOverlay.java
+++ b/src/main/java/com/wynntils/modules/chat/overlays/ChatOverlay.java
@@ -98,7 +98,7 @@ public class ChatOverlay extends GuiNewChat {
                             if (!ChatConfig.INSTANCE.transparent) {
                                 drawRect(-2, j2 - 9, extraY, j2, l1 / 2 << 24);
                             }
-                            String s = ChatManager.renderMessage(chatline.getChatComponent()).getFormattedText();
+                            String s = McIf.getFormattedText(ChatManager.renderMessage(chatline.getChatComponent()));
                             GlStateManager.enableBlend();
                             mc.fontRenderer.drawStringWithShadow(s, 0.0F, (float)(j2 - 8), 16777215 + (l1 << 24));
                             GlStateManager.disableAlpha();
@@ -208,7 +208,7 @@ public class ChatOverlay extends GuiNewChat {
 
         // spam filter
         if (!noProcessing && tab.getLastMessage() != null) {
-            if (ChatConfig.INSTANCE.blockChatSpamFilter && tab.getLastMessage().getFormattedText().equals(originalMessage.getFormattedText()) && chatLineId == 0) {
+            if (ChatConfig.INSTANCE.blockChatSpamFilter && McIf.getFormattedText(tab.getLastMessage()).equals(McIf.getFormattedText(originalMessage)) && chatLineId == 0) {
                 try {
                     List<ChatLine> lines = tab.getCurrentMessages();
                     if (lines != null && lines.size() > 0) {

--- a/src/main/java/com/wynntils/modules/chat/overlays/ChatOverlay.java
+++ b/src/main/java/com/wynntils/modules/chat/overlays/ChatOverlay.java
@@ -39,7 +39,7 @@ public class ChatOverlay extends GuiNewChat {
     private static ChatOverlay chat;
 
     private static final Logger LOGGER = LogManager.getFormatterLogger("chat");
-    private final Minecraft mc = Minecraft.getMinecraft();
+    private final Minecraft mc = McIf.mc();
 
     private int scrollPos;
     private boolean isScrolled;
@@ -293,7 +293,7 @@ public class ChatOverlay extends GuiNewChat {
     public void switchTabs(int amount) {
         currentTab = Math.floorMod(currentTab + amount, TabManager.getAvailableTabs().size());
 
-        Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
+        McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
     }
 
     public void resetScroll() {

--- a/src/main/java/com/wynntils/modules/chat/overlays/ChatOverlay.java
+++ b/src/main/java/com/wynntils/modules/chat/overlays/ChatOverlay.java
@@ -39,7 +39,6 @@ public class ChatOverlay extends GuiNewChat {
     private static ChatOverlay chat;
 
     private static final Logger LOGGER = LogManager.getFormatterLogger("chat");
-    private final Minecraft mc = McIf.mc();
 
     private int scrollPos;
     private boolean isScrolled;
@@ -56,7 +55,7 @@ public class ChatOverlay extends GuiNewChat {
     }
 
     public void drawChat(int updateCounter) {
-        if (mc.gameSettings.chatVisibility != EntityPlayer.EnumChatVisibility.HIDDEN) {
+        if (McIf.mc().gameSettings.chatVisibility != EntityPlayer.EnumChatVisibility.HIDDEN) {
             int chatSize = getCurrentTab().getCurrentMessages().size();
 
             getCurrentTab().checkNotifications();
@@ -90,7 +89,7 @@ public class ChatOverlay extends GuiNewChat {
                             l1 = 255;
                         }
 
-                        l1 = (int)((float)l1 * (mc.gameSettings.chatOpacity * 0.9F + 0.1F));
+                        l1 = (int)((float)l1 * (McIf.mc().gameSettings.chatOpacity * 0.9F + 0.1F));
                         ++l;
 
                         if (l1 > 3) {
@@ -100,7 +99,7 @@ public class ChatOverlay extends GuiNewChat {
                             }
                             String s = McIf.getFormattedText(ChatManager.renderMessage(chatline.getChatComponent()));
                             GlStateManager.enableBlend();
-                            mc.fontRenderer.drawStringWithShadow(s, 0.0F, (float)(j2 - 8), 16777215 + (l1 << 24));
+                            McIf.mc().fontRenderer.drawStringWithShadow(s, 0.0F, (float)(j2 - 8), 16777215 + (l1 << 24));
                             GlStateManager.disableAlpha();
                             GlStateManager.disableBlend();
                         }
@@ -111,7 +110,7 @@ public class ChatOverlay extends GuiNewChat {
             if (flag) {
                 // continuing chat render
                 if (chatSize > 0) {
-                    int k2 = mc.fontRenderer.FONT_HEIGHT;
+                    int k2 = McIf.mc().fontRenderer.FONT_HEIGHT;
                     GlStateManager.translate(-3.0F, 0.0F, 0.0F);
                     int l2 = chatSize * k2 + chatSize;
                     int i3 = l * k2 + l;
@@ -140,7 +139,7 @@ public class ChatOverlay extends GuiNewChat {
     }
 
     public void printChatMessageWithOptionalDeletion(ITextComponent chatComponent, int chatLineId) {
-        setChatLine(chatComponent, chatLineId, mc.ingameGUI.getUpdateCounter(), false, false);
+        setChatLine(chatComponent, chatLineId, McIf.mc().ingameGUI.getUpdateCounter(), false, false);
         LOGGER.info("[CHAT] " + McIf.getUnformattedText(chatComponent).replaceAll("\r", "\\\\r").replaceAll("\n", "\\\\n"));
     }
 
@@ -149,7 +148,7 @@ public class ChatOverlay extends GuiNewChat {
     }
 
     public void printUnloggedChatMessage(ITextComponent chatComponent, int chatLineId) {
-        setChatLine(chatComponent, chatLineId, mc.ingameGUI.getUpdateCounter(), false, true);
+        setChatLine(chatComponent, chatLineId, McIf.mc().ingameGUI.getUpdateCounter(), false, true);
     }
 
     private void setChatLine(ITextComponent chatComponent, int chatLineId, int updateCounter, boolean displayOnly, boolean noEvent) {
@@ -231,7 +230,7 @@ public class ChatOverlay extends GuiNewChat {
 
                         int chatWidth = MathHelper.floor((float)getChatWidth() / getChatScale());
 
-                        List<ITextComponent> chatLines = GuiUtilRenderComponents.splitText(chatWithCounter, chatWidth, mc.fontRenderer, false, false);
+                        List<ITextComponent> chatLines = GuiUtilRenderComponents.splitText(chatWithCounter, chatWidth, McIf.mc().fontRenderer, false, false);
 
                         Collections.reverse(chatLines);
                         lines.addAll(0, chatLines
@@ -262,7 +261,7 @@ public class ChatOverlay extends GuiNewChat {
 
         int thisGroupId = noProcessing ? 0 : tab.increaseCurrentGroupId();
         int chatWidth = MathHelper.floor((float)getChatWidth() / getChatScale());
-        List<ITextComponent> list = GuiUtilRenderComponents.splitText(displayedMessage, chatWidth, mc.fontRenderer, false, false);
+        List<ITextComponent> list = GuiUtilRenderComponents.splitText(displayedMessage, chatWidth, McIf.mc().fontRenderer, false, false);
         boolean flag = tab == getCurrentTab() && getChatOpen();
 
         for (ITextComponent itextcomponent : list) {
@@ -318,7 +317,7 @@ public class ChatOverlay extends GuiNewChat {
     @Nullable
     public ITextComponent getChatComponent(int mouseX, int mouseY) {
         if (getChatOpen()) {
-            ScaledResolution scaledresolution = new ScaledResolution(mc);
+            ScaledResolution scaledresolution = new ScaledResolution(McIf.mc());
             int i = scaledresolution.getScaleFactor();
             float f = getChatScale();
             int j = mouseX / i - 2;
@@ -329,8 +328,8 @@ public class ChatOverlay extends GuiNewChat {
             if (j >= 0 && k >= 0) {
                 int l = Math.min(getLineCount(), getCurrentTab().getCurrentMessages().size());
 
-                if (j <= MathHelper.floor((float) getChatWidth() / getChatScale()) && k < mc.fontRenderer.FONT_HEIGHT * l + l) {
-                    int i1 = k / mc.fontRenderer.FONT_HEIGHT + scrollPos;
+                if (j <= MathHelper.floor((float) getChatWidth() / getChatScale()) && k < McIf.mc().fontRenderer.FONT_HEIGHT * l + l) {
+                    int i1 = k / McIf.mc().fontRenderer.FONT_HEIGHT + scrollPos;
 
                     if (i1 >= 0 && i1 < getCurrentTab().getCurrentMessages().size()) {
                         ChatLine chatline = getCurrentTab().getCurrentMessages().get(i1);
@@ -338,7 +337,7 @@ public class ChatOverlay extends GuiNewChat {
 
                         for (ITextComponent itextcomponent : chatline.getChatComponent()) {
                             if (itextcomponent instanceof TextComponentString) {
-                                j1 += mc.fontRenderer.getStringWidth(GuiUtilRenderComponents.removeTextColorsIfConfigured(((TextComponentString) itextcomponent).getText(), false));
+                                j1 += McIf.mc().fontRenderer.getStringWidth(GuiUtilRenderComponents.removeTextColorsIfConfigured(((TextComponentString) itextcomponent).getText(), false));
 
                                 if (j1 > j) {
                                     return itextcomponent;
@@ -353,7 +352,7 @@ public class ChatOverlay extends GuiNewChat {
     }
 
     public boolean getChatOpen() {
-        return mc.currentScreen instanceof GuiChat;
+        return McIf.mc().currentScreen instanceof GuiChat;
     }
 
     public void deleteChatLine(int id) {
@@ -380,15 +379,15 @@ public class ChatOverlay extends GuiNewChat {
     }
 
     public int getChatWidth() {
-        return calculateChatboxWidth(mc.gameSettings.chatWidth);
+        return calculateChatboxWidth(McIf.mc().gameSettings.chatWidth);
     }
 
     public int getChatHeight() {
-        return calculateChatboxHeight(getChatOpen() ? mc.gameSettings.chatHeightFocused : mc.gameSettings.chatHeightUnfocused);
+        return calculateChatboxHeight(getChatOpen() ? McIf.mc().gameSettings.chatHeightFocused : McIf.mc().gameSettings.chatHeightUnfocused);
     }
 
     public float getChatScale() {
-        return mc.gameSettings.chatScale;
+        return McIf.mc().gameSettings.chatScale;
     }
 
     public static int calculateChatboxWidth(float scale) {

--- a/src/main/java/com/wynntils/modules/chat/overlays/gui/ChatGUI.java
+++ b/src/main/java/com/wynntils/modules/chat/overlays/gui/ChatGUI.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.chat.overlays.gui;
 
+import com.wynntils.McIf;
 import com.wynntils.core.framework.rendering.ScreenRenderer;
 import com.wynntils.core.framework.rendering.SmartFontRenderer;
 import com.wynntils.core.framework.rendering.colors.CommonColors;
@@ -53,7 +54,7 @@ public class ChatGUI extends GuiChat {
         for (Map.Entry<ChatTab, ChatButton> tabButton : tabButtons.entrySet()) {
             if (tabButton.getValue().isMouseOver()) {
                 if (mouseButton == 1) {
-                    mc.displayGuiScreen(new TabGUI(TabManager.getAvailableTabs().indexOf(tabButton.getKey())));
+                    McIf.mc().displayGuiScreen(new TabGUI(TabManager.getAvailableTabs().indexOf(tabButton.getKey())));
                 } else {
                     ChatOverlay.getChat().setCurrentTab(TabManager.getAvailableTabs().indexOf(tabButton.getKey()));
                     tabButtons.values().stream().forEach(ChatButton::unselect);
@@ -69,7 +70,7 @@ public class ChatGUI extends GuiChat {
     @Override
     protected void actionPerformed(GuiButton button) throws IOException {
         if (button == addTab) {
-            mc.displayGuiScreen(new TabGUI(-2));
+            McIf.mc().displayGuiScreen(new TabGUI(-2));
         } else if (button instanceof ChatButton) {
             ChatButton chatButton = (ChatButton) button;
             if (chatButton.getLanguage() != null) {
@@ -133,14 +134,14 @@ public class ChatGUI extends GuiChat {
         if (!ChatConfig.INSTANCE.useBrackets) {
             drawRect(2, this.height - 14, this.inputField.width + 2, this.height - 2, Integer.MIN_VALUE);
             this.inputField.drawTextBox();
-            ITextComponent itextcomponent = this.mc.ingameGUI.getChatGUI().getChatComponent(Mouse.getX(), Mouse.getY());
+            ITextComponent itextcomponent = McIf.mc().ingameGUI.getChatGUI().getChatComponent(Mouse.getX(), Mouse.getY());
 
             for (int i = 0; i < this.buttonList.size(); ++i) {
-                ((GuiButton) this.buttonList.get(i)).drawButton(this.mc, mouseX, mouseY, partialTicks);
+                ((GuiButton) this.buttonList.get(i)).drawButton(McIf.mc(), mouseX, mouseY, partialTicks);
             }
 
             for (int j = 0; j < this.labelList.size(); ++j) {
-                ((GuiLabel) this.labelList.get(j)).drawLabel(this.mc, mouseX, mouseY);
+                ((GuiLabel) this.labelList.get(j)).drawLabel(McIf.mc(), mouseX, mouseY);
             }
 
             if (itextcomponent != null && itextcomponent.getStyle().getHoverEvent() != null) {
@@ -194,7 +195,7 @@ public class ChatGUI extends GuiChat {
         }
 
         @Override
-        public void drawButton(Minecraft mc, int mouseX, int mouseY, float partialTicks) {
+        public void drawButton(Minecraft minecraft, int mouseX, int mouseY, float partialTicks) {
             if (this.visible) {
                 this.hovered = mouseX >= this.x && mouseY >= this.y && mouseX < this.x + this.width && mouseY < this.y + this.height;
                 ScreenRenderer.beginGL(this.x, this.y);

--- a/src/main/java/com/wynntils/modules/chat/overlays/gui/ChatGUI.java
+++ b/src/main/java/com/wynntils/modules/chat/overlays/gui/ChatGUI.java
@@ -59,7 +59,7 @@ public class ChatGUI extends GuiChat {
                     tabButtons.values().stream().forEach(ChatButton::unselect);
                     tabButton.getValue().setSelected(true);
                 }
-                Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
+                McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
             }
         }
 
@@ -142,7 +142,7 @@ public class ChatGUI extends GuiChat {
             for (int j = 0; j < this.labelList.size(); ++j) {
                 ((GuiLabel) this.labelList.get(j)).drawLabel(this.mc, mouseX, mouseY);
             }
-            
+
             if (itextcomponent != null && itextcomponent.getStyle().getHoverEvent() != null) {
                 this.handleComponentHover(itextcomponent, mouseX, mouseY);
             }

--- a/src/main/java/com/wynntils/modules/chat/overlays/gui/TabGUI.java
+++ b/src/main/java/com/wynntils/modules/chat/overlays/gui/TabGUI.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.chat.overlays.gui;
 
+import com.wynntils.McIf;
 import com.wynntils.modules.chat.instances.ChatTab;
 import com.wynntils.modules.chat.managers.TabManager;
 import com.wynntils.modules.chat.overlays.ChatOverlay;
@@ -69,19 +70,19 @@ public class TabGUI extends GuiScreen {
 
         deleteButton.enabled = (id != -2) && TabManager.getAvailableTabs().size() > 1;
 
-        nameTextField = new GuiTextField(3, mc.fontRenderer, x - 110, y - 90, 80, 20);
+        nameTextField = new GuiTextField(3, McIf.mc().fontRenderer, x - 110, y - 90, 80, 20);
         nameTextField.setVisible(true);
         nameTextField.setEnabled(true);
         nameTextField.setEnableBackgroundDrawing(true);
         nameTextField.setMaxStringLength(10);
 
-        autoCommandField = new GuiTextField(3, mc.fontRenderer, x - 12, y - 90, 80, 20);
+        autoCommandField = new GuiTextField(3, McIf.mc().fontRenderer, x - 12, y - 90, 80, 20);
         autoCommandField.setVisible(true);
         autoCommandField.setEnabled(true);
         autoCommandField.setEnableBackgroundDrawing(true);
         autoCommandField.setMaxStringLength(10);
 
-        orderNbField = new GuiTextField(3, mc.fontRenderer, x + 85, y - 90, 25, 20);
+        orderNbField = new GuiTextField(3, McIf.mc().fontRenderer, x + 85, y - 90, 25, 20);
         orderNbField.setVisible(true);
         orderNbField.setEnabled(true);
         orderNbField.setEnableBackgroundDrawing(true);
@@ -90,7 +91,7 @@ public class TabGUI extends GuiScreen {
         buttonList.add(lowPriority = new GuiCheckBox(3, x - 100, y + 22, "Low Priority", true));
 
         // Simple
-        labelList.add(simpleSettings = new GuiLabel(mc.fontRenderer, 4, x - 100, y - 35, 10, 10, 0xFFFFFF));
+        labelList.add(simpleSettings = new GuiLabel(McIf.mc().fontRenderer, 4, x - 100, y - 35, 10, 10, 0xFFFFFF));
         simpleSettings.addLine("Message types " + RED + "*");
 
         simpleRegexSettings.add(allRegex = new GuiCheckBox(10, x - 100, y - 25, "All", false));
@@ -102,7 +103,7 @@ public class TabGUI extends GuiScreen {
         buttonList.addAll(simpleRegexSettings);
         applyRegexSettings();
         // Advanced
-        regexTextField = new GuiTextField(3, mc.fontRenderer, x - 100, y - 20, 200, 20);
+        regexTextField = new GuiTextField(3, McIf.mc().fontRenderer, x - 100, y - 20, 200, 20);
         regexTextField.setVisible(false);
         regexTextField.setEnabled(true);
         regexTextField.setEnableBackgroundDrawing(true);
@@ -117,14 +118,14 @@ public class TabGUI extends GuiScreen {
             checkIfRegexIsValid();
         }
 
-        labelList.add(nameLabel = new GuiLabel(mc.fontRenderer, 0, x - 110, y - 105, 10, 10, 0xFFFFFF));
+        labelList.add(nameLabel = new GuiLabel(McIf.mc().fontRenderer, 0, x - 110, y - 105, 10, 10, 0xFFFFFF));
         nameLabel.addLine("Name " + RED + "*");
-        labelList.add(regexLabel = new GuiLabel(mc.fontRenderer, 1, x - 100, y - 35, 10, 10, 0xFFFFFF));
+        labelList.add(regexLabel = new GuiLabel(McIf.mc().fontRenderer, 1, x - 100, y - 35, 10, 10, 0xFFFFFF));
         regexLabel.addLine("Regex " + RED + "*");
         regexLabel.visible = false;
-        labelList.add(autoCommand = new GuiLabel(mc.fontRenderer, 2, x - 12, y - 105, 10, 10, 0xFFFFFF));
+        labelList.add(autoCommand = new GuiLabel(McIf.mc().fontRenderer, 2, x - 12, y - 105, 10, 10, 0xFFFFFF));
         autoCommand.addLine("Auto Command");
-        labelList.add(orderNb = new GuiLabel(mc.fontRenderer, 3, x + 85, y - 105, 10, 10, 0xFFFFFF));
+        labelList.add(orderNb = new GuiLabel(McIf.mc().fontRenderer, 3, x + 85, y - 105, 10, 10, 0xFFFFFF));
         orderNb.addLine("Order #");
 
         Keyboard.enableRepeatEvents(true);
@@ -139,22 +140,22 @@ public class TabGUI extends GuiScreen {
     protected void actionPerformed(GuiButton button) throws IOException {
         super.actionPerformed(button);
 
-        if (button == closeButton) mc.displayGuiScreen(new ChatGUI());
+        if (button == closeButton) McIf.mc().displayGuiScreen(new ChatGUI());
         else if (button == saveButton) {
             if (id == -2) {
                 TabManager.registerNewTab(new ChatTab(nameTextField.getText(), regexTextField.getText(), regexSettingsCreator(), autoCommandField.getText(), lowPriority.isChecked(), orderNbField.getText().matches("[0-9]+") ? Integer.parseInt(orderNbField.getText()) : 0));
             } else {
                 TabManager.updateTab(id, nameTextField.getText(), regexTextField.getText(), regexSettingsCreator(), autoCommandField.getText(), lowPriority.isChecked(), orderNbField.getText().matches("[0-9]+") ? Integer.parseInt(orderNbField.getText()) : 0);
             }
-            mc.displayGuiScreen(new ChatGUI());
+            McIf.mc().displayGuiScreen(new ChatGUI());
         } else if (button == deleteButton) {
-            mc.displayGuiScreen(new GuiYesNo((result, cc) -> {
+            McIf.mc().displayGuiScreen(new GuiYesNo((result, cc) -> {
                 if (result) {
                     int c = TabManager.deleteTab(id);
                     if (ChatOverlay.getChat().getCurrentTabId() == id) ChatOverlay.getChat().setCurrentTab(c);
-                    mc.displayGuiScreen(new ChatGUI());
+                    McIf.mc().displayGuiScreen(new ChatGUI());
                 } else {
-                    mc.displayGuiScreen(this);
+                    McIf.mc().displayGuiScreen(this);
                 }
             }, WHITE + (BOLD + "Do you really want to delete this chat tab?"), RED + "This action is irreversible!", 0));
         } else if (button == advancedButton) {

--- a/src/main/java/com/wynntils/modules/core/commands/CommandAdmin.java
+++ b/src/main/java/com/wynntils/modules/core/commands/CommandAdmin.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.core.commands;
 
+import com.wynntils.McIf;
 import com.wynntils.modules.core.enums.AccountType;
 import com.wynntils.modules.core.managers.UserManager;
 import net.minecraft.client.Minecraft;

--- a/src/main/java/com/wynntils/modules/core/commands/CommandAdmin.java
+++ b/src/main/java/com/wynntils/modules/core/commands/CommandAdmin.java
@@ -36,7 +36,7 @@ public class CommandAdmin extends CommandBase implements IClientCommand {
 
     @Override
     public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException {
-        if (!UserManager.isAccountType(McIf.mc().player.getUniqueID(), AccountType.MODERATOR)) return;
+        if (!UserManager.isAccountType(McIf.player().getUniqueID(), AccountType.MODERATOR)) return;
 
         TextComponentString output;
 

--- a/src/main/java/com/wynntils/modules/core/commands/CommandAdmin.java
+++ b/src/main/java/com/wynntils/modules/core/commands/CommandAdmin.java
@@ -36,7 +36,7 @@ public class CommandAdmin extends CommandBase implements IClientCommand {
 
     @Override
     public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException {
-        if (!UserManager.isAccountType(Minecraft.getMinecraft().player.getUniqueID(), AccountType.MODERATOR)) return;
+        if (!UserManager.isAccountType(McIf.mc().player.getUniqueID(), AccountType.MODERATOR)) return;
 
         TextComponentString output;
 

--- a/src/main/java/com/wynntils/modules/core/commands/CommandCompass.java
+++ b/src/main/java/com/wynntils/modules/core/commands/CommandCompass.java
@@ -202,8 +202,8 @@ public class CommandCompass extends CommandBase implements IClientCommand {
 
             if (args.length >= 2 && args[1].equalsIgnoreCase("location")) {
                 // Use current location instead of compass
-                x = Minecraft.getMinecraft().player.posX;
-                z = Minecraft.getMinecraft().player.posZ;
+                x = McIf.mc().player.posX;
+                z = McIf.mc().player.posZ;
                 type = "location";
                 recipientIndex = 2;
             } else {
@@ -249,8 +249,8 @@ public class CommandCompass extends CommandBase implements IClientCommand {
             }
 
             try {
-                int x = getSingleCoordinate(xStr, (int) Minecraft.getMinecraft().player.posX);
-                int z = getSingleCoordinate(zStr, (int) Minecraft.getMinecraft().player.posZ);
+                int x = getSingleCoordinate(xStr, (int) McIf.mc().player.posX);
+                int z = getSingleCoordinate(zStr, (int) McIf.mc().player.posZ);
 
                 CompassManager.setCompassLocation(new Location(x, 0, z));
 
@@ -283,11 +283,11 @@ public class CommandCompass extends CommandBase implements IClientCommand {
     public static void shareCoordinates(String recipientUser, String type, int x, int z) {
         String location = "[" + x + ", " + z + "]";
         if (recipientUser == null) {
-            Minecraft.getMinecraft().player.sendChatMessage("/p " + " My " + type + " is at " + location);
+            McIf.mc().player.sendChatMessage("/p " + " My " + type + " is at " + location);
         }else if (recipientUser.equalsIgnoreCase("guild")) {
-            Minecraft.getMinecraft().player.sendChatMessage("/g " + " My " + type + " is at " + location);
+            McIf.mc().player.sendChatMessage("/g " + " My " + type + " is at " + location);
         } else {
-            Minecraft.getMinecraft().player.sendChatMessage("/msg " + recipientUser + " My " + type + " is at " + location);
+            McIf.mc().player.sendChatMessage("/msg " + recipientUser + " My " + type + " is at " + location);
         }
     }
 

--- a/src/main/java/com/wynntils/modules/core/commands/CommandCompass.java
+++ b/src/main/java/com/wynntils/modules/core/commands/CommandCompass.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.core.commands;
 
+import com.wynntils.McIf;
 import com.wynntils.core.framework.instances.PlayerInfo;
 import com.wynntils.core.framework.instances.data.SocialData;
 import com.wynntils.core.utils.objects.Location;

--- a/src/main/java/com/wynntils/modules/core/commands/CommandCompass.java
+++ b/src/main/java/com/wynntils/modules/core/commands/CommandCompass.java
@@ -202,8 +202,8 @@ public class CommandCompass extends CommandBase implements IClientCommand {
 
             if (args.length >= 2 && args[1].equalsIgnoreCase("location")) {
                 // Use current location instead of compass
-                x = McIf.mc().player.posX;
-                z = McIf.mc().player.posZ;
+                x = McIf.player().posX;
+                z = McIf.player().posZ;
                 type = "location";
                 recipientIndex = 2;
             } else {
@@ -249,8 +249,8 @@ public class CommandCompass extends CommandBase implements IClientCommand {
             }
 
             try {
-                int x = getSingleCoordinate(xStr, (int) McIf.mc().player.posX);
-                int z = getSingleCoordinate(zStr, (int) McIf.mc().player.posZ);
+                int x = getSingleCoordinate(xStr, (int) McIf.player().posX);
+                int z = getSingleCoordinate(zStr, (int) McIf.player().posZ);
 
                 CompassManager.setCompassLocation(new Location(x, 0, z));
 
@@ -283,11 +283,11 @@ public class CommandCompass extends CommandBase implements IClientCommand {
     public static void shareCoordinates(String recipientUser, String type, int x, int z) {
         String location = "[" + x + ", " + z + "]";
         if (recipientUser == null) {
-            McIf.mc().player.sendChatMessage("/p " + " My " + type + " is at " + location);
+            McIf.player().sendChatMessage("/p " + " My " + type + " is at " + location);
         }else if (recipientUser.equalsIgnoreCase("guild")) {
-            McIf.mc().player.sendChatMessage("/g " + " My " + type + " is at " + location);
+            McIf.player().sendChatMessage("/g " + " My " + type + " is at " + location);
         } else {
-            McIf.mc().player.sendChatMessage("/msg " + recipientUser + " My " + type + " is at " + location);
+            McIf.player().sendChatMessage("/msg " + recipientUser + " My " + type + " is at " + location);
         }
     }
 

--- a/src/main/java/com/wynntils/modules/core/commands/CommandTerritory.java
+++ b/src/main/java/com/wynntils/modules/core/commands/CommandTerritory.java
@@ -44,7 +44,7 @@ public class CommandTerritory extends CommandBase implements IClientCommand {
     @Override
     public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException {
         if (args.length <= 0) {
-            Minecraft.getMinecraft().player.playSound(SoundEvents.BLOCK_ANVIL_PLACE, 1.0f, 1.0f);
+            McIf.mc().player.playSound(SoundEvents.BLOCK_ANVIL_PLACE, 1.0f, 1.0f);
 
             throw new WrongUsageException("/territory [name] | Ex: /territory Detlas");
         }
@@ -60,12 +60,12 @@ public class CommandTerritory extends CommandBase implements IClientCommand {
 
         Optional<TerritoryProfile> selectedTerritory = territories.stream().filter(c -> c.getFriendlyName().equalsIgnoreCase(finalTerritoryName)).findFirst();
         if (!selectedTerritory.isPresent()) {
-            Minecraft.getMinecraft().player.playSound(SoundEvents.BLOCK_ANVIL_PLACE, 1.0f, 1.0f);
+            McIf.mc().player.playSound(SoundEvents.BLOCK_ANVIL_PLACE, 1.0f, 1.0f);
 
             throw new CommandException("Invalid territory! Use: /territory [name] | Ex: /territory Detlas");
         }
 
-        Minecraft.getMinecraft().player.playSound(SoundEvents.ENTITY_PLAYER_LEVELUP, 1.0f, 10.0f);
+        McIf.mc().player.playSound(SoundEvents.ENTITY_PLAYER_LEVELUP, 1.0f, 10.0f);
 
         TerritoryProfile tp = selectedTerritory.get();
 

--- a/src/main/java/com/wynntils/modules/core/commands/CommandTerritory.java
+++ b/src/main/java/com/wynntils/modules/core/commands/CommandTerritory.java
@@ -44,7 +44,7 @@ public class CommandTerritory extends CommandBase implements IClientCommand {
     @Override
     public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException {
         if (args.length <= 0) {
-            McIf.mc().player.playSound(SoundEvents.BLOCK_ANVIL_PLACE, 1.0f, 1.0f);
+            McIf.player().playSound(SoundEvents.BLOCK_ANVIL_PLACE, 1.0f, 1.0f);
 
             throw new WrongUsageException("/territory [name] | Ex: /territory Detlas");
         }
@@ -60,12 +60,12 @@ public class CommandTerritory extends CommandBase implements IClientCommand {
 
         Optional<TerritoryProfile> selectedTerritory = territories.stream().filter(c -> c.getFriendlyName().equalsIgnoreCase(finalTerritoryName)).findFirst();
         if (!selectedTerritory.isPresent()) {
-            McIf.mc().player.playSound(SoundEvents.BLOCK_ANVIL_PLACE, 1.0f, 1.0f);
+            McIf.player().playSound(SoundEvents.BLOCK_ANVIL_PLACE, 1.0f, 1.0f);
 
             throw new CommandException("Invalid territory! Use: /territory [name] | Ex: /territory Detlas");
         }
 
-        McIf.mc().player.playSound(SoundEvents.ENTITY_PLAYER_LEVELUP, 1.0f, 10.0f);
+        McIf.player().playSound(SoundEvents.ENTITY_PLAYER_LEVELUP, 1.0f, 10.0f);
 
         TerritoryProfile tp = selectedTerritory.get();
 

--- a/src/main/java/com/wynntils/modules/core/commands/CommandTerritory.java
+++ b/src/main/java/com/wynntils/modules/core/commands/CommandTerritory.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.core.commands;
 
+import com.wynntils.McIf;
 import com.wynntils.core.utils.objects.Location;
 import com.wynntils.modules.core.managers.CompassManager;
 import com.wynntils.webapi.WebManager;

--- a/src/main/java/com/wynntils/modules/core/commands/CommandWynntils.java
+++ b/src/main/java/com/wynntils/modules/core/commands/CommandWynntils.java
@@ -163,7 +163,7 @@ public class CommandWynntils extends CommandBase implements IClientCommand {
                 if (!Reference.developmentEnvironment) {
                     ITextComponent message = new TextComponentString(TextFormatting.RED + "You can't use this command outside a development environment");
 
-                    Minecraft.getMinecraft().player.sendMessage(message);
+                    McIf.mc().player.sendMessage(message);
                     return;
                 }
 

--- a/src/main/java/com/wynntils/modules/core/commands/CommandWynntils.java
+++ b/src/main/java/com/wynntils/modules/core/commands/CommandWynntils.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.core.commands;
 
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.framework.rendering.textures.Textures;
 import com.wynntils.core.utils.helpers.Delay;

--- a/src/main/java/com/wynntils/modules/core/commands/CommandWynntils.java
+++ b/src/main/java/com/wynntils/modules/core/commands/CommandWynntils.java
@@ -163,7 +163,7 @@ public class CommandWynntils extends CommandBase implements IClientCommand {
                 if (!Reference.developmentEnvironment) {
                     ITextComponent message = new TextComponentString(TextFormatting.RED + "You can't use this command outside a development environment");
 
-                    McIf.mc().player.sendMessage(message);
+                    McIf.player().sendMessage(message);
                     return;
                 }
 

--- a/src/main/java/com/wynntils/modules/core/enums/ToggleSetting.java
+++ b/src/main/java/com/wynntils/modules/core/enums/ToggleSetting.java
@@ -60,7 +60,7 @@ public enum ToggleSetting {
             // show message is false when the option was already on the value status
             if (!showMessage) return;
 
-            Minecraft.getMinecraft().player.sendMessage(getToggleText(value));
+            McIf.mc().player.sendMessage(getToggleText(value));
         }, TOGGLE_MESSAGE_PATTERN);
 
         response.setCancel(true);

--- a/src/main/java/com/wynntils/modules/core/enums/ToggleSetting.java
+++ b/src/main/java/com/wynntils/modules/core/enums/ToggleSetting.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.core.enums;
 
+import com.wynntils.McIf;
 import com.wynntils.core.utils.helpers.CommandResponse;
 import net.minecraft.client.Minecraft;
 import net.minecraft.util.text.TextComponentBase;
@@ -46,7 +47,7 @@ public enum ToggleSetting {
         String inverseMatcher = value ? disabledMatcher : enabledMatcher;
 
         CommandResponse response = new CommandResponse("/toggle " + name, (m, t) -> {
-            String message = t.getUnformattedText();
+            String message = McIf.getUnformattedText(t);
             // Try again if the current value was already the expected result
             if (!message.contains(matcher)) {
                 // Make sure it's the right toggle in case we're running multiple

--- a/src/main/java/com/wynntils/modules/core/enums/ToggleSetting.java
+++ b/src/main/java/com/wynntils/modules/core/enums/ToggleSetting.java
@@ -60,7 +60,7 @@ public enum ToggleSetting {
             // show message is false when the option was already on the value status
             if (!showMessage) return;
 
-            McIf.mc().player.sendMessage(getToggleText(value));
+            McIf.player().sendMessage(getToggleText(value));
         }, TOGGLE_MESSAGE_PATTERN);
 
         response.setCancel(true);

--- a/src/main/java/com/wynntils/modules/core/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/core/events/ClientEvents.java
@@ -100,19 +100,19 @@ public class ClientEvents implements Listener {
         if (e.getGui() instanceof GuiInventory) {
             if (e.getGui() instanceof InventoryReplacer) return;
 
-            e.setGui(new InventoryReplacer(McIf.mc().player));
+            e.setGui(new InventoryReplacer(McIf.player()));
             return;
         }
         if (e.getGui() instanceof GuiChest) {
             if (e.getGui() instanceof ChestReplacer) return;
 
-            e.setGui(new ChestReplacer(McIf.mc().player.inventory, ReflectionFields.GuiChest_lowerChestInventory.getValue(e.getGui())));
+            e.setGui(new ChestReplacer(McIf.player().inventory, ReflectionFields.GuiChest_lowerChestInventory.getValue(e.getGui())));
             return;
         }
         if (e.getGui() instanceof GuiScreenHorseInventory) {
             if (e.getGui() instanceof HorseReplacer) return;
 
-            e.setGui(new HorseReplacer(McIf.mc().player.inventory, ReflectionFields.GuiScreenHorseInventory_horseInventory.getValue(e.getGui()), (AbstractHorse) ReflectionFields.GuiScreenHorseInventory_horseEntity.getValue(e.getGui())));
+            e.setGui(new HorseReplacer(McIf.player().inventory, ReflectionFields.GuiScreenHorseInventory_horseInventory.getValue(e.getGui()), (AbstractHorse) ReflectionFields.GuiScreenHorseInventory_horseEntity.getValue(e.getGui())));
         }
         if (e.getGui() instanceof GuiIngameMenu) {
             if (e.getGui() instanceof IngameMenuReplacer) return;
@@ -149,8 +149,8 @@ public class ClientEvents implements Listener {
         SPacketEntityVelocity velocity = e.getPacket();
         if (McIf.world() != null) {
             Entity entity = McIf.world().getEntityByID(velocity.getEntityID());
-            Entity vehicle = McIf.mc().player.getLowestRidingEntity();
-            if ((entity == vehicle) && (vehicle != McIf.mc().player) && (vehicle.canPassengerSteer())) {
+            Entity vehicle = McIf.player().getLowestRidingEntity();
+            if ((entity == vehicle) && (vehicle != McIf.player()) && (vehicle.canPassengerSteer())) {
                 e.setCanceled(true);
             }
         }
@@ -161,8 +161,8 @@ public class ClientEvents implements Listener {
         // I'm not sure what this does, but the code has been here a long time,
         // just moving it here. /magicus, 2021
         SPacketMoveVehicle moveVehicle = e.getPacket();
-        Entity vehicle = McIf.mc().player.getLowestRidingEntity();
-        if ((vehicle == McIf.mc().player) || (!vehicle.canPassengerSteer()) || (vehicle.getDistance(moveVehicle.getX(), moveVehicle.getY(), moveVehicle.getZ()) <= 25D)) {
+        Entity vehicle = McIf.player().getLowestRidingEntity();
+        if ((vehicle == McIf.player()) || (!vehicle.canPassengerSteer()) || (vehicle.getDistance(moveVehicle.getX(), moveVehicle.getY(), moveVehicle.getZ()) <= 25D)) {
             e.setCanceled(true);
         }
     }

--- a/src/main/java/com/wynntils/modules/core/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/core/events/ClientEvents.java
@@ -135,7 +135,7 @@ public class ClientEvents implements Listener {
         if (e.getPacket().getAction() == 1) {
             ScorePlayerTeam scoreplayerteam;
 
-            Scoreboard scoreboard = Minecraft.getMinecraft().world.getScoreboard();
+            Scoreboard scoreboard = McIf.mc().world.getScoreboard();
             scoreplayerteam = scoreboard.getTeam(e.getPacket().getName());
             if (scoreplayerteam == null) {
                 // This would cause an NPE so cancel it
@@ -149,10 +149,10 @@ public class ClientEvents implements Listener {
         // I'm not sure what this does, but the code has been here a long time,
         // just moving it here. /magicus, 2021
         SPacketEntityVelocity velocity = e.getPacket();
-        if (Minecraft.getMinecraft().world != null) {
-            Entity entity = Minecraft.getMinecraft().world.getEntityByID(velocity.getEntityID());
-            Entity vehicle = Minecraft.getMinecraft().player.getLowestRidingEntity();
-            if ((entity == vehicle) && (vehicle != Minecraft.getMinecraft().player) && (vehicle.canPassengerSteer())) {
+        if (McIf.mc().world != null) {
+            Entity entity = McIf.mc().world.getEntityByID(velocity.getEntityID());
+            Entity vehicle = McIf.mc().player.getLowestRidingEntity();
+            if ((entity == vehicle) && (vehicle != McIf.mc().player) && (vehicle.canPassengerSteer())) {
                 e.setCanceled(true);
             }
         }
@@ -163,8 +163,8 @@ public class ClientEvents implements Listener {
         // I'm not sure what this does, but the code has been here a long time,
         // just moving it here. /magicus, 2021
         SPacketMoveVehicle moveVehicle = e.getPacket();
-        Entity vehicle = Minecraft.getMinecraft().player.getLowestRidingEntity();
-        if ((vehicle == Minecraft.getMinecraft().player) || (!vehicle.canPassengerSteer()) || (vehicle.getDistance(moveVehicle.getX(), moveVehicle.getY(), moveVehicle.getZ()) <= 25D)) {
+        Entity vehicle = McIf.mc().player.getLowestRidingEntity();
+        if ((vehicle == McIf.mc().player) || (!vehicle.canPassengerSteer()) || (vehicle.getDistance(moveVehicle.getX(), moveVehicle.getY(), moveVehicle.getZ()) <= 25D)) {
             e.setCanceled(true);
         }
     }
@@ -172,13 +172,13 @@ public class ClientEvents implements Listener {
     @SubscribeEvent
     public void findLabels(PacketEvent<SPacketEntityMetadata> e) {
         // makes this method always be called in main thread
-        if (!Minecraft.getMinecraft().isCallingFromMinecraftThread()) {
-            Minecraft.getMinecraft().addScheduledTask(() -> findLabels(e));
+        if (!McIf.mc().isCallingFromMinecraftThread()) {
+            McIf.mc().addScheduledTask(() -> findLabels(e));
             return;
         }
 
         if (e.getPacket().getDataManagerEntries() == null || e.getPacket().getDataManagerEntries().isEmpty()) return;
-        Entity i = Minecraft.getMinecraft().world.getEntityByID(e.getPacket().getEntityId());
+        Entity i = McIf.mc().world.getEntityByID(e.getPacket().getEntityId());
         if (i == null) return;
 
         if (i instanceof EntityItemFrame) {

--- a/src/main/java/com/wynntils/modules/core/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/core/events/ClientEvents.java
@@ -5,7 +5,6 @@
 package com.wynntils.modules.core.events;
 
 import com.wynntils.McIf;
-import com.wynntils.ModCore;
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.*;
 import com.wynntils.core.framework.FrameworkManager;
@@ -34,7 +33,6 @@ import com.wynntils.modules.core.overlays.inventories.InventoryReplacer;
 import com.wynntils.modules.utilities.UtilitiesModule;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiIngameMenu;
 import net.minecraft.client.gui.GuiMainMenu;
 import net.minecraft.client.gui.GuiScreen;
@@ -102,19 +100,19 @@ public class ClientEvents implements Listener {
         if (e.getGui() instanceof GuiInventory) {
             if (e.getGui() instanceof InventoryReplacer) return;
 
-            e.setGui(new InventoryReplacer(ModCore.mc().player));
+            e.setGui(new InventoryReplacer(McIf.mc().player));
             return;
         }
         if (e.getGui() instanceof GuiChest) {
             if (e.getGui() instanceof ChestReplacer) return;
 
-            e.setGui(new ChestReplacer(ModCore.mc().player.inventory, ReflectionFields.GuiChest_lowerChestInventory.getValue(e.getGui())));
+            e.setGui(new ChestReplacer(McIf.mc().player.inventory, ReflectionFields.GuiChest_lowerChestInventory.getValue(e.getGui())));
             return;
         }
         if (e.getGui() instanceof GuiScreenHorseInventory) {
             if (e.getGui() instanceof HorseReplacer) return;
 
-            e.setGui(new HorseReplacer(ModCore.mc().player.inventory, ReflectionFields.GuiScreenHorseInventory_horseInventory.getValue(e.getGui()), (AbstractHorse) ReflectionFields.GuiScreenHorseInventory_horseEntity.getValue(e.getGui())));
+            e.setGui(new HorseReplacer(McIf.mc().player.inventory, ReflectionFields.GuiScreenHorseInventory_horseInventory.getValue(e.getGui()), (AbstractHorse) ReflectionFields.GuiScreenHorseInventory_horseEntity.getValue(e.getGui())));
         }
         if (e.getGui() instanceof GuiIngameMenu) {
             if (e.getGui() instanceof IngameMenuReplacer) return;
@@ -350,7 +348,7 @@ public class ClientEvents implements Listener {
     @SubscribeEvent
     public void mainMenuActionPerformed(GuiScreenEvent.ActionPerformedEvent.Post e) {
         GuiScreen gui = e.getGui();
-        if (gui != gui.mc.currentScreen || !(gui instanceof GuiMainMenu)) return;
+        if (gui != McIf.mc().currentScreen || !(gui instanceof GuiMainMenu)) return;
 
         MainMenuButtons.actionPerformed((GuiMainMenu) gui, e.getButton(), e.getButtonList());
     }

--- a/src/main/java/com/wynntils/modules/core/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/core/events/ClientEvents.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.core.events;
 
+import com.wynntils.McIf;
 import com.wynntils.ModCore;
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.*;
@@ -47,7 +48,6 @@ import net.minecraft.entity.item.EntityItemFrame;
 import net.minecraft.entity.passive.AbstractHorse;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
-import net.minecraft.network.datasync.EntityDataManager;
 import net.minecraft.network.play.client.CPacketClientSettings;
 import net.minecraft.network.play.client.CPacketHeldItemChange;
 import net.minecraft.network.play.server.*;
@@ -290,7 +290,7 @@ public class ClientEvents implements Listener {
     public void updateActionBar(PacketEvent<SPacketChat> e) {
         if (!Reference.onServer || e.getPacket().getType() != ChatType.GAME_INFO) return;
 
-        PlayerInfo.get(ActionBarData.class).updateActionBar(e.getPacket().getChatComponent().getUnformattedText());
+        PlayerInfo.get(ActionBarData.class).updateActionBar(McIf.getUnformattedText(e.getPacket().getChatComponent()));
         if (UtilitiesModule.getModule().getActionBarOverlay().active) e.setCanceled(true); // only disable when the wynntils action bar is enabled
     }
 

--- a/src/main/java/com/wynntils/modules/core/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/core/events/ClientEvents.java
@@ -133,7 +133,7 @@ public class ClientEvents implements Listener {
         if (e.getPacket().getAction() == 1) {
             ScorePlayerTeam scoreplayerteam;
 
-            Scoreboard scoreboard = McIf.mc().world.getScoreboard();
+            Scoreboard scoreboard = McIf.world().getScoreboard();
             scoreplayerteam = scoreboard.getTeam(e.getPacket().getName());
             if (scoreplayerteam == null) {
                 // This would cause an NPE so cancel it
@@ -147,8 +147,8 @@ public class ClientEvents implements Listener {
         // I'm not sure what this does, but the code has been here a long time,
         // just moving it here. /magicus, 2021
         SPacketEntityVelocity velocity = e.getPacket();
-        if (McIf.mc().world != null) {
-            Entity entity = McIf.mc().world.getEntityByID(velocity.getEntityID());
+        if (McIf.world() != null) {
+            Entity entity = McIf.world().getEntityByID(velocity.getEntityID());
             Entity vehicle = McIf.mc().player.getLowestRidingEntity();
             if ((entity == vehicle) && (vehicle != McIf.mc().player) && (vehicle.canPassengerSteer())) {
                 e.setCanceled(true);
@@ -176,7 +176,7 @@ public class ClientEvents implements Listener {
         }
 
         if (e.getPacket().getDataManagerEntries() == null || e.getPacket().getDataManagerEntries().isEmpty()) return;
-        Entity i = McIf.mc().world.getEntityByID(e.getPacket().getEntityId());
+        Entity i = McIf.world().getEntityByID(e.getPacket().getEntityId());
         if (i == null) return;
 
         if (i instanceof EntityItemFrame) {

--- a/src/main/java/com/wynntils/modules/core/events/ServerEvents.java
+++ b/src/main/java/com/wynntils/modules/core/events/ServerEvents.java
@@ -7,7 +7,6 @@ package com.wynntils.modules.core.events;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.wynntils.McIf;
-import com.wynntils.ModCore;
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.*;
 import com.wynntils.core.framework.FrameworkManager;
@@ -35,7 +34,6 @@ import com.wynntils.modules.core.overlays.ui.PlayerInfoReplacer;
 import com.wynntils.webapi.WebManager;
 import com.wynntils.webapi.downloader.DownloaderManager;
 import com.wynntils.webapi.profiles.TerritoryProfile;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.client.gui.GuiIngame;
 import net.minecraft.network.play.server.SPacketSpawnPosition;
@@ -327,7 +325,7 @@ public class ServerEvents implements Listener {
      */
     private static void startUpdateRegionName() {
         updateTimer = executor.scheduleAtFixedRate(() -> {
-            EntityPlayerSP pl = ModCore.mc().player;
+            EntityPlayerSP pl = McIf.mc().player;
 
             FrameworkManager.getEventBus().post(new SchedulerEvent.RegionUpdate());
 

--- a/src/main/java/com/wynntils/modules/core/events/ServerEvents.java
+++ b/src/main/java/com/wynntils/modules/core/events/ServerEvents.java
@@ -99,7 +99,7 @@ public class ServerEvents implements Listener {
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void joinWorldEvent(WynnWorldEvent.Join e) {
         if (PlayerInfo.get(CharacterData.class).getClassId() == -1 || CoreDBConfig.INSTANCE.lastClass == ClassType.NONE)
-            McIf.mc().player.sendChatMessage("/class");
+            McIf.player().sendChatMessage("/class");
 
         // This codeblock will only be executed if the Wynncraft AUTOJOIN setting is enabled
         // Reason: When you join a world with autojoin enabled, your current class is NONE,
@@ -114,12 +114,12 @@ public class ServerEvents implements Listener {
         // guild members
         if (WebManager.getPlayerProfile() != null && WebManager.getPlayerProfile().getGuildName() != null) {
             waitingForGuildList = true;
-            McIf.mc().player.sendChatMessage("/guild list");
+            McIf.player().sendChatMessage("/guild list");
         }
 
         // friends
         waitingForFriendList = true;
-        McIf.mc().player.sendChatMessage("/friends list");
+        McIf.player().sendChatMessage("/friends list");
 
         // party members
         PartyManager.handlePartyList();  // party list here
@@ -145,7 +145,7 @@ public class ServerEvents implements Listener {
         String messageText = McIf.getUnformattedText(e.getMessage());
         String formatted = McIf.getFormattedText(e.getMessage());
         Matcher m = FRIENDS_LIST.matcher(formatted);
-        if (m.find() && m.group(1).equals(McIf.mc().player.getName())) {
+        if (m.find() && m.group(1).equals(McIf.player().getName())) {
             String[] friends = m.group(2).split(", ");
 
             Set<String> friendsList = PlayerInfo.get(SocialData.class).getFriendList();
@@ -243,7 +243,7 @@ public class ServerEvents implements Listener {
         TextComponentString msg = new TextComponentString("The Wynntils servers are currently down! You can still use Wynntils, but some features may not work. Our servers should be back soon.");
         msg.getStyle().setColor(TextFormatting.RED);
         msg.getStyle().setBold(true);
-        new Delay(() -> McIf.mc().player.sendMessage(msg), 30); // delay so the player actually loads in
+        new Delay(() -> McIf.player().sendMessage(msg), 30); // delay so the player actually loads in
     }
 
     private static boolean triedToShowChangelog = false;
@@ -286,7 +286,7 @@ public class ServerEvents implements Listener {
     @SubscribeEvent
     public void onCompassChange(PacketEvent<SPacketSpawnPosition> e) {
         currentSpawn = e.getPacket().getSpawnPos();
-        if (McIf.mc().player == null) {
+        if (McIf.player() == null) {
             CompassManager.reset();
             return;
         }
@@ -325,7 +325,7 @@ public class ServerEvents implements Listener {
      */
     private static void startUpdateRegionName() {
         updateTimer = executor.scheduleAtFixedRate(() -> {
-            EntityPlayerSP pl = McIf.mc().player;
+            EntityPlayerSP pl = McIf.player();
 
             FrameworkManager.getEventBus().post(new SchedulerEvent.RegionUpdate());
 

--- a/src/main/java/com/wynntils/modules/core/events/ServerEvents.java
+++ b/src/main/java/com/wynntils/modules/core/events/ServerEvents.java
@@ -77,8 +77,8 @@ public class ServerEvents implements Listener {
         e.getManager().channel().pipeline().addBefore("fml:packet_handler", Reference.MOD_ID + ":packet_filter", new PacketIncomingFilter());
         e.getManager().channel().pipeline().addBefore("fml:packet_handler", Reference.MOD_ID + ":outgoingFilter", new PacketOutgoingFilter());
 
-        GuiIngame ingameGui = Minecraft.getMinecraft().ingameGUI;
-        ReflectionFields.GuiIngame_overlayPlayerList.setValue(ingameGui, new PlayerInfoReplacer(Minecraft.getMinecraft(), ingameGui));
+        GuiIngame ingameGui = McIf.mc().ingameGUI;
+        ReflectionFields.GuiIngame_overlayPlayerList.setValue(ingameGui, new PlayerInfoReplacer(McIf.mc(), ingameGui));
 
         WebManager.tryReloadApiUrls(true);
         WebManager.checkForUpdatesOnJoin();
@@ -101,7 +101,7 @@ public class ServerEvents implements Listener {
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void joinWorldEvent(WynnWorldEvent.Join e) {
         if (PlayerInfo.get(CharacterData.class).getClassId() == -1 || CoreDBConfig.INSTANCE.lastClass == ClassType.NONE)
-            Minecraft.getMinecraft().player.sendChatMessage("/class");
+            McIf.mc().player.sendChatMessage("/class");
 
         // This codeblock will only be executed if the Wynncraft AUTOJOIN setting is enabled
         // Reason: When you join a world with autojoin enabled, your current class is NONE,
@@ -116,12 +116,12 @@ public class ServerEvents implements Listener {
         // guild members
         if (WebManager.getPlayerProfile() != null && WebManager.getPlayerProfile().getGuildName() != null) {
             waitingForGuildList = true;
-            Minecraft.getMinecraft().player.sendChatMessage("/guild list");
+            McIf.mc().player.sendChatMessage("/guild list");
         }
 
         // friends
         waitingForFriendList = true;
-        Minecraft.getMinecraft().player.sendChatMessage("/friends list");
+        McIf.mc().player.sendChatMessage("/friends list");
 
         // party members
         PartyManager.handlePartyList();  // party list here
@@ -147,7 +147,7 @@ public class ServerEvents implements Listener {
         String messageText = McIf.getUnformattedText(e.getMessage());
         String formatted = McIf.getFormattedText(e.getMessage());
         Matcher m = FRIENDS_LIST.matcher(formatted);
-        if (m.find() && m.group(1).equals(Minecraft.getMinecraft().player.getName())) {
+        if (m.find() && m.group(1).equals(McIf.mc().player.getName())) {
             String[] friends = m.group(2).split(", ");
 
             Set<String> friendsList = PlayerInfo.get(SocialData.class).getFriendList();
@@ -245,7 +245,7 @@ public class ServerEvents implements Listener {
         TextComponentString msg = new TextComponentString("The Wynntils servers are currently down! You can still use Wynntils, but some features may not work. Our servers should be back soon.");
         msg.getStyle().setColor(TextFormatting.RED);
         msg.getStyle().setBold(true);
-        new Delay(() -> Minecraft.getMinecraft().player.sendMessage(msg), 30); // delay so the player actually loads in
+        new Delay(() -> McIf.mc().player.sendMessage(msg), 30); // delay so the player actually loads in
     }
 
     private static boolean triedToShowChangelog = false;
@@ -257,7 +257,7 @@ public class ServerEvents implements Listener {
     @SubscribeEvent
     public void onJoinLobby(WynnClassChangeEvent e) {
         if (!Reference.onServer || !CoreDBConfig.INSTANCE.enableChangelogOnUpdate || !CoreDBConfig.INSTANCE.showChangelogs) return;
-        if (UpdateOverlay.isDownloading() || DownloaderManager.isRestartOnQueueFinish() || Minecraft.getMinecraft().world == null) return;
+        if (UpdateOverlay.isDownloading() || DownloaderManager.isRestartOnQueueFinish() || McIf.mc().world == null) return;
         if (e.getNewClass() == ClassType.NONE) return;
 
         synchronized (this) {
@@ -270,8 +270,8 @@ public class ServerEvents implements Listener {
             List<String> changelog = WebManager.getChangelog(major, false);
             if (changelog == null) return;
 
-            Minecraft.getMinecraft().addScheduledTask(() -> {
-                Minecraft.getMinecraft().displayGuiScreen(new ChangelogUI(changelog, major));
+            McIf.mc().addScheduledTask(() -> {
+                McIf.mc().displayGuiScreen(new ChangelogUI(changelog, major));
 
                 // Showed changelog; Don't show next time.
                 CoreDBConfig.INSTANCE.showChangelogs = false;
@@ -288,7 +288,7 @@ public class ServerEvents implements Listener {
     @SubscribeEvent
     public void onCompassChange(PacketEvent<SPacketSpawnPosition> e) {
         currentSpawn = e.getPacket().getSpawnPos();
-        if (Minecraft.getMinecraft().player == null) {
+        if (McIf.mc().player == null) {
             CompassManager.reset();
             return;
         }

--- a/src/main/java/com/wynntils/modules/core/events/ServerEvents.java
+++ b/src/main/java/com/wynntils/modules/core/events/ServerEvents.java
@@ -255,7 +255,7 @@ public class ServerEvents implements Listener {
     @SubscribeEvent
     public void onJoinLobby(WynnClassChangeEvent e) {
         if (!Reference.onServer || !CoreDBConfig.INSTANCE.enableChangelogOnUpdate || !CoreDBConfig.INSTANCE.showChangelogs) return;
-        if (UpdateOverlay.isDownloading() || DownloaderManager.isRestartOnQueueFinish() || McIf.mc().world == null) return;
+        if (UpdateOverlay.isDownloading() || DownloaderManager.isRestartOnQueueFinish() || McIf.world() == null) return;
         if (e.getNewClass() == ClassType.NONE) return;
 
         synchronized (this) {

--- a/src/main/java/com/wynntils/modules/core/events/ServerEvents.java
+++ b/src/main/java/com/wynntils/modules/core/events/ServerEvents.java
@@ -145,7 +145,7 @@ public class ServerEvents implements Listener {
         PartyManager.handleMessages(e.getMessage());  // party messages here
 
         String messageText = McIf.getUnformattedText(e.getMessage());
-        String formatted = e.getMessage().getFormattedText();
+        String formatted = McIf.getFormattedText(e.getMessage());
         Matcher m = FRIENDS_LIST.matcher(formatted);
         if (m.find() && m.group(1).equals(Minecraft.getMinecraft().player.getName())) {
             String[] friends = m.group(2).split(", ");

--- a/src/main/java/com/wynntils/modules/core/events/ServerEvents.java
+++ b/src/main/java/com/wynntils/modules/core/events/ServerEvents.java
@@ -6,6 +6,7 @@ package com.wynntils.modules.core.events;
 
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.wynntils.McIf;
 import com.wynntils.ModCore;
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.*;
@@ -143,7 +144,7 @@ public class ServerEvents implements Listener {
         }
         PartyManager.handleMessages(e.getMessage());  // party messages here
 
-        String messageText = e.getMessage().getUnformattedText();
+        String messageText = McIf.getUnformattedText(e.getMessage());
         String formatted = e.getMessage().getFormattedText();
         Matcher m = FRIENDS_LIST.matcher(formatted);
         if (m.find() && m.group(1).equals(Minecraft.getMinecraft().player.getName())) {

--- a/src/main/java/com/wynntils/modules/core/instances/GatheringBake.java
+++ b/src/main/java/com/wynntils/modules/core/instances/GatheringBake.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.core.instances;
 
+import com.wynntils.McIf;
 import com.wynntils.core.framework.enums.professions.GatheringMaterial;
 import com.wynntils.core.framework.enums.professions.ProfessionType;
 import net.minecraft.client.Minecraft;
@@ -17,7 +18,7 @@ public class GatheringBake {
     double xpAmount = 0;
     double xpPercentage = 0;
 
-    long created = Minecraft.getSystemTime();
+    long created = McIf.getSystemTime();
 
     public GatheringBake() { }
 
@@ -74,7 +75,7 @@ public class GatheringBake {
     }
 
     public boolean isInvalid() {
-        return Minecraft.getSystemTime() - created >= 600;
+        return McIf.getSystemTime() - created >= 600;
     }
 
 }

--- a/src/main/java/com/wynntils/modules/core/instances/MainMenuButtons.java
+++ b/src/main/java/com/wynntils/modules/core/instances/MainMenuButtons.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.core.instances;
 
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.framework.rendering.textures.Textures;
 import com.wynntils.core.utils.ServerUtils;
@@ -32,7 +33,7 @@ public class MainMenuButtons {
     private static final int WYNNCRAFT_BUTTON_ID = 3790627;
 
     private static WynncraftButton lastButton = null;
-    
+
     private static boolean alreadyLoaded = false;
 
     public static void addButtons(GuiMainMenu to, List<GuiButton> buttonList, boolean resize) {
@@ -50,7 +51,7 @@ public class MainMenuButtons {
 
             // little pling when finished loading
             if (!alreadyLoaded) {
-                Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.BLOCK_NOTE_PLING, 1f));
+                McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.BLOCK_NOTE_PLING, 1f));
                 alreadyLoaded = true;
             }
             return;
@@ -141,7 +142,7 @@ public class MainMenuButtons {
         }
 
         private static void doAction() {
-            clickedWynncraftButton(Minecraft.getMinecraft(), getWynncraftServerData(Minecraft.getMinecraft()), null);
+            clickedWynncraftButton(McIf.mc(), getWynncraftServerData(Minecraft.getMinecraft()), null);
         }
     }
 

--- a/src/main/java/com/wynntils/modules/core/instances/MainMenuButtons.java
+++ b/src/main/java/com/wynntils/modules/core/instances/MainMenuButtons.java
@@ -40,7 +40,7 @@ public class MainMenuButtons {
         if (!CoreDBConfig.INSTANCE.addMainMenuButton) return;
 
         if (lastButton == null || !resize) {
-            ServerData s = getWynncraftServerData(to.mc);
+            ServerData s = getWynncraftServerData();
             FMLClientHandler.instance().setupServerList();
 
             lastButton = new WynncraftButton(s, WYNNCRAFT_BUTTON_ID, to.width / 2 + 104, to.height / 4 + 48 + 24);
@@ -63,13 +63,13 @@ public class MainMenuButtons {
 
     public static void actionPerformed(GuiMainMenu on, GuiButton button, List<GuiButton> buttonList) {
         if (button.id == WYNNCRAFT_BUTTON_ID) {
-            clickedWynncraftButton(on.mc, ((WynncraftButton) button).serverIcon.getServer(), on);
+            clickedWynncraftButton(((WynncraftButton) button).serverIcon.getServer(), on);
         }
     }
 
-    private static void clickedWynncraftButton(Minecraft mc, ServerData server, GuiScreen backGui) {
+    private static void clickedWynncraftButton(ServerData server, GuiScreen backGui) {
         if (hasUpdate()) {
-            mc.displayGuiScreen(new UpdateAvailableScreen(server));
+            McIf.mc().displayGuiScreen(new UpdateAvailableScreen(server));
         } else {
             WebManager.skipJoinUpdate();
             ServerUtils.connect(backGui, server);
@@ -80,8 +80,8 @@ public class MainMenuButtons {
         return !Reference.developmentEnvironment && WebManager.getUpdate() != null && WebManager.getUpdate().hasUpdate();
     }
 
-    private static ServerData getWynncraftServerData(Minecraft mc) {
-        return ServerUtils.getWynncraftServerData(serverList = new ServerList(mc), true);
+    private static ServerData getWynncraftServerData() {
+        return ServerUtils.getWynncraftServerData(serverList = new ServerList(McIf.mc()), true);
     }
 
     private static class WynncraftButton extends GuiButton {
@@ -96,15 +96,15 @@ public class MainMenuButtons {
         }
 
         @Override
-        public void drawButton(Minecraft mc, int mouseX, int mouseY, float partialTicks) {
+        public void drawButton(Minecraft minecraft, int mouseX, int mouseY, float partialTicks) {
             if (!visible) return;
 
-            super.drawButton(mc, mouseX, mouseY, partialTicks);
+            super.drawButton(minecraft, mouseX, mouseY, partialTicks);
 
             ServerIcon.ping();
             ResourceLocation icon = serverIcon.getServerIcon();
             if (icon == null) icon = ServerIcon.UNKNOWN_SERVER;
-            mc.getTextureManager().bindTexture(icon);
+            minecraft.getTextureManager().bindTexture(icon);
 
             boolean hasUpdate = hasUpdate();
 
@@ -142,7 +142,7 @@ public class MainMenuButtons {
         }
 
         private static void doAction() {
-            clickedWynncraftButton(McIf.mc(), getWynncraftServerData(Minecraft.getMinecraft()), null);
+            clickedWynncraftButton(getWynncraftServerData(), null);
         }
     }
 

--- a/src/main/java/com/wynntils/modules/core/instances/OtherPlayerProfile.java
+++ b/src/main/java/com/wynntils/modules/core/instances/OtherPlayerProfile.java
@@ -109,7 +109,7 @@ public class OtherPlayerProfile {
 
         hasHat = e.isWearing(EnumPlayerModelParts.HAT);
 
-        if (e.isDead || e.getDistance(McIf.mc().player) >= 30) return false;
+        if (e.isDead || e.getDistance(McIf.player()) >= 30) return false;
         x = (int) e.posX;
         y = (int) e.posY;
         z = (int) e.posZ;

--- a/src/main/java/com/wynntils/modules/core/instances/OtherPlayerProfile.java
+++ b/src/main/java/com/wynntils/modules/core/instances/OtherPlayerProfile.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.core.instances;
 
+import com.wynntils.McIf;
 import com.wynntils.core.framework.instances.PlayerInfo;
 import com.wynntils.core.framework.instances.data.SocialData;
 import com.wynntils.modules.core.managers.GuildAndFriendManager;
@@ -78,7 +79,7 @@ public class OtherPlayerProfile {
     }
 
     public NetworkPlayerInfo getPlayerInfo() {
-        NetHandlerPlayClient conn = Minecraft.getMinecraft().getConnection();
+        NetHandlerPlayClient conn = McIf.mc().getConnection();
         return conn == null ? null : conn.getPlayerInfo(uuid);
     }
 
@@ -108,7 +109,7 @@ public class OtherPlayerProfile {
 
         hasHat = e.isWearing(EnumPlayerModelParts.HAT);
 
-        if (e.isDead || e.getDistance(Minecraft.getMinecraft().player) >= 30) return false;
+        if (e.isDead || e.getDistance(McIf.mc().player) >= 30) return false;
         x = (int) e.posX;
         y = (int) e.posY;
         z = (int) e.posZ;

--- a/src/main/java/com/wynntils/modules/core/instances/TotemTracker.java
+++ b/src/main/java/com/wynntils/modules/core/instances/TotemTracker.java
@@ -68,11 +68,11 @@ public class TotemTracker {
     }
 
     private Entity getBufferedEntity(int entityId) {
-        Entity entity = McIf.mc().world.getEntityByID(entityId);
+        Entity entity = McIf.world().getEntityByID(entityId);
         if (entity != null) return entity;
 
         if (entityId == bufferedId) {
-            return new EntityArmorStand(McIf.mc().world, bufferedX, bufferedY, bufferedZ);
+            return new EntityArmorStand(McIf.world(), bufferedX, bufferedY, bufferedZ);
         }
 
         return null;

--- a/src/main/java/com/wynntils/modules/core/instances/TotemTracker.java
+++ b/src/main/java/com/wynntils/modules/core/instances/TotemTracker.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.core.instances;
 
+import com.wynntils.McIf;
 import com.wynntils.ModCore;
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.PacketEvent;
@@ -138,9 +139,9 @@ public class TotemTracker {
             }
 
             // Is it created close to us? Then it's a potential new totem
-            if (isClose(e.getPacket().getX(), Minecraft.getMinecraft().player.posX) &&
-                    isClose(e.getPacket().getY(), Minecraft.getMinecraft().player.posY + 1.0) &&
-                    isClose(e.getPacket().getZ(), Minecraft.getMinecraft().player.posZ)) {
+            if (isClose(e.getPacket().getX(), McIf.mc().player.posX) &&
+                    isClose(e.getPacket().getY(), McIf.mc().player.posY + 1.0) &&
+                    isClose(e.getPacket().getZ(), McIf.mc().player.posZ)) {
                 potentialId = e.getPacket().getEntityID();
                 potentialX = e.getPacket().getX();
                 potentialY = e.getPacket().getY();
@@ -154,7 +155,7 @@ public class TotemTracker {
     public void onTotemSpellCast(SpellEvent.Cast e) {
         if (e.getSpell().equals("Totem") || e.getSpell().equals("Sky Emblem")) {
             totemCastTimestamp = System.currentTimeMillis();
-            heldWeaponSlot =  Minecraft.getMinecraft().player.inventory.currentItem;
+            heldWeaponSlot =  McIf.mc().player.inventory.currentItem;
             checkTotemSummoned();
         } else if (e.getSpell().equals("Uproot") || e.getSpell().equals("Gale Funnel")) {
             totemCastTimestamp = System.currentTimeMillis();

--- a/src/main/java/com/wynntils/modules/core/instances/TotemTracker.java
+++ b/src/main/java/com/wynntils/modules/core/instances/TotemTracker.java
@@ -5,7 +5,6 @@
 package com.wynntils.modules.core.instances;
 
 import com.wynntils.McIf;
-import com.wynntils.ModCore;
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.PacketEvent;
 import com.wynntils.core.events.custom.SpellEvent;
@@ -13,7 +12,6 @@ import com.wynntils.core.events.custom.WynnClassChangeEvent;
 import com.wynntils.core.framework.FrameworkManager;
 import com.wynntils.core.utils.Utils;
 import com.wynntils.core.utils.objects.Location;
-import net.minecraft.client.Minecraft;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.EntityArmorStand;
 import net.minecraft.network.play.client.CPacketHeldItemChange;
@@ -66,15 +64,15 @@ public class TotemTracker {
     }
 
     private void postEvent(Event event) {
-        ModCore.mc().addScheduledTask(() -> FrameworkManager.getEventBus().post(event));
+        McIf.mc().addScheduledTask(() -> FrameworkManager.getEventBus().post(event));
     }
 
     private Entity getBufferedEntity(int entityId) {
-        Entity entity = ModCore.mc().world.getEntityByID(entityId);
+        Entity entity = McIf.mc().world.getEntityByID(entityId);
         if (entity != null) return entity;
 
         if (entityId == bufferedId) {
-            return new EntityArmorStand(ModCore.mc().world, bufferedX, bufferedY, bufferedZ);
+            return new EntityArmorStand(McIf.mc().world, bufferedX, bufferedY, bufferedZ);
         }
 
         return null;

--- a/src/main/java/com/wynntils/modules/core/instances/TotemTracker.java
+++ b/src/main/java/com/wynntils/modules/core/instances/TotemTracker.java
@@ -137,9 +137,9 @@ public class TotemTracker {
             }
 
             // Is it created close to us? Then it's a potential new totem
-            if (isClose(e.getPacket().getX(), McIf.mc().player.posX) &&
-                    isClose(e.getPacket().getY(), McIf.mc().player.posY + 1.0) &&
-                    isClose(e.getPacket().getZ(), McIf.mc().player.posZ)) {
+            if (isClose(e.getPacket().getX(), McIf.player().posX) &&
+                    isClose(e.getPacket().getY(), McIf.player().posY + 1.0) &&
+                    isClose(e.getPacket().getZ(), McIf.player().posZ)) {
                 potentialId = e.getPacket().getEntityID();
                 potentialX = e.getPacket().getX();
                 potentialY = e.getPacket().getY();
@@ -153,7 +153,7 @@ public class TotemTracker {
     public void onTotemSpellCast(SpellEvent.Cast e) {
         if (e.getSpell().equals("Totem") || e.getSpell().equals("Sky Emblem")) {
             totemCastTimestamp = System.currentTimeMillis();
-            heldWeaponSlot =  McIf.mc().player.inventory.currentItem;
+            heldWeaponSlot =  McIf.player().inventory.currentItem;
             checkTotemSummoned();
         } else if (e.getSpell().equals("Uproot") || e.getSpell().equals("Gale Funnel")) {
             totemCastTimestamp = System.currentTimeMillis();

--- a/src/main/java/com/wynntils/modules/core/instances/inventory/FakeInventory.java
+++ b/src/main/java/com/wynntils/modules/core/instances/inventory/FakeInventory.java
@@ -60,7 +60,7 @@ public class FakeInventory {
     private boolean expectingResponse = false;
     private long limitTime = 10000;
 
-    private Minecraft mc = Minecraft.getMinecraft();
+    private Minecraft mc = McIf.mc();
 
     public FakeInventory(Pattern expectedWindowTitle, IInventoryOpenAction openAction) {
         this.expectedWindowTitle = expectedWindowTitle;

--- a/src/main/java/com/wynntils/modules/core/instances/inventory/FakeInventory.java
+++ b/src/main/java/com/wynntils/modules/core/instances/inventory/FakeInventory.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.core.instances.inventory;
 
+import com.wynntils.McIf;
 import com.wynntils.core.events.custom.PacketEvent;
 import com.wynntils.core.framework.FrameworkManager;
 import com.wynntils.core.utils.objects.Pair;
@@ -203,7 +204,7 @@ public class FakeInventory {
             return;
         }
 
-        if (!expectedWindowTitle.matcher(TextFormatting.getTextWithoutFormattingCodes(e.getPacket().getWindowTitle().getUnformattedText())).matches()) {
+        if (!expectedWindowTitle.matcher(TextFormatting.getTextWithoutFormattingCodes(McIf.getUnformattedText(e.getPacket().getWindowTitle()))).matches()) {
             close(InventoryResult.CLOSED_OVERLAP);
             return;
         }
@@ -213,7 +214,7 @@ public class FakeInventory {
         lastAction = Minecraft.getSystemTime();
 
         windowId = e.getPacket().getWindowId();
-        windowTitle = e.getPacket().getWindowTitle().getUnformattedText();
+        windowTitle = McIf.getUnformattedText(e.getPacket().getWindowTitle());
         inventory = NonNullList.create();
 
         e.setCanceled(true);

--- a/src/main/java/com/wynntils/modules/core/instances/inventory/FakeInventory.java
+++ b/src/main/java/com/wynntils/modules/core/instances/inventory/FakeInventory.java
@@ -60,8 +60,6 @@ public class FakeInventory {
     private boolean expectingResponse = false;
     private long limitTime = 10000;
 
-    private Minecraft mc = McIf.mc();
-
     public FakeInventory(Pattern expectedWindowTitle, IInventoryOpenAction openAction) {
         this.expectedWindowTitle = expectedWindowTitle;
         this.openAction = openAction;
@@ -110,10 +108,10 @@ public class FakeInventory {
         FrameworkManager.getEventBus().unregister(this);
         isOpen = false;
 
-        if (windowId != -1) mc.getConnection().sendPacket(new CPacketCloseWindow(windowId));
+        if (windowId != -1) McIf.mc().getConnection().sendPacket(new CPacketCloseWindow(windowId));
         windowId = -1;
 
-        if(onClose != null) mc.addScheduledTask(() -> onClose.accept(this, result));
+        if(onClose != null) McIf.mc().addScheduledTask(() -> onClose.accept(this, result));
     }
 
     public void clickItem(int slot, int mouseButton, ClickType type) {
@@ -123,7 +121,7 @@ public class FakeInventory {
         expectingResponse = true;
 
         transaction++;
-        mc.getConnection().sendPacket(new CPacketClickWindow(windowId, slot, mouseButton, type, inventory.get(slot), transaction));
+        McIf.mc().getConnection().sendPacket(new CPacketClickWindow(windowId, slot, mouseButton, type, inventory.get(slot), transaction));
     }
 
     public Pair<Integer, ItemStack> findItem(String name, BiPredicate<String, String> filterType) {
@@ -234,7 +232,7 @@ public class FakeInventory {
         expectingResponse = false;
         lastAction = Minecraft.getSystemTime();
 
-        if (onReceiveItems != null) mc.addScheduledTask(() -> onReceiveItems.accept(this));
+        if (onReceiveItems != null) McIf.mc().addScheduledTask(() -> onReceiveItems.accept(this));
 
         e.setCanceled(true);
     }
@@ -247,7 +245,7 @@ public class FakeInventory {
             return;
         }
 
-        mc.getConnection().sendPacket(new CPacketConfirmTransaction(windowId, e.getPacket().getActionNumber(), true));
+        McIf.mc().getConnection().sendPacket(new CPacketConfirmTransaction(windowId, e.getPacket().getActionNumber(), true));
         e.setCanceled(true);
     }
 

--- a/src/main/java/com/wynntils/modules/core/instances/inventory/FakeInventory.java
+++ b/src/main/java/com/wynntils/modules/core/instances/inventory/FakeInventory.java
@@ -86,7 +86,7 @@ public class FakeInventory {
     public void open() {
         if (isOpen) return;
 
-        lastAction = Minecraft.getSystemTime();
+        lastAction = McIf.getSystemTime();
         expectingResponse = true;
 
         FrameworkManager.getEventBus().register(this);
@@ -117,7 +117,7 @@ public class FakeInventory {
     public void clickItem(int slot, int mouseButton, ClickType type) {
         if (!isOpen) return;
 
-        lastAction = Minecraft.getSystemTime();
+        lastAction = McIf.getSystemTime();
         expectingResponse = true;
 
         transaction++;
@@ -189,7 +189,7 @@ public class FakeInventory {
     public void onTick(TickEvent.ClientTickEvent e) {
         if (!isOpen || e.phase != TickEvent.Phase.END) return;
         if (!expectingResponse) return;
-        if (Minecraft.getSystemTime() - lastAction < limitTime) return;
+        if (McIf.getSystemTime() - lastAction < limitTime) return;
 
         close(InventoryResult.CLOSED_PREMATURELY);
     }
@@ -209,7 +209,7 @@ public class FakeInventory {
 
         isOpen = true;
         expectingResponse = false;
-        lastAction = Minecraft.getSystemTime();
+        lastAction = McIf.getSystemTime();
 
         windowId = e.getPacket().getWindowId();
         windowTitle = McIf.getUnformattedText(e.getPacket().getWindowTitle());
@@ -230,7 +230,7 @@ public class FakeInventory {
         inventory.addAll(e.getPacket().getItemStacks());
 
         expectingResponse = false;
-        lastAction = Minecraft.getSystemTime();
+        lastAction = McIf.getSystemTime();
 
         if (onReceiveItems != null) McIf.mc().addScheduledTask(() -> onReceiveItems.accept(this));
 

--- a/src/main/java/com/wynntils/modules/core/instances/inventory/InventoryOpenByItem.java
+++ b/src/main/java/com/wynntils/modules/core/instances/inventory/InventoryOpenByItem.java
@@ -28,13 +28,13 @@ public class InventoryOpenByItem implements IInventoryOpenAction {
     @Override
     public void onOpen(FakeInventory inv, Runnable onDrop) {
         PacketQueue.queueComplexPacket(rightClick, SPacketOpenWindow.class).setSender((conn, pack) -> {
-            if (McIf.mc().player.inventory.currentItem != inputSlot) {
+            if (McIf.player().inventory.currentItem != inputSlot) {
                 conn.sendPacket(new CPacketHeldItemChange(inputSlot));
             }
 
             conn.sendPacket(pack);
-            if (McIf.mc().player.inventory.currentItem != inputSlot) {
-                conn.sendPacket(new CPacketHeldItemChange(McIf.mc().player.inventory.currentItem));
+            if (McIf.player().inventory.currentItem != inputSlot) {
+                conn.sendPacket(new CPacketHeldItemChange(McIf.player().inventory.currentItem));
             }
         }).onDrop(onDrop);
     }

--- a/src/main/java/com/wynntils/modules/core/instances/inventory/InventoryOpenByItem.java
+++ b/src/main/java/com/wynntils/modules/core/instances/inventory/InventoryOpenByItem.java
@@ -4,7 +4,7 @@
 
 package com.wynntils.modules.core.instances.inventory;
 
-import com.wynntils.ModCore;
+import com.wynntils.McIf;
 import com.wynntils.modules.core.interfaces.IInventoryOpenAction;
 import com.wynntils.modules.core.managers.PacketQueue;
 import net.minecraft.client.Minecraft;
@@ -27,16 +27,14 @@ public class InventoryOpenByItem implements IInventoryOpenAction {
 
     @Override
     public void onOpen(FakeInventory inv, Runnable onDrop) {
-        Minecraft mc = ModCore.mc();
-
         PacketQueue.queueComplexPacket(rightClick, SPacketOpenWindow.class).setSender((conn, pack) -> {
-            if (mc.player.inventory.currentItem != inputSlot) {
+            if (McIf.mc().player.inventory.currentItem != inputSlot) {
                 conn.sendPacket(new CPacketHeldItemChange(inputSlot));
             }
 
             conn.sendPacket(pack);
-            if (mc.player.inventory.currentItem != inputSlot) {
-                conn.sendPacket(new CPacketHeldItemChange(mc.player.inventory.currentItem));
+            if (McIf.mc().player.inventory.currentItem != inputSlot) {
+                conn.sendPacket(new CPacketHeldItemChange(McIf.mc().player.inventory.currentItem));
             }
         }).onDrop(onDrop);
     }

--- a/src/main/java/com/wynntils/modules/core/instances/packet/PacketIncomingFilter.java
+++ b/src/main/java/com/wynntils/modules/core/instances/packet/PacketIncomingFilter.java
@@ -4,7 +4,7 @@
 
 package com.wynntils.modules.core.instances.packet;
 
-import com.wynntils.ModCore;
+import com.wynntils.McIf;
 import com.wynntils.core.events.custom.PacketEvent;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
@@ -28,7 +28,7 @@ public class PacketIncomingFilter extends ChannelInboundHandlerAdapter {
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
         if (msg == null) return;
 
-        PacketEvent.Incoming<? extends Packet<?>> event = new PacketEvent.Incoming<>((Packet<?>) msg, ModCore.mc().getConnection(), this, ctx);
+        PacketEvent.Incoming<? extends Packet<?>> event = new PacketEvent.Incoming<>((Packet<?>) msg, McIf.mc().getConnection(), this, ctx);
         boolean cancel = MinecraftForge.EVENT_BUS.post(event);
         if (cancel) return;
 

--- a/src/main/java/com/wynntils/modules/core/instances/packet/PacketOutgoingFilter.java
+++ b/src/main/java/com/wynntils/modules/core/instances/packet/PacketOutgoingFilter.java
@@ -4,7 +4,7 @@
 
 package com.wynntils.modules.core.instances.packet;
 
-import com.wynntils.ModCore;
+import com.wynntils.McIf;
 import com.wynntils.core.events.custom.PacketEvent;
 import com.wynntils.core.framework.FrameworkManager;
 import com.wynntils.modules.core.instances.inventory.InventoryOpenByItem;
@@ -36,7 +36,7 @@ public class PacketOutgoingFilter extends ChannelOutboundHandlerAdapter {
         }
 
         PacketEvent.Outgoing<? extends Packet<?>> event = noEvent ? null :
-            new PacketEvent.Outgoing<>(packet, ModCore.mc().getConnection(), this, ctx);
+            new PacketEvent.Outgoing<>(packet, McIf.mc().getConnection(), this, ctx);
         if (!noEvent && FrameworkManager.getEventBus().post(event)) return;
 
         super.write(ctx, msg, promise);

--- a/src/main/java/com/wynntils/modules/core/instances/packet/PacketResponse.java
+++ b/src/main/java/com/wynntils/modules/core/instances/packet/PacketResponse.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.core.instances.packet;
 
+import com.wynntils.McIf;
 import com.wynntils.core.utils.Utils;
 import com.wynntils.modules.core.managers.PingManager;
 import net.minecraft.client.Minecraft;
@@ -73,7 +74,7 @@ public class PacketResponse {
         if (skipping || !shouldSend()) return;
 
         Utils.runAsync(() -> {
-            NetHandlerPlayClient conn = Minecraft.getMinecraft().getConnection();
+            NetHandlerPlayClient conn = McIf.mc().getConnection();
             if (this.sender != null) {
                 this.sender.accept(conn, input);
             } else {

--- a/src/main/java/com/wynntils/modules/core/managers/CompassManager.java
+++ b/src/main/java/com/wynntils/modules/core/managers/CompassManager.java
@@ -15,7 +15,7 @@ public class CompassManager {
     private static Location compassLocation = null;
 
     public static Location getCompassLocation() {
-        if (compassLocation != null) compassLocation.setY(McIf.mc().player.posY);
+        if (compassLocation != null) compassLocation.setY(McIf.player().posY);
         return compassLocation;
     }
 

--- a/src/main/java/com/wynntils/modules/core/managers/CompassManager.java
+++ b/src/main/java/com/wynntils/modules/core/managers/CompassManager.java
@@ -5,6 +5,7 @@
 package com.wynntils.modules.core.managers;
 
 
+import com.wynntils.McIf;
 import com.wynntils.core.utils.objects.Location;
 import com.wynntils.modules.core.events.ServerEvents;
 import net.minecraft.client.Minecraft;
@@ -14,21 +15,21 @@ public class CompassManager {
     private static Location compassLocation = null;
 
     public static Location getCompassLocation() {
-        if (compassLocation != null) compassLocation.setY(Minecraft.getMinecraft().player.posY);
+        if (compassLocation != null) compassLocation.setY(McIf.mc().player.posY);
         return compassLocation;
     }
 
     public static void setCompassLocation(Location compassLocation) {
         CompassManager.compassLocation = compassLocation;
 
-        Minecraft.getMinecraft().world.setSpawnPoint(compassLocation.toBlockPos());
+        McIf.mc().world.setSpawnPoint(compassLocation.toBlockPos());
     }
 
     public static void reset() {
         compassLocation = null;
 
-        if (Minecraft.getMinecraft().world != null) {
-            Minecraft.getMinecraft().world.setSpawnPoint(ServerEvents.getCurrentSpawnPosition());
+        if (McIf.mc().world != null) {
+            McIf.mc().world.setSpawnPoint(ServerEvents.getCurrentSpawnPosition());
         }
     }
 

--- a/src/main/java/com/wynntils/modules/core/managers/CompassManager.java
+++ b/src/main/java/com/wynntils/modules/core/managers/CompassManager.java
@@ -22,14 +22,14 @@ public class CompassManager {
     public static void setCompassLocation(Location compassLocation) {
         CompassManager.compassLocation = compassLocation;
 
-        McIf.mc().world.setSpawnPoint(compassLocation.toBlockPos());
+        McIf.world().setSpawnPoint(compassLocation.toBlockPos());
     }
 
     public static void reset() {
         compassLocation = null;
 
-        if (McIf.mc().world != null) {
-            McIf.mc().world.setSpawnPoint(ServerEvents.getCurrentSpawnPosition());
+        if (McIf.world() != null) {
+            McIf.world().setSpawnPoint(ServerEvents.getCurrentSpawnPosition());
         }
     }
 

--- a/src/main/java/com/wynntils/modules/core/managers/GuildAndFriendManager.java
+++ b/src/main/java/com/wynntils/modules/core/managers/GuildAndFriendManager.java
@@ -26,7 +26,7 @@ public class GuildAndFriendManager {
 
     public static void tryResolveNames() {
         // Try to resolve names from the connection map
-        EntityPlayerSP player = McIf.mc().player;
+        EntityPlayerSP player = McIf.player();
         if (player == null) return;
         NetHandlerPlayClient conn = player.connection;
         if (conn == null) return;

--- a/src/main/java/com/wynntils/modules/core/managers/GuildAndFriendManager.java
+++ b/src/main/java/com/wynntils/modules/core/managers/GuildAndFriendManager.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.core.managers;
 
+import com.wynntils.McIf;
 import com.wynntils.modules.core.instances.OtherPlayerProfile;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
@@ -25,7 +26,7 @@ public class GuildAndFriendManager {
 
     public static void tryResolveNames() {
         // Try to resolve names from the connection map
-        EntityPlayerSP player = Minecraft.getMinecraft().player;
+        EntityPlayerSP player = McIf.mc().player;
         if (player == null) return;
         NetHandlerPlayClient conn = player.connection;
         if (conn == null) return;

--- a/src/main/java/com/wynntils/modules/core/managers/PartyManager.java
+++ b/src/main/java/com/wynntils/modules/core/managers/PartyManager.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.core.managers;
 
+import com.wynntils.McIf;
 import com.wynntils.core.framework.instances.PlayerInfo;
 import com.wynntils.core.framework.instances.containers.PartyContainer;
 import com.wynntils.core.framework.instances.data.SocialData;
@@ -28,7 +29,7 @@ public class PartyManager {
             if (components.getFormattedText().startsWith("§e")) continue;
 
             boolean owner = components.getFormattedText().startsWith("§b");
-            String member = components.getUnformattedText().contains(",") ? components.getUnformattedText().split(",")[0] : components.getUnformattedText();
+            String member = McIf.getUnformattedText(components).contains(",") ? McIf.getUnformattedText(components).split(",")[0] : McIf.getUnformattedText(components);
 
             if (owner) partyContainer.setOwner(member);
             partyContainer.addMember(member);
@@ -41,35 +42,35 @@ public class PartyManager {
     }
 
     public static void handleMessages(ITextComponent component) {
-        if (component.getUnformattedText().startsWith("You have successfully joined the party.")) {
+        if (McIf.getUnformattedText(component).startsWith("You have successfully joined the party.")) {
             handlePartyList();
             return;
         }
-        if (component.getUnformattedText().startsWith("You have been removed from the party.")
-                || component.getUnformattedText().startsWith("Your party has been disbanded since you were the only member remaining.")
-                || component.getUnformattedText().startsWith("Your party has been disbanded.")) {
+        if (McIf.getUnformattedText(component).startsWith("You have been removed from the party.")
+                || McIf.getUnformattedText(component).startsWith("Your party has been disbanded since you were the only member remaining.")
+                || McIf.getUnformattedText(component).startsWith("Your party has been disbanded.")) {
             PartyContainer partyContainer = PlayerInfo.get(SocialData.class).getPlayerParty();
             partyContainer.removeMember(Minecraft.getMinecraft().player.getName());
             return;
         }
-        if (component.getUnformattedText().startsWith("You have successfully created a party.")) {
+        if (McIf.getUnformattedText(component).startsWith("You have successfully created a party.")) {
             PartyContainer partyContainer = PlayerInfo.get(SocialData.class).getPlayerParty();
             partyContainer.setOwner(Minecraft.getMinecraft().player.getName());
             partyContainer.addMember(Minecraft.getMinecraft().player.getName());
             return;
         }
-        if (component.getFormattedText().startsWith("§e") && component.getUnformattedText().contains("has joined the party.")) {
+        if (component.getFormattedText().startsWith("§e") && McIf.getUnformattedText(component).contains("has joined the party.")) {
             PartyContainer partyContainer = PlayerInfo.get(SocialData.class).getPlayerParty();
 
-            String member = component.getUnformattedText().split(" has joined the party.")[0];
+            String member = McIf.getUnformattedText(component).split(" has joined the party.")[0];
             partyContainer.addMember(member);
             return;
         }
-        if (component.getFormattedText().startsWith("§e") && component.getUnformattedText().contains("has left the party.")) {
+        if (component.getFormattedText().startsWith("§e") && McIf.getUnformattedText(component).contains("has left the party.")) {
             handlePartyList();
             PartyContainer partyContainer = PlayerInfo.get(SocialData.class).getPlayerParty();
 
-            String member = component.getUnformattedText().split(" has left the party.")[0];
+            String member = McIf.getUnformattedText(component).split(" has left the party.")[0];
             partyContainer.removeMember(member);
         }
     }

--- a/src/main/java/com/wynntils/modules/core/managers/PartyManager.java
+++ b/src/main/java/com/wynntils/modules/core/managers/PartyManager.java
@@ -20,7 +20,7 @@ public class PartyManager {
     private static final CommandResponse listExecutor = new CommandResponse("/party list", (matcher, text) -> {
         String entire = matcher.group(0);
         if (entire.contains("You must be in")) {  // clears the party
-            PlayerInfo.get(SocialData.class).getPlayerParty().removeMember(McIf.mc().player.getName());
+            PlayerInfo.get(SocialData.class).getPlayerParty().removeMember(McIf.player().getName());
             return;
         }
 
@@ -50,13 +50,13 @@ public class PartyManager {
                 || McIf.getUnformattedText(component).startsWith("Your party has been disbanded since you were the only member remaining.")
                 || McIf.getUnformattedText(component).startsWith("Your party has been disbanded.")) {
             PartyContainer partyContainer = PlayerInfo.get(SocialData.class).getPlayerParty();
-            partyContainer.removeMember(McIf.mc().player.getName());
+            partyContainer.removeMember(McIf.player().getName());
             return;
         }
         if (McIf.getUnformattedText(component).startsWith("You have successfully created a party.")) {
             PartyContainer partyContainer = PlayerInfo.get(SocialData.class).getPlayerParty();
-            partyContainer.setOwner(McIf.mc().player.getName());
-            partyContainer.addMember(McIf.mc().player.getName());
+            partyContainer.setOwner(McIf.player().getName());
+            partyContainer.addMember(McIf.player().getName());
             return;
         }
         if (McIf.getFormattedText(component).startsWith("§e") && McIf.getUnformattedText(component).contains("has joined the party.")) {

--- a/src/main/java/com/wynntils/modules/core/managers/PartyManager.java
+++ b/src/main/java/com/wynntils/modules/core/managers/PartyManager.java
@@ -20,7 +20,7 @@ public class PartyManager {
     private static final CommandResponse listExecutor = new CommandResponse("/party list", (matcher, text) -> {
         String entire = matcher.group(0);
         if (entire.contains("You must be in")) {  // clears the party
-            PlayerInfo.get(SocialData.class).getPlayerParty().removeMember(Minecraft.getMinecraft().player.getName());
+            PlayerInfo.get(SocialData.class).getPlayerParty().removeMember(McIf.mc().player.getName());
             return;
         }
 
@@ -50,13 +50,13 @@ public class PartyManager {
                 || McIf.getUnformattedText(component).startsWith("Your party has been disbanded since you were the only member remaining.")
                 || McIf.getUnformattedText(component).startsWith("Your party has been disbanded.")) {
             PartyContainer partyContainer = PlayerInfo.get(SocialData.class).getPlayerParty();
-            partyContainer.removeMember(Minecraft.getMinecraft().player.getName());
+            partyContainer.removeMember(McIf.mc().player.getName());
             return;
         }
         if (McIf.getUnformattedText(component).startsWith("You have successfully created a party.")) {
             PartyContainer partyContainer = PlayerInfo.get(SocialData.class).getPlayerParty();
-            partyContainer.setOwner(Minecraft.getMinecraft().player.getName());
-            partyContainer.addMember(Minecraft.getMinecraft().player.getName());
+            partyContainer.setOwner(McIf.mc().player.getName());
+            partyContainer.addMember(McIf.mc().player.getName());
             return;
         }
         if (McIf.getFormattedText(component).startsWith("§e") && McIf.getUnformattedText(component).contains("has joined the party.")) {

--- a/src/main/java/com/wynntils/modules/core/managers/PartyManager.java
+++ b/src/main/java/com/wynntils/modules/core/managers/PartyManager.java
@@ -26,9 +26,9 @@ public class PartyManager {
 
         PartyContainer partyContainer = PlayerInfo.get(SocialData.class).getPlayerParty();
         for (ITextComponent components : text.getSiblings()) {
-            if (components.getFormattedText().startsWith("§e")) continue;
+            if (McIf.getFormattedText(components).startsWith("§e")) continue;
 
-            boolean owner = components.getFormattedText().startsWith("§b");
+            boolean owner = McIf.getFormattedText(components).startsWith("§b");
             String member = McIf.getUnformattedText(components).contains(",") ? McIf.getUnformattedText(components).split(",")[0] : McIf.getUnformattedText(components);
 
             if (owner) partyContainer.setOwner(member);
@@ -59,14 +59,14 @@ public class PartyManager {
             partyContainer.addMember(Minecraft.getMinecraft().player.getName());
             return;
         }
-        if (component.getFormattedText().startsWith("§e") && McIf.getUnformattedText(component).contains("has joined the party.")) {
+        if (McIf.getFormattedText(component).startsWith("§e") && McIf.getUnformattedText(component).contains("has joined the party.")) {
             PartyContainer partyContainer = PlayerInfo.get(SocialData.class).getPlayerParty();
 
             String member = McIf.getUnformattedText(component).split(" has joined the party.")[0];
             partyContainer.addMember(member);
             return;
         }
-        if (component.getFormattedText().startsWith("§e") && McIf.getUnformattedText(component).contains("has left the party.")) {
+        if (McIf.getFormattedText(component).startsWith("§e") && McIf.getUnformattedText(component).contains("has left the party.")) {
             handlePartyList();
             PartyContainer partyContainer = PlayerInfo.get(SocialData.class).getPlayerParty();
 

--- a/src/main/java/com/wynntils/modules/core/managers/PingManager.java
+++ b/src/main/java/com/wynntils/modules/core/managers/PingManager.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.core.managers;
 
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.framework.instances.PlayerInfo;
 import com.wynntils.core.framework.instances.data.CharacterData;
@@ -23,7 +24,7 @@ public class PingManager {
     public static void calculatePing() {
         if (!Reference.onWorld
             || !PlayerInfo.get(CharacterData.class).isLoaded()
-            || Minecraft.getMinecraft().currentScreen instanceof GuiChat
+            || McIf.mc().currentScreen instanceof GuiChat
             || System.currentTimeMillis() - lastCall < 15000) return;
 
         CommandResponse response = new CommandResponse("/toggle", (m, t) -> {

--- a/src/main/java/com/wynntils/modules/core/managers/UserManager.java
+++ b/src/main/java/com/wynntils/modules/core/managers/UserManager.java
@@ -74,11 +74,9 @@ public class UserManager {
     }
 
     public static void clearRegistry() {
-        Minecraft mc = McIf.mc();
-
         // needs to be run inside the client thread
         // otherwise some weird corrupting issues WILL happen
-        mc.addScheduledTask(() -> {
+        McIf.mc().addScheduledTask(() -> {
             Iterator<Map.Entry<UUID, WynntilsUser>> it = users.entrySet().iterator();
             while (it.hasNext()) {
                 Map.Entry<UUID, WynntilsUser> next = it.next();
@@ -87,7 +85,7 @@ public class UserManager {
                 }
 
                 // removes the texture from the texture registry as well
-                mc.getTextureManager().deleteTexture(next.getValue().getCosmetics().getLocation());
+                McIf.mc().getTextureManager().deleteTexture(next.getValue().getCosmetics().getLocation());
 
                 it.remove();
             }

--- a/src/main/java/com/wynntils/modules/core/managers/UserManager.java
+++ b/src/main/java/com/wynntils/modules/core/managers/UserManager.java
@@ -5,6 +5,7 @@
 package com.wynntils.modules.core.managers;
 
 import com.google.gson.JsonObject;
+import com.wynntils.McIf;
 import com.wynntils.modules.core.enums.AccountType;
 import com.wynntils.modules.core.instances.account.CosmeticInfo;
 import com.wynntils.modules.core.instances.account.WynntilsUser;
@@ -51,8 +52,8 @@ public class UserManager {
 
                     // loading needs to occur inside the client thread
                     // otherwise some weird texture corruption WILL happen
-                    Minecraft.getMinecraft().addScheduledTask(() -> {
-                        TextureManager textureManager = Minecraft.getMinecraft().getTextureManager();
+                    McIf.mc().addScheduledTask(() -> {
+                        TextureManager textureManager = McIf.mc().getTextureManager();
                         textureManager.loadTexture(rl, info);
 
                         users.put(uuid, new WynntilsUser(AccountType.valueOf(user.get("accountType").getAsString()), info));
@@ -73,7 +74,7 @@ public class UserManager {
     }
 
     public static void clearRegistry() {
-        Minecraft mc = Minecraft.getMinecraft();
+        Minecraft mc = McIf.mc();
 
         // needs to be run inside the client thread
         // otherwise some weird corrupting issues WILL happen

--- a/src/main/java/com/wynntils/modules/core/overlays/DownloadOverlay.java
+++ b/src/main/java/com/wynntils/modules/core/overlays/DownloadOverlay.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.core.overlays;
 
+import com.wynntils.McIf;
 import com.wynntils.core.framework.overlays.Overlay;
 import com.wynntils.core.framework.rendering.SmartFontRenderer;
 import com.wynntils.core.framework.rendering.colors.CommonColors;
@@ -47,7 +48,7 @@ public class DownloadOverlay extends Overlay {
                     timeToRestart = System.currentTimeMillis() + 10000;
                 }
                 if (timeToRestart - System.currentTimeMillis() <= 0) {
-                    mc.shutdown();
+                    McIf.mc().shutdown();
                     return;
                 }
 

--- a/src/main/java/com/wynntils/modules/core/overlays/UpdateOverlay.java
+++ b/src/main/java/com/wynntils/modules/core/overlays/UpdateOverlay.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.core.overlays;
 
+import com.wynntils.McIf;
 import com.wynntils.ModCore;
 import com.wynntils.Reference;
 import com.wynntils.core.framework.overlays.Overlay;
@@ -132,7 +133,7 @@ public class UpdateOverlay extends Overlay {
                             String message = TextFormatting.DARK_AQUA + "An update to Wynntils (";
                             message += CoreDBConfig.INSTANCE.updateStream == UpdateStream.STABLE ? "Version " + jarName.split("_")[0].split("-")[1] : "Build " + jarName.split("_")[1].replace(".jar", "");
                             message += ") has been downloaded, and will be applied when the game is restarted.";
-                            ModCore.mc().player.sendMessage(new TextComponentString(message));
+                            McIf.mc().player.sendMessage(new TextComponentString(message));
                             scheduleCopyUpdateAtShutdown(jarName);
                         } catch (Exception ex) {
                             ex.printStackTrace();

--- a/src/main/java/com/wynntils/modules/core/overlays/UpdateOverlay.java
+++ b/src/main/java/com/wynntils/modules/core/overlays/UpdateOverlay.java
@@ -133,7 +133,7 @@ public class UpdateOverlay extends Overlay {
                             String message = TextFormatting.DARK_AQUA + "An update to Wynntils (";
                             message += CoreDBConfig.INSTANCE.updateStream == UpdateStream.STABLE ? "Version " + jarName.split("_")[0].split("-")[1] : "Build " + jarName.split("_")[1].replace(".jar", "");
                             message += ") has been downloaded, and will be applied when the game is restarted.";
-                            McIf.mc().player.sendMessage(new TextComponentString(message));
+                            McIf.player().sendMessage(new TextComponentString(message));
                             scheduleCopyUpdateAtShutdown(jarName);
                         } catch (Exception ex) {
                             ex.printStackTrace();

--- a/src/main/java/com/wynntils/modules/core/overlays/ui/ChangelogUI.java
+++ b/src/main/java/com/wynntils/modules/core/overlays/ui/ChangelogUI.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.core.overlays.ui;
 
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.framework.rendering.ScreenRenderer;
 import com.wynntils.core.framework.rendering.SmartFontRenderer;
@@ -75,7 +76,7 @@ public class ChangelogUI extends GuiScreen {
      * @param forceLatest {@link WebManager#getChangelog(boolean, boolean)}'s second argument (Latest or current changelog?)
      */
     public static void loadChangelogAndShow(GuiScreen previousGui, boolean major, boolean forceLatest) {
-        Minecraft mc = Minecraft.getMinecraft();
+        Minecraft mc = McIf.mc();
 
         GuiScreen loadingScreen = new ChangelogUI(previousGui, Collections.singletonList("Loading..."), major);
         mc.displayGuiScreen(loadingScreen);
@@ -129,7 +130,7 @@ public class ChangelogUI extends GuiScreen {
 
         float scrollPositionOffset = scrollbarSize == 118 ? 0 : (((changelogContent.size() / 15.0f) * 159) * scrollPercent);
         for (String changelogLine : changelogContent) {
-            renderer.drawString(changelogLine.replace("%user%", Minecraft.getMinecraft().getSession().getUsername()), textX, baseY - scrollPositionOffset, CommonColors.BROWN, SmartFontRenderer.TextAlignment.LEFT_RIGHT, SmartFontRenderer.TextShadow.NONE);
+            renderer.drawString(changelogLine.replace("%user%", McIf.mc().getSession().getUsername()), textX, baseY - scrollPositionOffset, CommonColors.BROWN, SmartFontRenderer.TextAlignment.LEFT_RIGHT, SmartFontRenderer.TextShadow.NONE);
 
             baseY += 10;
         }
@@ -166,8 +167,8 @@ public class ChangelogUI extends GuiScreen {
     @Override
     protected void keyTyped(char charType, int keyCode) throws IOException {
         if (keyCode == 1) {  // ESC
-            Minecraft.getMinecraft().displayGuiScreen(previousGui);
-            if (Minecraft.getMinecraft().currentScreen == null) mc.setIngameFocus();
+            McIf.mc().displayGuiScreen(previousGui);
+            if (McIf.mc().currentScreen == null) mc.setIngameFocus();
         }
     }
 

--- a/src/main/java/com/wynntils/modules/core/overlays/ui/ChangelogUI.java
+++ b/src/main/java/com/wynntils/modules/core/overlays/ui/ChangelogUI.java
@@ -76,31 +76,30 @@ public class ChangelogUI extends GuiScreen {
      * @param forceLatest {@link WebManager#getChangelog(boolean, boolean)}'s second argument (Latest or current changelog?)
      */
     public static void loadChangelogAndShow(GuiScreen previousGui, boolean major, boolean forceLatest) {
-        Minecraft mc = McIf.mc();
 
         GuiScreen loadingScreen = new ChangelogUI(previousGui, Collections.singletonList("Loading..."), major);
-        mc.displayGuiScreen(loadingScreen);
-        if (mc.currentScreen != loadingScreen) {
+        McIf.mc().displayGuiScreen(loadingScreen);
+        if (McIf.mc().currentScreen != loadingScreen) {
             // Changed by an event handler
             return;
         }
 
         new Thread(() -> {
-            if (mc.currentScreen != loadingScreen) {
+            if (McIf.mc().currentScreen != loadingScreen) {
                 return;
             }
             List<String> changelog = WebManager.getChangelog(major, forceLatest);
-            if (mc.currentScreen != loadingScreen) {
+            if (McIf.mc().currentScreen != loadingScreen) {
                 return;
             }
 
-            mc.addScheduledTask(() -> {
-                if (mc.currentScreen != loadingScreen) {
+            McIf.mc().addScheduledTask(() -> {
+                if (McIf.mc().currentScreen != loadingScreen) {
                     return;
                 }
 
                 ChangelogUI gui = new ChangelogUI(previousGui, changelog, major);
-                mc.displayGuiScreen(gui);
+                McIf.mc().displayGuiScreen(gui);
             });
 
         }, "wynntils-changelog").start();
@@ -168,7 +167,7 @@ public class ChangelogUI extends GuiScreen {
     protected void keyTyped(char charType, int keyCode) throws IOException {
         if (keyCode == 1) {  // ESC
             McIf.mc().displayGuiScreen(previousGui);
-            if (McIf.mc().currentScreen == null) mc.setIngameFocus();
+            if (McIf.mc().currentScreen == null) McIf.mc().setIngameFocus();
         }
     }
 

--- a/src/main/java/com/wynntils/modules/core/overlays/ui/UpdateAvailableScreen.java
+++ b/src/main/java/com/wynntils/modules/core/overlays/ui/UpdateAvailableScreen.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.core.overlays.ui;
 
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.utils.ServerUtils;
 import com.wynntils.modules.core.CoreModule;
@@ -42,10 +43,10 @@ public class UpdateAvailableScreen extends GuiScreen {
     public void drawScreen(int mouseX, int mouseY, float partialTicks) {
         drawDefaultBackground();
 
-        int yOffset = Math.min(this.height / 2, this.height / 4 + 80 - mc.fontRenderer.FONT_HEIGHT * 2);
-        drawCenteredString(mc.fontRenderer, text, this.width/2, yOffset - mc.fontRenderer.FONT_HEIGHT - 2, 0xFFFFFFFF);
-        drawCenteredString(mc.fontRenderer, "Update now or when leaving Minecraft?", this.width/2, yOffset, 0xFFFFFFFF);
-        drawCenteredString(mc.fontRenderer, "(Updating now will exit Minecraft after downloading update)", this.width/2, yOffset + mc.fontRenderer.FONT_HEIGHT + 2, 0xFFFFFFFF);
+        int yOffset = Math.min(this.height / 2, this.height / 4 + 80 - McIf.mc().fontRenderer.FONT_HEIGHT * 2);
+        drawCenteredString(McIf.mc().fontRenderer, text, this.width/2, yOffset - McIf.mc().fontRenderer.FONT_HEIGHT - 2, 0xFFFFFFFF);
+        drawCenteredString(McIf.mc().fontRenderer, "Update now or when leaving Minecraft?", this.width/2, yOffset, 0xFFFFFFFF);
+        drawCenteredString(McIf.mc().fontRenderer, "(Updating now will exit Minecraft after downloading update)", this.width/2, yOffset + McIf.mc().fontRenderer.FONT_HEIGHT + 2, 0xFFFFFFFF);
 
         super.drawScreen(mouseX, mouseY, partialTicks);
     }
@@ -57,14 +58,14 @@ public class UpdateAvailableScreen extends GuiScreen {
             CoreDBConfig.INSTANCE.showChangelogs = true;
             CoreDBConfig.INSTANCE.lastVersion = Reference.VERSION;
             CoreDBConfig.INSTANCE.saveSettings(CoreModule.getModule());
-            mc.displayGuiScreen(new UpdatingScreen(button.id == 1));
+            McIf.mc().displayGuiScreen(new UpdatingScreen(button.id == 1));
         } else if (button.id == 3) {
             // Ignore
             WebManager.skipJoinUpdate();
             ServerUtils.connect(null, server);
         } else if (button.id == 4) {
             // Cancel
-            mc.displayGuiScreen(null);
+            McIf.mc().displayGuiScreen(null);
         } else if (button.id == 0) {
             // View changelog
             boolean major = CoreDBConfig.INSTANCE.updateStream == UpdateStream.STABLE;

--- a/src/main/java/com/wynntils/modules/core/overlays/ui/UpdatingScreen.java
+++ b/src/main/java/com/wynntils/modules/core/overlays/ui/UpdatingScreen.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.core.overlays.ui;
 
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.modules.core.CoreModule;
 import com.wynntils.modules.core.config.CoreDBConfig;
@@ -56,7 +57,7 @@ public class UpdatingScreen extends GuiScreen {
                 if (!failed) {
                     UpdateOverlay.scheduleCopyUpdateAtShutdown(jarName);
                     if (restartNow) {
-                        mc.shutdown();
+                        McIf.mc().shutdown();
                     }
                     complete = true;
                     updateText();
@@ -103,7 +104,7 @@ public class UpdatingScreen extends GuiScreen {
                 int count;
 
                 while ((count = fis.read(data)) != -1) {
-                    if (mc.currentScreen != UpdatingScreen.this) {
+                    if (McIf.mc().currentScreen != UpdatingScreen.this) {
                         // Cancelled
                         fos.close();
                         fis.close();
@@ -120,7 +121,7 @@ public class UpdatingScreen extends GuiScreen {
             }
             fis.close();
 
-            if (mc.currentScreen != UpdatingScreen.this) {
+            if (McIf.mc().currentScreen != UpdatingScreen.this) {
                 failed = true;
                 setChangelogs();
             }
@@ -135,7 +136,7 @@ public class UpdatingScreen extends GuiScreen {
     @Override
     public void actionPerformed(GuiButton button) {
         if (button.id == 0) {
-            mc.displayGuiScreen(null);
+            McIf.mc().displayGuiScreen(null);
         }
     }
 
@@ -154,24 +155,24 @@ public class UpdatingScreen extends GuiScreen {
 
         if (failed) {
             setChangelogs();
-            drawCenteredString(mc.fontRenderer, TextFormatting.RED + "Update download failed", this.width/2, this.height/2, 0xFFFFFFFF);
+            drawCenteredString(McIf.mc().fontRenderer, TextFormatting.RED + "Update download failed", this.width/2, this.height/2, 0xFFFFFFFF);
         } else if (complete) {
-            drawCenteredString(mc.fontRenderer, TextFormatting.GREEN + "Update download complete", this.width/2, this.height/2, 0xFFFFFF);
+            drawCenteredString(McIf.mc().fontRenderer, TextFormatting.GREEN + "Update download complete", this.width/2, this.height/2, 0xFFFFFF);
         } else {
             int left = Math.max(this.width/2 - 100, 10);
             int right = Math.min(this.width/2 + 100, this.width - 10);
-            int top = this.height/2 - 2 - MathHelper.ceil(mc.fontRenderer.FONT_HEIGHT / 2f);
-            int bottom = this.height/2 + 2 + MathHelper.floor(mc.fontRenderer.FONT_HEIGHT / 2f);
+            int top = this.height/2 - 2 - MathHelper.ceil(McIf.mc().fontRenderer.FONT_HEIGHT / 2f);
+            int bottom = this.height/2 + 2 + MathHelper.floor(McIf.mc().fontRenderer.FONT_HEIGHT / 2f);
             drawRect(left - 1, top - 1, right + 1, bottom + 1, 0xFFC0C0C0);
             int progressPoint = MathHelper.clamp(MathHelper.floor(progress * (right - left) + left), left, right);
             drawRect(left, top, progressPoint, bottom, 0xFFCB3D35);
             drawRect(progressPoint, top, right, bottom, 0xFFFFFFFF);
 
             String label = String.format("%d%%", MathHelper.clamp(MathHelper.floor(progress * 100), 0, 100));
-            mc.fontRenderer.drawString(label, (this.width - mc.fontRenderer.getStringWidth(label))/2, top + 3, 0xFF000000);
-            int x = (this.width - mc.fontRenderer.getStringWidth(String.format("Downloading %s", DOTS[DOTS.length - 1]))) / 2;
+            McIf.mc().fontRenderer.drawString(label, (this.width - McIf.mc().fontRenderer.getStringWidth(label))/2, top + 3, 0xFF000000);
+            int x = (this.width - McIf.mc().fontRenderer.getStringWidth(String.format("Downloading %s", DOTS[DOTS.length - 1]))) / 2;
             String title = String.format("Downloading %s", DOTS[((int) (System.currentTimeMillis() % (DOT_TIME * DOTS.length))) / DOT_TIME]);
-            drawString(mc.fontRenderer, title, x, top - mc.fontRenderer.FONT_HEIGHT - 2, 0xFFFFFFFF);
+            drawString(McIf.mc().fontRenderer, title, x, top - McIf.mc().fontRenderer.FONT_HEIGHT - 2, 0xFFFFFFFF);
         }
 
         super.drawScreen(mouseX, mouseY, partialTicks);

--- a/src/main/java/com/wynntils/modules/cosmetics/CosmeticsModule.java
+++ b/src/main/java/com/wynntils/modules/cosmetics/CosmeticsModule.java
@@ -22,9 +22,9 @@ public class CosmeticsModule extends Module {
     }
 
     public void postEnable() {
-        Minecraft.getMinecraft().gameSettings.setModelPartEnabled(EnumPlayerModelParts.CAPE, true);
+        McIf.mc().gameSettings.setModelPartEnabled(EnumPlayerModelParts.CAPE, true);
 
-        for (RenderPlayer render : Minecraft.getMinecraft().getRenderManager().getSkinMap().values()) {
+        for (RenderPlayer render : McIf.mc().getRenderManager().getSkinMap().values()) {
             render.addLayer(new LayerCape(render));
             render.addLayer(new LayerElytra(render));
             render.addLayer(new LayerFoxEars(render));

--- a/src/main/java/com/wynntils/modules/cosmetics/CosmeticsModule.java
+++ b/src/main/java/com/wynntils/modules/cosmetics/CosmeticsModule.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.cosmetics;
 
+import com.wynntils.McIf;
 import com.wynntils.core.framework.instances.Module;
 import com.wynntils.core.framework.interfaces.annotations.ModuleInfo;
 import com.wynntils.modules.cosmetics.configs.CosmeticsConfig;

--- a/src/main/java/com/wynntils/modules/cosmetics/layers/LayerCape.java
+++ b/src/main/java/com/wynntils/modules/cosmetics/layers/LayerCape.java
@@ -50,7 +50,7 @@ public class LayerCape implements LayerRenderer<AbstractClientPlayer> {
     public void doRenderLayer(AbstractClientPlayer player, float limbSwing, float limbSwingAmount, float partialTicks, float ageInTicks, float netHeadYaw, float headPitch, float scale) {
         if (!CosmeticsConfig.INSTANCE.forceCapes
                 && !McIf.mc().gameSettings.getModelParts().toString().contains("CAPE")
-                && player.getUniqueID() == McIf.mc().player.getUniqueID()) return;
+                && player.getUniqueID() == McIf.player().getUniqueID()) return;
 
         WynntilsUser info = UserManager.getUser(player.getUniqueID());
         if (info == null || !info.getCosmetics().hasCape()) return;

--- a/src/main/java/com/wynntils/modules/cosmetics/layers/LayerCape.java
+++ b/src/main/java/com/wynntils/modules/cosmetics/layers/LayerCape.java
@@ -4,12 +4,11 @@
 
 package com.wynntils.modules.cosmetics.layers;
 
-import com.wynntils.ModCore;
+import com.wynntils.McIf;
 import com.wynntils.core.utils.reflections.ReflectionFields;
 import com.wynntils.modules.core.instances.account.WynntilsUser;
 import com.wynntils.modules.core.managers.UserManager;
 import com.wynntils.modules.cosmetics.configs.CosmeticsConfig;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.AbstractClientPlayer;
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
@@ -51,7 +50,7 @@ public class LayerCape implements LayerRenderer<AbstractClientPlayer> {
     public void doRenderLayer(AbstractClientPlayer player, float limbSwing, float limbSwingAmount, float partialTicks, float ageInTicks, float netHeadYaw, float headPitch, float scale) {
         if (!CosmeticsConfig.INSTANCE.forceCapes
                 && !McIf.mc().gameSettings.getModelParts().toString().contains("CAPE")
-                && player.getUniqueID() == ModCore.mc().player.getUniqueID()) return;
+                && player.getUniqueID() == McIf.mc().player.getUniqueID()) return;
 
         WynntilsUser info = UserManager.getUser(player.getUniqueID());
         if (info == null || !info.getCosmetics().hasCape()) return;

--- a/src/main/java/com/wynntils/modules/cosmetics/layers/LayerCape.java
+++ b/src/main/java/com/wynntils/modules/cosmetics/layers/LayerCape.java
@@ -50,7 +50,7 @@ public class LayerCape implements LayerRenderer<AbstractClientPlayer> {
 
     public void doRenderLayer(AbstractClientPlayer player, float limbSwing, float limbSwingAmount, float partialTicks, float ageInTicks, float netHeadYaw, float headPitch, float scale) {
         if (!CosmeticsConfig.INSTANCE.forceCapes
-                && !Minecraft.getMinecraft().gameSettings.getModelParts().toString().contains("CAPE")
+                && !McIf.mc().gameSettings.getModelParts().toString().contains("CAPE")
                 && player.getUniqueID() == ModCore.mc().player.getUniqueID()) return;
 
         WynntilsUser info = UserManager.getUser(player.getUniqueID());

--- a/src/main/java/com/wynntils/modules/cosmetics/layers/LayerElytra.java
+++ b/src/main/java/com/wynntils/modules/cosmetics/layers/LayerElytra.java
@@ -44,7 +44,7 @@ public class LayerElytra extends ModelBase implements LayerRenderer<AbstractClie
     public void doRenderLayer(AbstractClientPlayer player, float limbSwing, float limbSwingAmount, float partialTicks, float ageInTicks, float netHeadYaw, float headPitch, float scale) {
         if (!CosmeticsConfig.INSTANCE.forceCapes
                 && !McIf.mc().gameSettings.getModelParts().toString().contains("CAPE")
-                && player.getUniqueID() == McIf.mc().player.getUniqueID()) return;
+                && player.getUniqueID() == McIf.player().getUniqueID()) return;
 
         WynntilsUser info = UserManager.getUser(player.getUniqueID());
         if (info == null || !info.getCosmetics().hasElytra()) return;

--- a/src/main/java/com/wynntils/modules/cosmetics/layers/LayerElytra.java
+++ b/src/main/java/com/wynntils/modules/cosmetics/layers/LayerElytra.java
@@ -44,7 +44,7 @@ public class LayerElytra extends ModelBase implements LayerRenderer<AbstractClie
     @Override
     public void doRenderLayer(AbstractClientPlayer player, float limbSwing, float limbSwingAmount, float partialTicks, float ageInTicks, float netHeadYaw, float headPitch, float scale) {
         if (!CosmeticsConfig.INSTANCE.forceCapes
-                && !Minecraft.getMinecraft().gameSettings.getModelParts().toString().contains("CAPE")
+                && !McIf.mc().gameSettings.getModelParts().toString().contains("CAPE")
                 && player.getUniqueID() == ModCore.mc().player.getUniqueID()) return;
 
         WynntilsUser info = UserManager.getUser(player.getUniqueID());

--- a/src/main/java/com/wynntils/modules/cosmetics/layers/LayerElytra.java
+++ b/src/main/java/com/wynntils/modules/cosmetics/layers/LayerElytra.java
@@ -4,12 +4,11 @@
 
 package com.wynntils.modules.cosmetics.layers;
 
-import com.wynntils.ModCore;
+import com.wynntils.McIf;
 import com.wynntils.modules.core.instances.account.WynntilsUser;
 import com.wynntils.modules.core.managers.UserManager;
 import com.wynntils.modules.cosmetics.configs.CosmeticsConfig;
 import com.wynntils.modules.cosmetics.layers.models.CustomElytraModel;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.AbstractClientPlayer;
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.renderer.GlStateManager.DestFactor;
@@ -45,7 +44,7 @@ public class LayerElytra extends ModelBase implements LayerRenderer<AbstractClie
     public void doRenderLayer(AbstractClientPlayer player, float limbSwing, float limbSwingAmount, float partialTicks, float ageInTicks, float netHeadYaw, float headPitch, float scale) {
         if (!CosmeticsConfig.INSTANCE.forceCapes
                 && !McIf.mc().gameSettings.getModelParts().toString().contains("CAPE")
-                && player.getUniqueID() == ModCore.mc().player.getUniqueID()) return;
+                && player.getUniqueID() == McIf.mc().player.getUniqueID()) return;
 
         WynntilsUser info = UserManager.getUser(player.getUniqueID());
         if (info == null || !info.getCosmetics().hasElytra()) return;

--- a/src/main/java/com/wynntils/modules/map/MapModule.java
+++ b/src/main/java/com/wynntils/modules/map/MapModule.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.map;
 
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.framework.enums.Priority;
 import com.wynntils.core.framework.instances.KeyHolder;

--- a/src/main/java/com/wynntils/modules/map/MapModule.java
+++ b/src/main/java/com/wynntils/modules/map/MapModule.java
@@ -63,7 +63,7 @@ public class MapModule extends Module {
 
         registerKeyBinding("New Waypoint", Keyboard.KEY_B, "Wynntils", KeyConflictContext.IN_GAME, true, () -> {
             if (Reference.onWorld)
-                Minecraft.getMinecraft().displayGuiScreen(new WaypointCreationMenu(null));
+                McIf.mc().displayGuiScreen(new WaypointCreationMenu(null));
         });
 
         mapKey = registerKeyBinding("Open Map", Keyboard.KEY_M, "Wynntils", KeyConflictContext.IN_GAME, true, () -> {

--- a/src/main/java/com/wynntils/modules/map/commands/CommandLocate.java
+++ b/src/main/java/com/wynntils/modules/map/commands/CommandLocate.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.map.commands;
 
+import com.wynntils.McIf;
 import com.wynntils.core.utils.objects.Location;
 import com.wynntils.webapi.WebManager;
 import com.wynntils.webapi.profiles.LocationProfile;

--- a/src/main/java/com/wynntils/modules/map/commands/CommandLocate.java
+++ b/src/main/java/com/wynntils/modules/map/commands/CommandLocate.java
@@ -88,7 +88,7 @@ public class CommandLocate extends CommandBase implements IClientCommand {
         }
 
         Map<Double, LocationProfile> distanceToLocations = new TreeMap<>();
-        Location currentLocation = new Location(Minecraft.getMinecraft().player);
+        Location currentLocation = new Location(McIf.mc().player);
 
         for (LocationProfile locationProfile : knownProfiles) {
             Location location = new Location(locationProfile.getX(), currentLocation.getY(), locationProfile.getZ());

--- a/src/main/java/com/wynntils/modules/map/commands/CommandLocate.java
+++ b/src/main/java/com/wynntils/modules/map/commands/CommandLocate.java
@@ -88,7 +88,7 @@ public class CommandLocate extends CommandBase implements IClientCommand {
         }
 
         Map<Double, LocationProfile> distanceToLocations = new TreeMap<>();
-        Location currentLocation = new Location(McIf.mc().player);
+        Location currentLocation = new Location(McIf.player());
 
         for (LocationProfile locationProfile : knownProfiles) {
             Location location = new Location(locationProfile.getX(), currentLocation.getY(), locationProfile.getZ());

--- a/src/main/java/com/wynntils/modules/map/commands/CommandLootRun.java
+++ b/src/main/java/com/wynntils/modules/map/commands/CommandLootRun.java
@@ -4,14 +4,13 @@
 
 package com.wynntils.modules.map.commands;
 
-import com.wynntils.ModCore;
+import com.wynntils.McIf;
 import com.wynntils.core.utils.Utils;
 import com.wynntils.core.utils.helpers.Delay;
 import com.wynntils.core.utils.objects.Location;
 import com.wynntils.modules.map.instances.LootRunNote;
 import com.wynntils.modules.map.managers.LootRunManager;
 import com.wynntils.modules.questbook.enums.QuestBookPages;
-import com.wynntils.modules.questbook.instances.QuestBookPage;
 import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.CommandException;
@@ -26,7 +25,6 @@ import net.minecraft.util.text.event.ClickEvent;
 import net.minecraft.util.text.event.HoverEvent;
 import net.minecraftforge.client.IClientCommand;
 
-import java.io.IOException;
 import java.net.URI;
 import java.util.*;
 
@@ -175,7 +173,7 @@ public class CommandLootRun extends CommandBase implements IClientCommand {
                     return;
                 }
 
-                Entity lowest = ModCore.mc().player.getLowestRidingEntity();
+                Entity lowest = McIf.mc().player.getLowestRidingEntity();
                 String message;
                 if (LootRunManager.undoMovement(lowest.posX, lowest.posY, lowest.posZ)) {
                     message = GREEN + "Undid your most recent movements!";
@@ -231,7 +229,7 @@ public class CommandLootRun extends CommandBase implements IClientCommand {
 
                 String text = String.join(" ", args);
                 text = text.substring(text.indexOf(" ")).trim();
-                EntityPlayerSP player = ModCore.mc().player;
+                EntityPlayerSP player = McIf.mc().player;
                 LootRunNote note = new LootRunNote(new Location(player.posX, player.posY, player.posZ), text);
 
                 ITextComponent message;
@@ -265,7 +263,7 @@ public class CommandLootRun extends CommandBase implements IClientCommand {
                 String command = args[0].toLowerCase(Locale.ROOT);
                 BlockPos pos;
                 if (args.length < 4) {
-                    pos = new BlockPos((int) ModCore.mc().player.posX, (int) ModCore.mc().player.posY, (int) ModCore.mc().player.posZ - 1);
+                    pos = new BlockPos((int) McIf.mc().player.posX, (int) McIf.mc().player.posY, (int) McIf.mc().player.posZ - 1);
                 } else {
                     int x = 0, y = 0, z = 0;
                     try {

--- a/src/main/java/com/wynntils/modules/map/commands/CommandLootRun.java
+++ b/src/main/java/com/wynntils/modules/map/commands/CommandLootRun.java
@@ -173,7 +173,7 @@ public class CommandLootRun extends CommandBase implements IClientCommand {
                     return;
                 }
 
-                Entity lowest = McIf.mc().player.getLowestRidingEntity();
+                Entity lowest = McIf.player().getLowestRidingEntity();
                 String message;
                 if (LootRunManager.undoMovement(lowest.posX, lowest.posY, lowest.posZ)) {
                     message = GREEN + "Undid your most recent movements!";
@@ -229,7 +229,7 @@ public class CommandLootRun extends CommandBase implements IClientCommand {
 
                 String text = String.join(" ", args);
                 text = text.substring(text.indexOf(" ")).trim();
-                EntityPlayerSP player = McIf.mc().player;
+                EntityPlayerSP player = McIf.player();
                 LootRunNote note = new LootRunNote(new Location(player.posX, player.posY, player.posZ), text);
 
                 ITextComponent message;
@@ -263,7 +263,7 @@ public class CommandLootRun extends CommandBase implements IClientCommand {
                 String command = args[0].toLowerCase(Locale.ROOT);
                 BlockPos pos;
                 if (args.length < 4) {
-                    pos = new BlockPos((int) McIf.mc().player.posX, (int) McIf.mc().player.posY, (int) McIf.mc().player.posZ - 1);
+                    pos = new BlockPos((int) McIf.player().posX, (int) McIf.player().posY, (int) McIf.player().posZ - 1);
                 } else {
                     int x = 0, y = 0, z = 0;
                     try {

--- a/src/main/java/com/wynntils/modules/map/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/map/events/ClientEvents.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.map.events;
 
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.*;
 import com.wynntils.core.framework.interfaces.Listener;

--- a/src/main/java/com/wynntils/modules/map/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/map/events/ClientEvents.java
@@ -117,7 +117,7 @@ public class ClientEvents implements Listener {
     public void recordLootRun(TickEvent.ClientTickEvent e) {
         if (!Reference.onWorld || e.phase != TickEvent.Phase.END || !LootRunManager.isRecording()) return;
 
-        EntityPlayerSP player = Minecraft.getMinecraft().player;
+        EntityPlayerSP player = McIf.mc().player;
         if (player == null) return;
 
         Entity lowestEntity = player.getLowestRidingEntity();

--- a/src/main/java/com/wynntils/modules/map/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/map/events/ClientEvents.java
@@ -117,7 +117,7 @@ public class ClientEvents implements Listener {
     public void recordLootRun(TickEvent.ClientTickEvent e) {
         if (!Reference.onWorld || e.phase != TickEvent.Phase.END || !LootRunManager.isRecording()) return;
 
-        EntityPlayerSP player = McIf.mc().player;
+        EntityPlayerSP player = McIf.player();
         if (player == null) return;
 
         Entity lowestEntity = player.getLowestRidingEntity();

--- a/src/main/java/com/wynntils/modules/map/instances/LootRunNote.java
+++ b/src/main/java/com/wynntils/modules/map/instances/LootRunNote.java
@@ -45,7 +45,7 @@ public class LootRunNote {
         RenderManager render = McIf.mc().getRenderManager();
         FontRenderer fr = render.getFontRenderer();
 
-        if (McIf.mc().player.getDistanceSq(location.x, location.y, location.z) > 4096f)
+        if (McIf.player().getDistanceSq(location.x, location.y, location.z) > 4096f)
             return; // only draw nametag when close
 
         String[] lines = StringUtils.wrapTextBySize(note, 200);

--- a/src/main/java/com/wynntils/modules/map/instances/LootRunNote.java
+++ b/src/main/java/com/wynntils/modules/map/instances/LootRunNote.java
@@ -1,6 +1,6 @@
 package com.wynntils.modules.map.instances;
 
-import com.wynntils.ModCore;
+import com.wynntils.McIf;
 import com.wynntils.core.framework.rendering.ScreenRenderer;
 import com.wynntils.core.framework.rendering.SmartFontRenderer;
 import com.wynntils.core.framework.rendering.colors.CustomColor;
@@ -42,11 +42,10 @@ public class LootRunNote {
     }
 
     public void drawNote(CustomColor color) {
-        RenderManager render = ModCore.mc().getRenderManager();
+        RenderManager render = McIf.mc().getRenderManager();
         FontRenderer fr = render.getFontRenderer();
-        EntityPlayerSP player = ModCore.mc().player;
 
-        if (player.getDistanceSq(location.x, location.y, location.z) > 4096f)
+        if (McIf.mc().player.getDistanceSq(location.x, location.y, location.z) > 4096f)
             return; // only draw nametag when close
 
         String[] lines = StringUtils.wrapTextBySize(note, 200);

--- a/src/main/java/com/wynntils/modules/map/instances/MapProfile.java
+++ b/src/main/java/com/wynntils/modules/map/instances/MapProfile.java
@@ -73,8 +73,8 @@ public class MapProfile {
 
     private void setReadyToUse() {
         // make sure this is being called from the main thread
-        if (!Minecraft.getMinecraft().isCallingFromMinecraftThread()) {
-            Minecraft.getMinecraft().addScheduledTask(this::setReadyToUse);
+        if (!McIf.mc().isCallingFromMinecraftThread()) {
+            McIf.mc().addScheduledTask(this::setReadyToUse);
             return;
         }
         readyToUse = true;

--- a/src/main/java/com/wynntils/modules/map/instances/MapProfile.java
+++ b/src/main/java/com/wynntils/modules/map/instances/MapProfile.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.map.instances;
 
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.utils.helpers.MD5Verification;
 import com.wynntils.webapi.WebManager;

--- a/src/main/java/com/wynntils/modules/map/managers/BeaconManager.java
+++ b/src/main/java/com/wynntils/modules/map/managers/BeaconManager.java
@@ -23,7 +23,7 @@ public class BeaconManager {
     private static final ResourceLocation beamResource = new ResourceLocation("textures/entity/beacon_beam.png");
 
     public static void drawBeam(Location loc, CustomColor color, float partialTicks) {
-        RenderManager renderManager = Minecraft.getMinecraft().getRenderManager();
+        RenderManager renderManager = McIf.mc().getRenderManager();
         if (renderManager.renderViewEntity == null) return;
 
         float alpha = 1f;
@@ -39,7 +39,7 @@ public class BeaconManager {
 
         alpha *= color.a;
 
-        double maxDistance = Minecraft.getMinecraft().gameSettings.renderDistanceChunks * 16d;
+        double maxDistance = McIf.mc().gameSettings.renderDistanceChunks * 16d;
         if (distance > maxDistance) {  // this will drag the beam to the visible area if outside of it
             // partial ticks aren't factored into player pos, so if we're going to use it for rendering, we need to recalculate to account for partial ticks
             Vec3d prevPosVec = new Vec3d(renderManager.renderViewEntity.prevPosX, renderManager.renderViewEntity.prevPosY, renderManager.renderViewEntity.prevPosZ);
@@ -55,7 +55,7 @@ public class BeaconManager {
     private static void drawBeam(double x, double y, double z, float alpha, CustomColor color) {
         pushAttrib();
         {
-            Minecraft.getMinecraft().renderEngine.bindTexture(beamResource);  // binds the texture
+            McIf.mc().renderEngine.bindTexture(beamResource);  // binds the texture
             glTexParameteri(3553, 10242, 10497);
 
             // beacon light animation

--- a/src/main/java/com/wynntils/modules/map/managers/BeaconManager.java
+++ b/src/main/java/com/wynntils/modules/map/managers/BeaconManager.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.map.managers;
 
+import com.wynntils.McIf;
 import com.wynntils.core.framework.rendering.colors.CustomColor;
 import com.wynntils.core.utils.objects.Location;
 import net.minecraft.client.Minecraft;
@@ -59,7 +60,7 @@ public class BeaconManager {
             glTexParameteri(3553, 10242, 10497);
 
             // beacon light animation
-            float time = Minecraft.getSystemTime() / 50F;
+            float time = McIf.getSystemTime() / 50F;
             float offset = -(-time * 0.2F - MathHelper.fastFloor(-time * 0.1F)) * 0.6F;
 
             // positions

--- a/src/main/java/com/wynntils/modules/map/managers/GuildResourceManager.java
+++ b/src/main/java/com/wynntils/modules/map/managers/GuildResourceManager.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.map.managers;
 
+import com.wynntils.McIf;
 import com.wynntils.modules.map.instances.GuildResourceContainer;
 import net.minecraft.advancements.Advancement;
 import net.minecraft.advancements.FrameType;
@@ -26,7 +27,7 @@ public class GuildResourceManager {
         for (Advancement.Builder advancement : info.getAdvancementsToAdd().values()) {
             Advancement built = advancement.build(null);
 
-            String territoryName = built.getDisplayText().getUnformattedText().replace("[", "")
+            String territoryName = McIf.getUnformattedText(built.getDisplayText()).replace("[", "")
                     .replace("]", "");
             // the territory name has a shit ton of spaces at the end to make the advancement box bigger
             while (territoryName.endsWith(" ")) {
@@ -42,7 +43,7 @@ public class GuildResourceManager {
             // description is literaly a raw string with \n so we have to split
             // the text component also didn't parse the colors corrently so we can't use the unformatted text
             // no clue why although.
-            String description = built.getDisplay().getDescription().getUnformattedText();
+            String description = McIf.getUnformattedText(built.getDisplay().getDescription());
             String[] colored = description.split("\n");
             String[] raw = StringUtils.stripControlCodes(description).split("\n");
 

--- a/src/main/java/com/wynntils/modules/map/overlays/MiniMapOverlay.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/MiniMapOverlay.java
@@ -69,11 +69,11 @@ public class MiniMapOverlay extends Overlay {
         int zoom = MapConfig.INSTANCE.mapZoom;
 
         // texture position
-        float minX = map.getTextureXPosition(McIf.mc().player.posX) - extraFactor * (mapSize/2f + zoom);  // <--- min texture x point
-        float minZ = map.getTextureZPosition(McIf.mc().player.posZ) - extraFactor * (mapSize/2f + zoom);  // <--- min texture z point
+        float minX = map.getTextureXPosition(McIf.player().posX) - extraFactor * (mapSize/2f + zoom);  // <--- min texture x point
+        float minZ = map.getTextureZPosition(McIf.player().posZ) - extraFactor * (mapSize/2f + zoom);  // <--- min texture z point
 
-        float maxX = map.getTextureXPosition(McIf.mc().player.posX) + extraFactor * (mapSize/2f + zoom);  // <--- max texture x point
-        float maxZ = map.getTextureZPosition(McIf.mc().player.posZ) + extraFactor * (mapSize/2f + zoom);  // <--- max texture z point
+        float maxX = map.getTextureXPosition(McIf.player().posX) + extraFactor * (mapSize/2f + zoom);  // <--- max texture x point
+        float maxZ = map.getTextureZPosition(McIf.player().posZ) + extraFactor * (mapSize/2f + zoom);  // <--- max texture z point
 
         minX /= (float)map.getImageWidth(); maxX /= (float)map.getImageWidth();
         minZ /= (float)map.getImageHeight(); maxZ /= (float)map.getImageHeight();
@@ -100,7 +100,7 @@ public class MiniMapOverlay extends Overlay {
 
             // rotation axis
             transformationOrigin(mapSize/2, mapSize/2);
-            if (MapConfig.INSTANCE.followPlayerRotation) rotate(180 - MathHelper.fastFloor(McIf.mc().player.rotationYaw));
+            if (MapConfig.INSTANCE.followPlayerRotation) rotate(180 - MathHelper.fastFloor(McIf.player().rotationYaw));
 
             // map quad
             float extraSize = (extraFactor - 1f) * mapSize/2f;  // How many extra pixels multiplying by extraFactor added on each side
@@ -134,17 +134,17 @@ public class MiniMapOverlay extends Overlay {
                 // TODO this needs to scale in even numbers to avoid distortion!
                 final float sizeMultiplier = 0.8f * MapConfig.INSTANCE.minimapIconSizeMultiplier * (1 - (1 - scaleFactor) * (1 - scaleFactor));
 
-                final double rotationRadians = Math.toRadians(McIf.mc().player.rotationYaw);
+                final double rotationRadians = Math.toRadians(McIf.player().rotationYaw);
                 final float sinRotationRadians = (float) Math.sin(rotationRadians);
                 final float cosRotationRadians = (float) -Math.cos(rotationRadians);
 
                 // These two points for a box bigger than the actual minimap so the icons outside
                 // can quickly be filtered out
-                final int minFastWorldX = (int) (McIf.mc().player.posX - extraFactor * (mapSize/2f + zoom));
-                final int minFastWorldZ = (int) (McIf.mc().player.posZ - extraFactor * (mapSize/2f + zoom));
+                final int minFastWorldX = (int) (McIf.player().posX - extraFactor * (mapSize/2f + zoom));
+                final int minFastWorldZ = (int) (McIf.player().posZ - extraFactor * (mapSize/2f + zoom));
 
-                final int maxFastWorldX = (int) (McIf.mc().player.posX + extraFactor * (mapSize/2f + zoom)) + 1;
-                final int maxFastWorldZ = (int) (McIf.mc().player.posZ + extraFactor * (mapSize/2f + zoom)) + 1;
+                final int maxFastWorldX = (int) (McIf.player().posX + extraFactor * (mapSize/2f + zoom)) + 1;
+                final int maxFastWorldZ = (int) (McIf.player().posZ + extraFactor * (mapSize/2f + zoom)) + 1;
 
                 Consumer<MapIcon> consumer = c -> {
                     if (!c.isEnabled(true)) return;
@@ -158,8 +158,8 @@ public class MiniMapOverlay extends Overlay {
                     ) {
                         return;
                     }
-                    float dx = (float) (posX - McIf.mc().player.posX) * scaleFactor;
-                    float dz = (float) (posZ - McIf.mc().player.posZ) * scaleFactor;
+                    float dx = (float) (posX - McIf.player().posX) * scaleFactor;
+                    float dz = (float) (posZ - McIf.player().posZ) * scaleFactor;
 
                     boolean followRotation = false;
 
@@ -169,7 +169,7 @@ public class MiniMapOverlay extends Overlay {
                             GlStateManager.pushMatrix();
                             Point drawingOrigin = MiniMapOverlay.drawingOrigin();
                             GlStateManager.translate(drawingOrigin.x + halfMapSize, drawingOrigin.y + halfMapSize, 0);
-                            GlStateManager.rotate(180 - McIf.mc().player.rotationYaw, 0, 0, 1);
+                            GlStateManager.rotate(180 - McIf.player().rotationYaw, 0, 0, 1);
                             GlStateManager.translate(-drawingOrigin.x - halfMapSize, -drawingOrigin.y - halfMapSize, 0);
                         } else {
                             float temp = dx * cosRotationRadians - dz * sinRotationRadians;
@@ -193,8 +193,8 @@ public class MiniMapOverlay extends Overlay {
                 MapIcon compassIcon = MapIcon.getCompass();
 
                 if (compassIcon.isEnabled(true)) {
-                    float dx = (float) (compassIcon.getPosX() - McIf.mc().player.posX) * scaleFactor;
-                    float dz = (float) (compassIcon.getPosZ() - McIf.mc().player.posZ) * scaleFactor;
+                    float dx = (float) (compassIcon.getPosX() - McIf.player().posX) * scaleFactor;
+                    float dz = (float) (compassIcon.getPosZ() - McIf.player().posZ) * scaleFactor;
 
                     if (MapConfig.INSTANCE.followPlayerRotation) {
                         float temp = dx * cosRotationRadians - dz * sinRotationRadians;
@@ -268,10 +268,10 @@ public class MiniMapOverlay extends Overlay {
             disableScissorTest();
             clearMask();
 
-            if (MapConfig.INSTANCE.followPlayerRotation) rotate(180 - MathHelper.fastFloor(McIf.mc().player.rotationYaw));
+            if (MapConfig.INSTANCE.followPlayerRotation) rotate(180 - MathHelper.fastFloor(McIf.player().rotationYaw));
 
             // cursor & cursor rotation
-            rotate(180 + MathHelper.fastFloor(McIf.mc().player.rotationYaw));
+            rotate(180 + MathHelper.fastFloor(McIf.player().rotationYaw));
 
             MapConfig.PointerType type = MapConfig.Textures.INSTANCE.pointerStyle;
 
@@ -304,12 +304,12 @@ public class MiniMapOverlay extends Overlay {
             if (MapConfig.INSTANCE.showCompass) {
                 if (MapConfig.INSTANCE.followPlayerRotation) {
                     float mapCentre = (float) mapSize / 2f;
-                    float yawRadians = (float) Math.toRadians(McIf.mc().player.rotationYaw);
+                    float yawRadians = (float) Math.toRadians(McIf.player().rotationYaw);
                     float northDX = mapCentre * MathHelper.sin(yawRadians);
                     float northDY = mapCentre * MathHelper.cos(yawRadians);
                     if (MapConfig.INSTANCE.mapFormat == MapConfig.MapFormat.SQUARE) {
                         // Scale by sec((offset from 90 degree angle)) to map to tangent from offset point
-                        float circleToSquareScale = MathHelper.cos((float) Math.toRadians((McIf.mc().player.rotationYaw % 360f + 405f) % 90f - 45f));
+                        float circleToSquareScale = MathHelper.cos((float) Math.toRadians((McIf.player().rotationYaw % 360f + 405f) % 90f - 45f));
                         northDX /= circleToSquareScale;
                         northDY /= circleToSquareScale;
                     }
@@ -332,7 +332,7 @@ public class MiniMapOverlay extends Overlay {
 
             if (MapConfig.INSTANCE.showCoords) {
                 drawString(
-                        String.join(", ", Integer.toString((int) McIf.mc().player.posX), Integer.toString((int) McIf.mc().player.posY), Integer.toString((int) McIf.mc().player.posZ)),
+                        String.join(", ", Integer.toString((int) McIf.player().posX), Integer.toString((int) McIf.player().posY), Integer.toString((int) McIf.player().posZ)),
                         mapSize / 2f, mapSize + 6, CommonColors.WHITE, SmartFontRenderer.TextAlignment.MIDDLE, SmartFontRenderer.TextShadow.OUTLINE
                 );
             }

--- a/src/main/java/com/wynntils/modules/map/overlays/MiniMapOverlay.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/MiniMapOverlay.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.map.overlays;
 
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.framework.overlays.Overlay;
 import com.wynntils.core.framework.rendering.ScreenRenderer;
@@ -68,11 +69,11 @@ public class MiniMapOverlay extends Overlay {
         int zoom = MapConfig.INSTANCE.mapZoom;
 
         // texture position
-        float minX = map.getTextureXPosition(mc.player.posX) - extraFactor * (mapSize/2f + zoom);  // <--- min texture x point
-        float minZ = map.getTextureZPosition(mc.player.posZ) - extraFactor * (mapSize/2f + zoom);  // <--- min texture z point
+        float minX = map.getTextureXPosition(McIf.mc().player.posX) - extraFactor * (mapSize/2f + zoom);  // <--- min texture x point
+        float minZ = map.getTextureZPosition(McIf.mc().player.posZ) - extraFactor * (mapSize/2f + zoom);  // <--- min texture z point
 
-        float maxX = map.getTextureXPosition(mc.player.posX) + extraFactor * (mapSize/2f + zoom);  // <--- max texture x point
-        float maxZ = map.getTextureZPosition(mc.player.posZ) + extraFactor * (mapSize/2f + zoom);  // <--- max texture z point
+        float maxX = map.getTextureXPosition(McIf.mc().player.posX) + extraFactor * (mapSize/2f + zoom);  // <--- max texture x point
+        float maxZ = map.getTextureZPosition(McIf.mc().player.posZ) + extraFactor * (mapSize/2f + zoom);  // <--- max texture z point
 
         minX /= (float)map.getImageWidth(); maxX /= (float)map.getImageWidth();
         minZ /= (float)map.getImageHeight(); maxZ /= (float)map.getImageHeight();
@@ -99,7 +100,7 @@ public class MiniMapOverlay extends Overlay {
 
             // rotation axis
             transformationOrigin(mapSize/2, mapSize/2);
-            if (MapConfig.INSTANCE.followPlayerRotation) rotate(180 - MathHelper.fastFloor(mc.player.rotationYaw));
+            if (MapConfig.INSTANCE.followPlayerRotation) rotate(180 - MathHelper.fastFloor(McIf.mc().player.rotationYaw));
 
             // map quad
             float extraSize = (extraFactor - 1f) * mapSize/2f;  // How many extra pixels multiplying by extraFactor added on each side
@@ -133,17 +134,17 @@ public class MiniMapOverlay extends Overlay {
                 // TODO this needs to scale in even numbers to avoid distortion!
                 final float sizeMultiplier = 0.8f * MapConfig.INSTANCE.minimapIconSizeMultiplier * (1 - (1 - scaleFactor) * (1 - scaleFactor));
 
-                final double rotationRadians = Math.toRadians(mc.player.rotationYaw);
+                final double rotationRadians = Math.toRadians(McIf.mc().player.rotationYaw);
                 final float sinRotationRadians = (float) Math.sin(rotationRadians);
                 final float cosRotationRadians = (float) -Math.cos(rotationRadians);
 
                 // These two points for a box bigger than the actual minimap so the icons outside
                 // can quickly be filtered out
-                final int minFastWorldX = (int) (mc.player.posX - extraFactor * (mapSize/2f + zoom));
-                final int minFastWorldZ = (int) (mc.player.posZ - extraFactor * (mapSize/2f + zoom));
+                final int minFastWorldX = (int) (McIf.mc().player.posX - extraFactor * (mapSize/2f + zoom));
+                final int minFastWorldZ = (int) (McIf.mc().player.posZ - extraFactor * (mapSize/2f + zoom));
 
-                final int maxFastWorldX = (int) (mc.player.posX + extraFactor * (mapSize/2f + zoom)) + 1;
-                final int maxFastWorldZ = (int) (mc.player.posZ + extraFactor * (mapSize/2f + zoom)) + 1;
+                final int maxFastWorldX = (int) (McIf.mc().player.posX + extraFactor * (mapSize/2f + zoom)) + 1;
+                final int maxFastWorldZ = (int) (McIf.mc().player.posZ + extraFactor * (mapSize/2f + zoom)) + 1;
 
                 Consumer<MapIcon> consumer = c -> {
                     if (!c.isEnabled(true)) return;
@@ -157,8 +158,8 @@ public class MiniMapOverlay extends Overlay {
                     ) {
                         return;
                     }
-                    float dx = (float) (posX - mc.player.posX) * scaleFactor;
-                    float dz = (float) (posZ - mc.player.posZ) * scaleFactor;
+                    float dx = (float) (posX - McIf.mc().player.posX) * scaleFactor;
+                    float dz = (float) (posZ - McIf.mc().player.posZ) * scaleFactor;
 
                     boolean followRotation = false;
 
@@ -168,7 +169,7 @@ public class MiniMapOverlay extends Overlay {
                             GlStateManager.pushMatrix();
                             Point drawingOrigin = MiniMapOverlay.drawingOrigin();
                             GlStateManager.translate(drawingOrigin.x + halfMapSize, drawingOrigin.y + halfMapSize, 0);
-                            GlStateManager.rotate(180 - mc.player.rotationYaw, 0, 0, 1);
+                            GlStateManager.rotate(180 - McIf.mc().player.rotationYaw, 0, 0, 1);
                             GlStateManager.translate(-drawingOrigin.x - halfMapSize, -drawingOrigin.y - halfMapSize, 0);
                         } else {
                             float temp = dx * cosRotationRadians - dz * sinRotationRadians;
@@ -192,8 +193,8 @@ public class MiniMapOverlay extends Overlay {
                 MapIcon compassIcon = MapIcon.getCompass();
 
                 if (compassIcon.isEnabled(true)) {
-                    float dx = (float) (compassIcon.getPosX() - mc.player.posX) * scaleFactor;
-                    float dz = (float) (compassIcon.getPosZ() - mc.player.posZ) * scaleFactor;
+                    float dx = (float) (compassIcon.getPosX() - McIf.mc().player.posX) * scaleFactor;
+                    float dz = (float) (compassIcon.getPosZ() - McIf.mc().player.posZ) * scaleFactor;
 
                     if (MapConfig.INSTANCE.followPlayerRotation) {
                         float temp = dx * cosRotationRadians - dz * sinRotationRadians;
@@ -267,10 +268,10 @@ public class MiniMapOverlay extends Overlay {
             disableScissorTest();
             clearMask();
 
-            if (MapConfig.INSTANCE.followPlayerRotation) rotate(180 - MathHelper.fastFloor(mc.player.rotationYaw));
+            if (MapConfig.INSTANCE.followPlayerRotation) rotate(180 - MathHelper.fastFloor(McIf.mc().player.rotationYaw));
 
             // cursor & cursor rotation
-            rotate(180 + MathHelper.fastFloor(mc.player.rotationYaw));
+            rotate(180 + MathHelper.fastFloor(McIf.mc().player.rotationYaw));
 
             MapConfig.PointerType type = MapConfig.Textures.INSTANCE.pointerStyle;
 
@@ -303,12 +304,12 @@ public class MiniMapOverlay extends Overlay {
             if (MapConfig.INSTANCE.showCompass) {
                 if (MapConfig.INSTANCE.followPlayerRotation) {
                     float mapCentre = (float) mapSize / 2f;
-                    float yawRadians = (float) Math.toRadians(mc.player.rotationYaw);
+                    float yawRadians = (float) Math.toRadians(McIf.mc().player.rotationYaw);
                     float northDX = mapCentre * MathHelper.sin(yawRadians);
                     float northDY = mapCentre * MathHelper.cos(yawRadians);
                     if (MapConfig.INSTANCE.mapFormat == MapConfig.MapFormat.SQUARE) {
                         // Scale by sec((offset from 90 degree angle)) to map to tangent from offset point
-                        float circleToSquareScale = MathHelper.cos((float) Math.toRadians((mc.player.rotationYaw % 360f + 405f) % 90f - 45f));
+                        float circleToSquareScale = MathHelper.cos((float) Math.toRadians((McIf.mc().player.rotationYaw % 360f + 405f) % 90f - 45f));
                         northDX /= circleToSquareScale;
                         northDY /= circleToSquareScale;
                     }
@@ -331,7 +332,7 @@ public class MiniMapOverlay extends Overlay {
 
             if (MapConfig.INSTANCE.showCoords) {
                 drawString(
-                        String.join(", ", Integer.toString((int) mc.player.posX), Integer.toString((int) mc.player.posY), Integer.toString((int) mc.player.posZ)),
+                        String.join(", ", Integer.toString((int) McIf.mc().player.posX), Integer.toString((int) McIf.mc().player.posY), Integer.toString((int) McIf.mc().player.posZ)),
                         mapSize / 2f, mapSize + 6, CommonColors.WHITE, SmartFontRenderer.TextAlignment.MIDDLE, SmartFontRenderer.TextShadow.OUTLINE
                 );
             }

--- a/src/main/java/com/wynntils/modules/map/overlays/objects/MapButton.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/objects/MapButton.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.map.overlays.objects;
 
+import com.wynntils.McIf;
 import com.wynntils.core.framework.rendering.ScreenRenderer;
 import com.wynntils.core.framework.rendering.textures.Textures;
 import com.wynntils.modules.map.overlays.enums.MapButtonType;

--- a/src/main/java/com/wynntils/modules/map/overlays/objects/MapButton.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/objects/MapButton.java
@@ -65,7 +65,7 @@ public class MapButton {
     }
 
     public void mouseClicked(int mouseX, int mouseY, int mouseButton) {
-        Minecraft.getMinecraft().getSoundHandler().playSound(
+        McIf.mc().getSoundHandler().playSound(
                 PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f)
         );
 

--- a/src/main/java/com/wynntils/modules/map/overlays/objects/MapPlayerIcon.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/objects/MapPlayerIcon.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.map.overlays.objects;
 
+import com.wynntils.McIf;
 import com.wynntils.core.framework.rendering.ScreenRenderer;
 import com.wynntils.core.framework.rendering.colors.CommonColors;
 import com.wynntils.modules.core.instances.OtherPlayerProfile;

--- a/src/main/java/com/wynntils/modules/map/overlays/objects/MapPlayerIcon.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/objects/MapPlayerIcon.java
@@ -107,7 +107,7 @@ public class MapPlayerIcon extends MapIcon {
                     (centreZ) + sizeZ + .5f
             );
 
-            Minecraft.getMinecraft().getTextureManager().bindTexture(res);
+            McIf.mc().getTextureManager().bindTexture(res);
 
             drawScaledCustomSizeModalRect(
                     ((centreX + ScreenRenderer.drawingOrigin().x) -sizeX),

--- a/src/main/java/com/wynntils/modules/map/overlays/objects/MapWaypointIcon.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/objects/MapWaypointIcon.java
@@ -146,9 +146,9 @@ public class MapWaypointIcon extends MapTextureIcon {
         int distancePlayerWp = 0;
         float percentage = 1f;
         // TODO: Find a better solution to detect whether icon is being drawn on minimap
-        if (MapConfig.Waypoints.INSTANCE.iconFade && Minecraft.getMinecraft().currentScreen == null) {
+        if (MapConfig.Waypoints.INSTANCE.iconFade && McIf.mc().currentScreen == null) {
             // If negative the waypoint is above the player
-            distancePlayerWp = (int) (Minecraft.getMinecraft().player.posY - wp.getY());
+            distancePlayerWp = (int) (McIf.mc().player.posY - wp.getY());
 
             if (MathHelper.abs(distancePlayerWp) > MapConfig.Waypoints.INSTANCE.iconFadeScale) return;
             percentage = (float) ((1 - (MathHelper.abs(distancePlayerWp) / (float) MapConfig.Waypoints.INSTANCE.iconFadeScale)) * 0.8 + 0.2);

--- a/src/main/java/com/wynntils/modules/map/overlays/objects/MapWaypointIcon.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/objects/MapWaypointIcon.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.map.overlays.objects;
 
+import com.wynntils.McIf;
 import com.wynntils.core.framework.rendering.ScreenRenderer;
 import com.wynntils.core.framework.rendering.colors.CustomColor;
 import com.wynntils.core.framework.rendering.textures.AssetsTexture;

--- a/src/main/java/com/wynntils/modules/map/overlays/objects/MapWaypointIcon.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/objects/MapWaypointIcon.java
@@ -148,7 +148,7 @@ public class MapWaypointIcon extends MapTextureIcon {
         // TODO: Find a better solution to detect whether icon is being drawn on minimap
         if (MapConfig.Waypoints.INSTANCE.iconFade && McIf.mc().currentScreen == null) {
             // If negative the waypoint is above the player
-            distancePlayerWp = (int) (McIf.mc().player.posY - wp.getY());
+            distancePlayerWp = (int) (McIf.player().posY - wp.getY());
 
             if (MathHelper.abs(distancePlayerWp) > MapConfig.Waypoints.INSTANCE.iconFadeScale) return;
             percentage = (float) ((1 - (MathHelper.abs(distancePlayerWp) / (float) MapConfig.Waypoints.INSTANCE.iconFadeScale)) * 0.8 + 0.2);

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/GuildWorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/GuildWorldMapUI.java
@@ -44,7 +44,7 @@ public class GuildWorldMapUI extends WorldMapUI {
     private boolean showTradeRoutes = true;
 
     public GuildWorldMapUI() {
-        super((float) McIf.mc().player.posX, (float) McIf.mc().player.posZ);
+        super((float) McIf.player().posX, (float) McIf.player().posZ);
     }
 
     @Override
@@ -117,8 +117,8 @@ public class GuildWorldMapUI extends WorldMapUI {
 
         float scale = getScaleFactor();
 
-        float playerPositionX = (map.getTextureXPosition(McIf.mc().player.posX) - minX) / (maxX - minX);
-        float playerPositionZ = (map.getTextureZPosition(McIf.mc().player.posZ) - minZ) / (maxZ - minZ);
+        float playerPositionX = (map.getTextureXPosition(McIf.player().posX) - minX) / (maxX - minX);
+        float playerPositionZ = (map.getTextureZPosition(McIf.player().posZ) - minZ) / (maxZ - minZ);
 
         if (playerPositionX > 0 && playerPositionX < 1 && playerPositionZ > 0 && playerPositionZ < 1) {  // <--- player position
             playerPositionX = width * playerPositionX;
@@ -128,7 +128,7 @@ public class GuildWorldMapUI extends WorldMapUI {
 
             GlStateManager.pushMatrix();
             GlStateManager.translate(drawingOrigin.x + playerPositionX, drawingOrigin.y + playerPositionZ, 0);
-            GlStateManager.rotate(180 + MathHelper.fastFloor(McIf.mc().player.rotationYaw), 0, 0, 1);
+            GlStateManager.rotate(180 + MathHelper.fastFloor(McIf.player().rotationYaw), 0, 0, 1);
             GlStateManager.translate(-drawingOrigin.x - playerPositionX, -drawingOrigin.y - playerPositionZ, 0);
 
             MapConfig.PointerType type = MapConfig.Textures.INSTANCE.pointerStyle;

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/GuildWorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/GuildWorldMapUI.java
@@ -43,7 +43,7 @@ public class GuildWorldMapUI extends WorldMapUI {
     private boolean showTradeRoutes = true;
 
     public GuildWorldMapUI() {
-        super((float) Minecraft.getMinecraft().player.posX, (float) Minecraft.getMinecraft().player.posZ);
+        super((float) McIf.mc().player.posX, (float) McIf.mc().player.posZ);
     }
 
     @Override
@@ -85,7 +85,7 @@ public class GuildWorldMapUI extends WorldMapUI {
 
         // HeyZeer0: This close the map if the user was pressing the map key and after a moment dropped it
         if (holdingMapKey && !isHoldingMapKey()) {
-            Minecraft.getMinecraft().displayGuiScreen(null);
+            McIf.mc().displayGuiScreen(null);
             return;
         }
 
@@ -212,7 +212,7 @@ public class GuildWorldMapUI extends WorldMapUI {
     @Override
     protected void keyTyped(char typedChar, int keyCode) throws IOException {
         if (!holdingMapKey && keyCode == MapModule.getModule().getGuildMapKey().getKeyBinding().getKeyCode()) {
-            Minecraft.getMinecraft().displayGuiScreen(null);
+            McIf.mc().displayGuiScreen(null);
             return;
         }
 

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/GuildWorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/GuildWorldMapUI.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.map.overlays.ui;
 
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.framework.rendering.ScreenRenderer;
 import com.wynntils.core.framework.rendering.textures.Textures;
@@ -116,8 +117,8 @@ public class GuildWorldMapUI extends WorldMapUI {
 
         float scale = getScaleFactor();
 
-        float playerPositionX = (map.getTextureXPosition(mc.player.posX) - minX) / (maxX - minX);
-        float playerPositionZ = (map.getTextureZPosition(mc.player.posZ) - minZ) / (maxZ - minZ);
+        float playerPositionX = (map.getTextureXPosition(McIf.mc().player.posX) - minX) / (maxX - minX);
+        float playerPositionZ = (map.getTextureZPosition(McIf.mc().player.posZ) - minZ) / (maxZ - minZ);
 
         if (playerPositionX > 0 && playerPositionX < 1 && playerPositionZ > 0 && playerPositionZ < 1) {  // <--- player position
             playerPositionX = width * playerPositionX;
@@ -127,7 +128,7 @@ public class GuildWorldMapUI extends WorldMapUI {
 
             GlStateManager.pushMatrix();
             GlStateManager.translate(drawingOrigin.x + playerPositionX, drawingOrigin.y + playerPositionZ, 0);
-            GlStateManager.rotate(180 + MathHelper.fastFloor(mc.player.rotationYaw), 0, 0, 1);
+            GlStateManager.rotate(180 + MathHelper.fastFloor(McIf.mc().player.rotationYaw), 0, 0, 1);
             GlStateManager.translate(-drawingOrigin.x - playerPositionX, -drawingOrigin.y - playerPositionZ, 0);
 
             MapConfig.PointerType type = MapConfig.Textures.INSTANCE.pointerStyle;

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/MainWorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/MainWorldMapUI.java
@@ -5,6 +5,7 @@
 package com.wynntils.modules.map.overlays.ui;
 
 import com.google.common.collect.Lists;
+import com.wynntils.McIf;
 import com.wynntils.core.framework.rendering.ScreenRenderer;
 import com.wynntils.core.utils.Utils;
 import com.wynntils.core.utils.objects.Location;
@@ -191,7 +192,7 @@ public class MainWorldMapUI extends WorldMapUI {
 
         if (mouseButton == 0) {
             if (compassIcon.mouseOver(mouseX, mouseY)) {
-                long currentTime = Minecraft.getSystemTime();
+                long currentTime = McIf.getSystemTime();
                 if (currentTime - lastClickTime < doubleClickTime) {
                     Location location = CompassManager.getCompassLocation();
                     McIf.mc().displayGuiScreen(new WaypointCreationMenu(null, (int) location.getX(), (int) location.getZ()));

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/MainWorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/MainWorldMapUI.java
@@ -233,8 +233,8 @@ public class MainWorldMapUI extends WorldMapUI {
             z = (int) location.getZ();
         } else {
             type = "location";
-            x = (int) McIf.mc().player.posX;
-            z = (int) McIf.mc().player.posZ;
+            x = (int) McIf.player().posX;
+            z = (int) McIf.player().posZ;
         }
 
         if (leftClick)

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/MainWorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/MainWorldMapUI.java
@@ -54,21 +54,21 @@ public class MainWorldMapUI extends WorldMapUI {
             DARK_GREEN + "[>] Create a new Waypoint",
             GRAY + "Click here to create",
             GRAY + "a new waypoint."
-        ), (v) -> true, (i, btn) -> Minecraft.getMinecraft().displayGuiScreen(new WaypointCreationMenu(null)));
+        ), (v) -> true, (i, btn) -> McIf.mc().displayGuiScreen(new WaypointCreationMenu(null)));
 
         addButton(MapButtonType.PENCIL, 0, Arrays.asList(
             GOLD + "[>] Manage Paths",
             GRAY + "List, Delete or Create",
             GRAY + "drawed lines that help you",
             GRAY + "to navigate around the world!"
-        ), (v) -> true, (i, btn) -> Minecraft.getMinecraft().displayGuiScreen(new PathWaypointOverwiewUI()));
+        ), (v) -> true, (i, btn) -> McIf.mc().displayGuiScreen(new PathWaypointOverwiewUI()));
 
         addButton(MapButtonType.PIN, 1, Arrays.asList(
                 RED + "[>] Manage Waypoints",
                 GRAY + "List, Delete or Create",
                 GRAY + "all your preview set",
                 GRAY + "waypoints!"
-        ), (v) -> true, (i, btn) -> Minecraft.getMinecraft().displayGuiScreen(new WaypointOverviewUI()));
+        ), (v) -> true, (i, btn) -> McIf.mc().displayGuiScreen(new WaypointOverviewUI()));
 
         addButton(MapButtonType.SEARCH, 2, Arrays.asList(
                 LIGHT_PURPLE + "[>] Search",
@@ -79,7 +79,7 @@ public class MainWorldMapUI extends WorldMapUI {
                 AQUA + "[>] Configure Markers",
                 GRAY + "Enable or disable each",
                 GRAY + "map marker available."
-        ), (v) -> true, (i, btn) -> Minecraft.getMinecraft().displayGuiScreen(new WorldMapSettingsUI()));
+        ), (v) -> true, (i, btn) -> McIf.mc().displayGuiScreen(new WorldMapSettingsUI()));
 
         addButton(MapButtonType.SHARE, 4, Arrays.asList(
                 BLUE + "[>] Share Location",
@@ -138,7 +138,7 @@ public class MainWorldMapUI extends WorldMapUI {
 
         // HeyZeer0: This close the map if the user was pressing the map key and after a moment dropped it
         if (holdingMapKey && !isHoldingMapKey()) {
-            Minecraft.getMinecraft().displayGuiScreen(null);
+            McIf.mc().displayGuiScreen(null);
             return;
         }
 
@@ -194,7 +194,7 @@ public class MainWorldMapUI extends WorldMapUI {
                 long currentTime = Minecraft.getSystemTime();
                 if (currentTime - lastClickTime < doubleClickTime) {
                     Location location = CompassManager.getCompassLocation();
-                    Minecraft.getMinecraft().displayGuiScreen(new WaypointCreationMenu(null, (int) location.getX(), (int) location.getZ()));
+                    McIf.mc().displayGuiScreen(new WaypointCreationMenu(null, (int) location.getX(), (int) location.getZ()));
                 } else {
                     lastClickTime = currentTime;
                 }
@@ -203,7 +203,7 @@ public class MainWorldMapUI extends WorldMapUI {
 
             forEachIcon(c -> {
                 if (c.mouseOver(mouseX, mouseY)) {
-                    Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.ENTITY_EXPERIENCE_ORB_PICKUP, 1f));
+                    McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.ENTITY_EXPERIENCE_ORB_PICKUP, 1f));
 
                     CompassManager.setCompassLocation(new Location(c.getInfo().getPosX(), 0, c.getInfo().getPosZ()));
                     resetCompassMapIcon();
@@ -215,7 +215,7 @@ public class MainWorldMapUI extends WorldMapUI {
     @Override
     protected void keyTyped(char typedChar, int keyCode) throws IOException {
         if (!holdingMapKey && keyCode == MapModule.getModule().getMapKey().getKeyBinding().getKeyCode()) {
-            Minecraft.getMinecraft().displayGuiScreen(null);
+            McIf.mc().displayGuiScreen(null);
             return;
         }
 
@@ -233,8 +233,8 @@ public class MainWorldMapUI extends WorldMapUI {
             z = (int) location.getZ();
         } else {
             type = "location";
-            x = (int) Minecraft.getMinecraft().player.posX;
-            z = (int) Minecraft.getMinecraft().player.posZ;
+            x = (int) McIf.mc().player.posX;
+            z = (int) McIf.mc().player.posZ;
         }
 
         if (leftClick)

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/PathWaypointCreationUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/PathWaypointCreationUI.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.map.overlays.ui;
 
+import com.wynntils.McIf;
 import com.wynntils.core.framework.enums.MouseButton;
 import com.wynntils.core.framework.rendering.ScreenRenderer;
 import com.wynntils.core.framework.ui.elements.UIEColorWheel;
@@ -84,9 +85,9 @@ public class PathWaypointCreationUI extends WorldMapUI {
         boolean returning = nameField != null;
         String name = returning ? nameField.getText() : profile.name;
 
-        nameField = new GuiTextField(0, mc.fontRenderer, this.width - 183, 23, 160, 20);
+        nameField = new GuiTextField(0, McIf.mc().fontRenderer, this.width - 183, 23, 160, 20);
         nameField.setText(name);
-        nameFieldLabel = new GuiLabel(mc.fontRenderer, 0, this.width - 218, 30, 40, 10, 0xFFFFFF);
+        nameFieldLabel = new GuiLabel(McIf.mc().fontRenderer, 0, this.width - 218, 30, 40, 10, 0xFFFFFF);
         nameFieldLabel.addLine("Name");
 
         if (!returning) {
@@ -97,7 +98,7 @@ public class PathWaypointCreationUI extends WorldMapUI {
         buttonList.add(hiddenBox = new GuiCheckBox(5, this.width - 143,  72, "Hidden", hidden));  // TODO: check align
         buttonList.add(circularBox = new GuiCheckBox(6, this.width - 83, 72, "Circular", profile.isCircular));
 
-        helpText = new GuiLabel(mc.fontRenderer, 1, 22, this.height - 36, 120, 10, 0xFFFFFF);
+        helpText = new GuiLabel(McIf.mc().fontRenderer, 1, 22, this.height - 36, 120, 10, 0xFFFFFF);
         helpText.addLine("Shift + drag to pan");
         helpText.addLine("Right click to remove points");
 
@@ -299,8 +300,8 @@ public class PathWaypointCreationUI extends WorldMapUI {
 
         if (nameField != null) nameField.drawTextBox();
 
-        nameFieldLabel.drawLabel(mc, mouseX, mouseY);
-        helpText.drawLabel(mc, mouseX, mouseY);
+        nameFieldLabel.drawLabel(McIf.mc(), mouseX, mouseY);
+        helpText.drawLabel(McIf.mc(), mouseX, mouseY);
 
         super.drawScreen(mouseX, mouseY, partialTicks);
     }
@@ -317,11 +318,11 @@ public class PathWaypointCreationUI extends WorldMapUI {
                 MapConfig.Waypoints.INSTANCE.pathWaypoints.add(profile);
             }
             MapConfig.Waypoints.INSTANCE.saveSettings(MapModule.getModule());
-            mc.displayGuiScreen(new PathWaypointOverwiewUI());
+            McIf.mc().displayGuiScreen(new PathWaypointOverwiewUI());
         } else if (btn == cancelButton) {
-            mc.displayGuiScreen(new PathWaypointOverwiewUI());
+            McIf.mc().displayGuiScreen(new PathWaypointOverwiewUI());
         } else if (btn == resetButton) {
-            mc.displayGuiScreen(new PathWaypointCreationUI(originalProfile));
+            McIf.mc().displayGuiScreen(new PathWaypointCreationUI(originalProfile));
         } else if (btn == clearButton) {
             int sz;
             while ((sz = profile.size()) != 0) profile.removePoint(sz - 1);

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/PathWaypointOverwiewUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/PathWaypointOverwiewUI.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.map.overlays.ui;
 
+import com.wynntils.McIf;
 import com.wynntils.core.framework.rendering.ScreenRenderer;
 import com.wynntils.core.framework.rendering.colors.CommonColors;
 import com.wynntils.core.utils.Utils;

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/PathWaypointOverwiewUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/PathWaypointOverwiewUI.java
@@ -94,13 +94,13 @@ public class PathWaypointOverwiewUI extends GuiScreen {
         } else if (b == exitBtn) {
             Utils.displayGuiScreen(new MainWorldMapUI());
         } else if (b.id % 10 == 3) {
-            Minecraft.getMinecraft().displayGuiScreen(new PathWaypointCreationUI(paths.get(b.id / 10 + page * pageHeight)));
+            McIf.mc().displayGuiScreen(new PathWaypointCreationUI(paths.get(b.id / 10 + page * pageHeight)));
         } else if (b.id %10 == 5) {
             MapConfig.Waypoints.INSTANCE.pathWaypoints.remove(paths.get(b.id / 10 + page * pageHeight));
             MapConfig.Waypoints.INSTANCE.saveSettings(MapModule.getModule());
-            Minecraft.getMinecraft().displayGuiScreen(new PathWaypointOverwiewUI());
+            McIf.mc().displayGuiScreen(new PathWaypointOverwiewUI());
         } else if (b == newBtn) {
-            Minecraft.getMinecraft().displayGuiScreen(new PathWaypointCreationUI());
+            McIf.mc().displayGuiScreen(new PathWaypointCreationUI());
         }
     }
 

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/WaypointCreationMenu.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/WaypointCreationMenu.java
@@ -57,8 +57,8 @@ public class WaypointCreationMenu extends UI {
     public WaypointCreationMenu(GuiScreen previousGui) {
         this.previousGui = previousGui;
 
-        initialX = Minecraft.getMinecraft().player.getPosition().getX();
-        initialZ = Minecraft.getMinecraft().player.getPosition().getZ();
+        initialX = McIf.mc().player.getPosition().getX();
+        initialZ = McIf.mc().player.getPosition().getZ();
     }
 
     // Create a waypoint at a position other than the current player's position
@@ -100,7 +100,7 @@ public class WaypointCreationMenu extends UI {
 
         xCoordField.setText(Integer.toString(initialX));
         zCoordField.setText(Integer.toString(initialZ));
-        yCoordField.setText(Integer.toString(Minecraft.getMinecraft().player.getPosition().getY()));
+        yCoordField.setText(Integer.toString(McIf.mc().player.getPosition().getY()));
 
         nameFieldLabel = new GuiLabel(mc.fontRenderer, 0, this.width/2 - 80, this.height/2 - 81, 40, 10, 0xFFFFFF);
         nameFieldLabel.addLine("Waypoint Name:");

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/WaypointCreationMenu.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/WaypointCreationMenu.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.map.overlays.ui;
 
+import com.wynntils.McIf;
 import com.wynntils.core.framework.rendering.ScreenRenderer;
 import com.wynntils.core.framework.rendering.colors.CommonColors;
 import com.wynntils.core.framework.rendering.colors.CustomColor;
@@ -80,10 +81,10 @@ public class WaypointCreationMenu extends UI {
     @Override public void onWindowUpdate() {
         buttonList.clear();
 
-        nameField = new GuiTextField(0, mc.fontRenderer, this.width/2 - 80, this.height/2 - 70, 160, 20);
-        xCoordField = new GuiTextField(1, mc.fontRenderer, this.width/2 - 65, this.height/2 - 30, 40, 20);
-        zCoordField = new GuiTextField(2, mc.fontRenderer, this.width/2 - 5, this.height/2 - 30, 40, 20);
-        yCoordField = new GuiTextField(3, mc.fontRenderer, this.width/2 + 55, this.height/2 - 30, 25, 20);
+        nameField = new GuiTextField(0, McIf.mc().fontRenderer, this.width/2 - 80, this.height/2 - 70, 160, 20);
+        xCoordField = new GuiTextField(1, McIf.mc().fontRenderer, this.width/2 - 65, this.height/2 - 30, 40, 20);
+        zCoordField = new GuiTextField(2, McIf.mc().fontRenderer, this.width/2 - 5, this.height/2 - 30, 40, 20);
+        yCoordField = new GuiTextField(3, McIf.mc().fontRenderer, this.width/2 + 55, this.height/2 - 30, 25, 20);
         buttonList.add(waypointTypeNext = new GuiButton(97, this.width/2 - 40, this.height/2 + 10, 18, 18, ">"));
         buttonList.add(waypointTypeBack = new GuiButton(98, this.width/2 - 80, this.height/2 + 10, 18, 18, "<"));
 
@@ -102,15 +103,15 @@ public class WaypointCreationMenu extends UI {
         zCoordField.setText(Integer.toString(initialZ));
         yCoordField.setText(Integer.toString(McIf.mc().player.getPosition().getY()));
 
-        nameFieldLabel = new GuiLabel(mc.fontRenderer, 0, this.width/2 - 80, this.height/2 - 81, 40, 10, 0xFFFFFF);
+        nameFieldLabel = new GuiLabel(McIf.mc().fontRenderer, 0, this.width/2 - 80, this.height/2 - 81, 40, 10, 0xFFFFFF);
         nameFieldLabel.addLine("Waypoint Name:");
-        xCoordFieldLabel = new GuiLabel(mc.fontRenderer, 1, this.width/2 - 75, this.height/2 - 24, 40, 10, 0xFFFFFF);
+        xCoordFieldLabel = new GuiLabel(McIf.mc().fontRenderer, 1, this.width/2 - 75, this.height/2 - 24, 40, 10, 0xFFFFFF);
         xCoordFieldLabel.addLine("X");
-        yCoordFieldLabel = new GuiLabel(mc.fontRenderer, 2, this.width/2 + 45, this.height/2 - 24, 40, 10, 0xFFFFFF);
+        yCoordFieldLabel = new GuiLabel(McIf.mc().fontRenderer, 2, this.width/2 + 45, this.height/2 - 24, 40, 10, 0xFFFFFF);
         yCoordFieldLabel.addLine("Y");
-        zCoordFieldLabel = new GuiLabel(mc.fontRenderer, 3, this.width/2 - 15, this.height/2 - 24, 40, 10, 0xFFFFFF);
+        zCoordFieldLabel = new GuiLabel(McIf.mc().fontRenderer, 3, this.width/2 - 15, this.height/2 - 24, 40, 10, 0xFFFFFF);
         zCoordFieldLabel.addLine("Z");
-        coordinatesLabel = new GuiLabel(mc.fontRenderer, 3, this.width/2 - 80, this.height/2 - 41, 40, 10, 0xFFFFFF);
+        coordinatesLabel = new GuiLabel(McIf.mc().fontRenderer, 3, this.width/2 - 80, this.height/2 - 41, 40, 10, 0xFFFFFF);
         coordinatesLabel.addLine("Coordinates:");
 
         boolean returning = state != null;  // true if reusing gui (i.e., returning from another gui)
@@ -217,11 +218,11 @@ public class WaypointCreationMenu extends UI {
         if (yCoordField != null) yCoordField.drawTextBox();
         if (zCoordField != null) zCoordField.drawTextBox();
 
-        nameFieldLabel.drawLabel(mc, mouseX, mouseY);
-        xCoordFieldLabel.drawLabel(mc, mouseX, mouseY);
-        yCoordFieldLabel.drawLabel(mc, mouseX, mouseY);
-        zCoordFieldLabel.drawLabel(mc, mouseX, mouseY);
-        coordinatesLabel.drawLabel(mc, mouseX, mouseY);
+        nameFieldLabel.drawLabel(McIf.mc(), mouseX, mouseY);
+        xCoordFieldLabel.drawLabel(McIf.mc(), mouseX, mouseY);
+        yCoordFieldLabel.drawLabel(McIf.mc(), mouseX, mouseY);
+        zCoordFieldLabel.drawLabel(McIf.mc(), mouseX, mouseY);
+        coordinatesLabel.drawLabel(McIf.mc(), mouseX, mouseY);
 
         fontRenderer.drawString("Icon:", this.width / 2.0f - 80, this.height / 2.0f, 0xFFFFFF, true);
         fontRenderer.drawString("Colour:", this.width / 2.0f, this.height / 2.0f, 0xFFFFFF, true);

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/WaypointCreationMenu.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/WaypointCreationMenu.java
@@ -58,8 +58,8 @@ public class WaypointCreationMenu extends UI {
     public WaypointCreationMenu(GuiScreen previousGui) {
         this.previousGui = previousGui;
 
-        initialX = McIf.mc().player.getPosition().getX();
-        initialZ = McIf.mc().player.getPosition().getZ();
+        initialX = McIf.player().getPosition().getX();
+        initialZ = McIf.player().getPosition().getZ();
     }
 
     // Create a waypoint at a position other than the current player's position
@@ -101,7 +101,7 @@ public class WaypointCreationMenu extends UI {
 
         xCoordField.setText(Integer.toString(initialX));
         zCoordField.setText(Integer.toString(initialZ));
-        yCoordField.setText(Integer.toString(McIf.mc().player.getPosition().getY()));
+        yCoordField.setText(Integer.toString(McIf.player().getPosition().getY()));
 
         nameFieldLabel = new GuiLabel(McIf.mc().fontRenderer, 0, this.width/2 - 80, this.height/2 - 81, 40, 10, 0xFFFFFF);
         nameFieldLabel.addLine("Waypoint Name:");

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/WaypointOverviewUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/WaypointOverviewUI.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.map.overlays.ui;
 
+import com.wynntils.McIf;
 import com.wynntils.core.framework.rendering.ScreenRenderer;
 import com.wynntils.core.framework.ui.elements.GuiButtonImageBetter;
 import com.wynntils.core.utils.Utils;

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/WaypointOverviewUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/WaypointOverviewUI.java
@@ -266,7 +266,7 @@ public class WaypointOverviewUI extends GuiScreen {
                 onWaypointChange();
             }
         } else if (b.id % 10 == 3) {
-            Minecraft.getMinecraft().displayGuiScreen(new WaypointCreationMenu(getWaypoints().get(b.id / 10 + page * pageHeight), this));
+            McIf.mc().displayGuiScreen(new WaypointCreationMenu(getWaypoints().get(b.id / 10 + page * pageHeight), this));
         } else if (b.id % 10 == 5) {
             MapConfig.Waypoints.INSTANCE.waypoints.remove(getWaypoints().get(b.id / 10 + page * pageHeight));
             onWaypointChange();

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/WorldMapSettingsUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/WorldMapSettingsUI.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.map.overlays.ui;
 
+import com.wynntils.McIf;
 import com.wynntils.core.framework.rendering.ScreenRenderer;
 import com.wynntils.core.framework.rendering.colors.CommonColors;
 import com.wynntils.core.framework.rendering.colors.CustomColor;
@@ -130,14 +131,14 @@ public class WorldMapSettingsUI extends GuiScreen {
     protected void mouseClicked(int mouseX, int mouseY, int mouseButton) throws IOException {
         if (mouseButton == 0 || mouseButton == 1) {
             for (Button btn : settingButtons) {
-                if (btn.mousePressed(mc, mouseX, mouseY)) {
+                if (btn.mousePressed(McIf.mc(), mouseX, mouseY)) {
                     btn.toggle(mouseX, mouseY, mouseButton == 1);
                     selectedButton = btn;
                     return;
                 }
             }
 
-            if (textureButton.mousePressed(mc, mouseX, mouseY)) {
+            if (textureButton.mousePressed(McIf.mc(), mouseX, mouseY)) {
                 selectedButton = textureButton;
                 int delta = mouseButton == 0 ? 1 : IconTexture.values().length - 1;
                 IconTexture newTexture = IconTexture.values()[(IconTexture.valueOf(textureButton.displayString).ordinal() + delta) % IconTexture.values().length];
@@ -287,7 +288,7 @@ public class WorldMapSettingsUI extends GuiScreen {
         }
 
         @Override
-        public void drawButton(Minecraft mc, int mouseX, int mouseY, float partialTicks) {
+        public void drawButton(Minecraft minecraft, int mouseX, int mouseY, float partialTicks) {
             if (!visible) {
                 this.hovered = false;
                 return;
@@ -304,7 +305,7 @@ public class WorldMapSettingsUI extends GuiScreen {
             icon.renderAt(renderer, x + height + (height * 0.375f), y + (height / 2f), miniScale, 1);
             CommonColors.WHITE.applyColor();
 
-            this.drawString(mc.fontRenderer, displayString, this.x + (int) (height * 1.75f) + 2, this.y + (this.height - mc.fontRenderer.FONT_HEIGHT) / 2, 0xFFFFFFFF);
+            this.drawString(minecraft.fontRenderer, displayString, this.x + (int) (height * 1.75f) + 2, this.y + (this.height - minecraft.fontRenderer.FONT_HEIGHT) / 2, 0xFFFFFFFF);
         }
 
     }

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/WorldMapSettingsUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/WorldMapSettingsUI.java
@@ -119,7 +119,7 @@ public class WorldMapSettingsUI extends GuiScreen {
 
     @Override
     protected void keyTyped(char typedChar, int keyCode) throws IOException {
-        if (keyCode == Minecraft.getMinecraft().gameSettings.keyBindInventory.getKeyCode() ||  // DEFAULT: E
+        if (keyCode == McIf.mc().gameSettings.keyBindInventory.getKeyCode() ||  // DEFAULT: E
                 keyCode == MapModule.getModule().getMapKey().getKeyBinding().getKeyCode()) {  // DEFAULT: M
             Utils.displayGuiScreen(new MainWorldMapUI());
         }

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/WorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/WorldMapUI.java
@@ -5,6 +5,7 @@
 package com.wynntils.modules.map.overlays.ui;
 
 import com.google.common.collect.Iterables;
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.framework.instances.GuiMovementScreen;
 import com.wynntils.core.framework.rendering.ScreenRenderer;
@@ -86,8 +87,6 @@ public class WorldMapUI extends GuiMovementScreen {
     }
 
     protected WorldMapUI(float startX, float startZ) {
-        mc = McIf.mc();
-
         // HeyZeer0: Handles the territories
         for (TerritoryProfile territory : WebManager.getTerritories().values()) {
             territories.put(territory.getFriendlyName(), new MapTerritory(territory).setRenderer(renderer));
@@ -179,8 +178,8 @@ public class WorldMapUI extends GuiMovementScreen {
     }
 
     protected void updateCenterPositionWithPlayerPosition() {
-        float newX = (float) mc.player.posX;
-        float newZ = (float) mc.player.posZ;
+        float newX = (float) McIf.mc().player.posX;
+        float newZ = (float) McIf.mc().player.posZ;
         if (newX == centerPositionX && newZ == centerPositionZ) return;
         updateCenterPosition(newX, newZ);
     }
@@ -313,8 +312,8 @@ public class WorldMapUI extends GuiMovementScreen {
 
         if (needToReset[0]) resetAllIcons();
 
-        float playerPositionX = (map.getTextureXPosition(mc.player.posX) - minX) / (maxX - minX);
-        float playerPositionZ = (map.getTextureZPosition(mc.player.posZ) - minZ) / (maxZ - minZ);
+        float playerPositionX = (map.getTextureXPosition(McIf.mc().player.posX) - minX) / (maxX - minX);
+        float playerPositionZ = (map.getTextureZPosition(McIf.mc().player.posZ) - minZ) / (maxZ - minZ);
 
         if (playerPositionX > 0 && playerPositionX < 1 && playerPositionZ > 0 && playerPositionZ < 1) {  // <--- player position
             playerPositionX = width * playerPositionX;
@@ -324,7 +323,7 @@ public class WorldMapUI extends GuiMovementScreen {
 
             pushMatrix();
             translate(drawingOrigin.x + playerPositionX, drawingOrigin.y + playerPositionZ, 0);
-            rotate(180 + MathHelper.fastFloor(mc.player.rotationYaw), 0, 0, 1);
+            rotate(180 + MathHelper.fastFloor(McIf.mc().player.rotationYaw), 0, 0, 1);
             translate(-drawingOrigin.x - playerPositionX, -drawingOrigin.y - playerPositionZ, 0);
 
             MapConfig.PointerType type = MapConfig.Textures.INSTANCE.pointerStyle;

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/WorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/WorldMapUI.java
@@ -82,11 +82,11 @@ public class WorldMapUI extends GuiMovementScreen {
     protected float outsideTextOpacity = 0f;
 
     protected WorldMapUI() {
-        this((float) Minecraft.getMinecraft().player.posX, (float) Minecraft.getMinecraft().player.posZ);
+        this((float) McIf.mc().player.posX, (float) McIf.mc().player.posZ);
     }
 
     protected WorldMapUI(float startX, float startZ) {
-        mc = Minecraft.getMinecraft();
+        mc = McIf.mc();
 
         // HeyZeer0: Handles the territories
         for (TerritoryProfile territory : WebManager.getTerritories().values()) {
@@ -105,7 +105,7 @@ public class WorldMapUI extends GuiMovementScreen {
         this.animationEnd = System.currentTimeMillis() + MapConfig.WorldMap.INSTANCE.animationLength;
 
         // Opening SFX
-        Minecraft.getMinecraft().getSoundHandler().playSound(
+        McIf.mc().getSoundHandler().playSound(
                 PositionedSoundRecord.getMasterRecord(SoundEvents.ITEM_ARMOR_EQUIP_LEATHER, 1f)
         );
     }

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/WorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/WorldMapUI.java
@@ -83,7 +83,7 @@ public class WorldMapUI extends GuiMovementScreen {
     protected float outsideTextOpacity = 0f;
 
     protected WorldMapUI() {
-        this((float) McIf.mc().player.posX, (float) McIf.mc().player.posZ);
+        this((float) McIf.player().posX, (float) McIf.player().posZ);
     }
 
     protected WorldMapUI(float startX, float startZ) {
@@ -178,8 +178,8 @@ public class WorldMapUI extends GuiMovementScreen {
     }
 
     protected void updateCenterPositionWithPlayerPosition() {
-        float newX = (float) McIf.mc().player.posX;
-        float newZ = (float) McIf.mc().player.posZ;
+        float newX = (float) McIf.player().posX;
+        float newZ = (float) McIf.player().posZ;
         if (newX == centerPositionX && newZ == centerPositionZ) return;
         updateCenterPosition(newX, newZ);
     }
@@ -312,8 +312,8 @@ public class WorldMapUI extends GuiMovementScreen {
 
         if (needToReset[0]) resetAllIcons();
 
-        float playerPositionX = (map.getTextureXPosition(McIf.mc().player.posX) - minX) / (maxX - minX);
-        float playerPositionZ = (map.getTextureZPosition(McIf.mc().player.posZ) - minZ) / (maxZ - minZ);
+        float playerPositionX = (map.getTextureXPosition(McIf.player().posX) - minX) / (maxX - minX);
+        float playerPositionZ = (map.getTextureZPosition(McIf.player().posZ) - minZ) / (maxZ - minZ);
 
         if (playerPositionX > 0 && playerPositionX < 1 && playerPositionZ > 0 && playerPositionZ < 1) {  // <--- player position
             playerPositionX = width * playerPositionX;
@@ -323,7 +323,7 @@ public class WorldMapUI extends GuiMovementScreen {
 
             pushMatrix();
             translate(drawingOrigin.x + playerPositionX, drawingOrigin.y + playerPositionZ, 0);
-            rotate(180 + MathHelper.fastFloor(McIf.mc().player.rotationYaw), 0, 0, 1);
+            rotate(180 + MathHelper.fastFloor(McIf.player().rotationYaw), 0, 0, 1);
             translate(-drawingOrigin.x - playerPositionX, -drawingOrigin.y - playerPositionZ, 0);
 
             MapConfig.PointerType type = MapConfig.Textures.INSTANCE.pointerStyle;

--- a/src/main/java/com/wynntils/modules/map/rendering/PointRenderer.java
+++ b/src/main/java/com/wynntils/modules/map/rendering/PointRenderer.java
@@ -39,11 +39,11 @@ public class PointRenderer {
 
     public static void drawTexturedLines(Texture texture, Long2ObjectMap<List<List<LootRunPath.LootRunPathLocation>>> points, Long2ObjectMap<List<List<Vector3d>>> directions, CustomColor color, float width) {
         List<ChunkPos> chunks = new ArrayList<>();
-        int renderDistance = Minecraft.getMinecraft().gameSettings.renderDistanceChunks;
+        int renderDistance = McIf.mc().gameSettings.renderDistanceChunks;
         for (int x = -renderDistance; x <= renderDistance; x++) {
             for (int z = -renderDistance; z <= renderDistance; z++) {
-                int playerChunkX = Minecraft.getMinecraft().player.chunkCoordX;
-                int playerChunkZ = Minecraft.getMinecraft().player.chunkCoordZ;
+                int playerChunkX = McIf.mc().player.chunkCoordX;
+                int playerChunkZ = McIf.mc().player.chunkCoordZ;
                 ChunkPos chunk = new ChunkPos(x + playerChunkX, z + playerChunkZ);
                 chunks.add(chunk);
             }
@@ -56,7 +56,7 @@ public class PointRenderer {
         texture.bind();
 
         for (ChunkPos chunk : chunks) {
-            if (!Minecraft.getMinecraft().world.isChunkGeneratedAt(chunk.x, chunk.z)) {
+            if (!McIf.mc().world.isChunkGeneratedAt(chunk.x, chunk.z)) {
                 continue;
             }
             List<List<LootRunPath.LootRunPathLocation>> pointsInChunk = points.get(ChunkPos.asLong(chunk.x, chunk.z));
@@ -69,7 +69,7 @@ public class PointRenderer {
                     List<Pair<LootRunPath.LootRunPathLocation, Vector3d>> toRender = new ArrayList<>();
                     for (int k = 0; k < pointsInRoute.size(); ++k) {
                         Point3d start = new Point3d(pointsInRoute.get(k).getLocation());
-                        World world = Minecraft.getMinecraft().world;
+                        World world = McIf.mc().world;
                         BlockPos minPos = new BlockPos(start.x - 0.3D, start.y - 1D, start.z - 0.3D);
                         BlockPos maxPos = new BlockPos(start.x + 0.3D, start.y - 1D, start.z + 0.3D);
                         Iterable<BlockPos> blocks = BlockPos.getAllInBox(minPos, maxPos);
@@ -203,7 +203,7 @@ public class PointRenderer {
     }
 
     private static void drawTexturedLine(Point3d start, Point3d end, float width) {
-        RenderManager renderManager = Minecraft.getMinecraft().getRenderManager();
+        RenderManager renderManager = McIf.mc().getRenderManager();
 
         Vector3d direction = new Vector3d(start);
         direction.sub(end);
@@ -251,17 +251,17 @@ public class PointRenderer {
         if (locations.isEmpty()) return;
 
         List<ChunkPos> chunks = new ArrayList<>();
-        int renderDistance = Minecraft.getMinecraft().gameSettings.renderDistanceChunks;
+        int renderDistance = McIf.mc().gameSettings.renderDistanceChunks;
         for (int x = -renderDistance; x <= renderDistance; x++) {
             for (int z = -renderDistance; z <= renderDistance; z++) {
-                int playerChunkX = Minecraft.getMinecraft().player.chunkCoordX;
-                int playerChunkZ = Minecraft.getMinecraft().player.chunkCoordZ;
+                int playerChunkX = McIf.mc().player.chunkCoordX;
+                int playerChunkZ = McIf.mc().player.chunkCoordZ;
                 ChunkPos chunk = new ChunkPos(x + playerChunkX, z + playerChunkZ);
                 chunks.add(chunk);
             }
         }
 
-        RenderManager renderManager = Minecraft.getMinecraft().getRenderManager();
+        RenderManager renderManager = McIf.mc().getRenderManager();
 
         GlStateManager.glLineWidth(3f);
         GlStateManager.depthMask(false);
@@ -277,7 +277,7 @@ public class PointRenderer {
 
         {
             for (ChunkPos chunkPos : chunks) {
-                if (!Minecraft.getMinecraft().world.isChunkGeneratedAt(chunkPos.x, chunkPos.z)) {
+                if (!McIf.mc().world.isChunkGeneratedAt(chunkPos.x, chunkPos.z)) {
                     continue;
                 }
                 List<List<LootRunPath.LootRunPathLocation>> locationsInChunk = locations.get(ChunkPos.asLong(chunkPos.x, chunkPos.z));
@@ -292,7 +292,7 @@ public class PointRenderer {
                             boolean pauseDraw = false;
                             BlockPos blockPos = loc.getLocation().toBlockPos();
 
-                            World world = Minecraft.getMinecraft().world;
+                            World world = McIf.mc().world;
 
                             if (!blockPos.equals(lastBlockPos)) {
                                 BlockPos minPos = new BlockPos(loc.getLocation().x - 0.3D, loc.getLocation().y - 1D, loc.getLocation().z - 0.3D);
@@ -375,9 +375,9 @@ public class PointRenderer {
     }
 
     public static void drawCube(BlockPos point, CustomColor color) {
-        if (!Minecraft.getMinecraft().world.isBlockLoaded(point, false)) return;
+        if (!McIf.mc().world.isBlockLoaded(point, false)) return;
 
-        RenderManager renderManager = Minecraft.getMinecraft().getRenderManager();
+        RenderManager renderManager = McIf.mc().getRenderManager();
 
         Location c = new Location(
             point.getX() - renderManager.viewerPosX,

--- a/src/main/java/com/wynntils/modules/map/rendering/PointRenderer.java
+++ b/src/main/java/com/wynntils/modules/map/rendering/PointRenderer.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.map.rendering;
 
+import com.wynntils.McIf;
 import com.wynntils.core.framework.rendering.colors.CommonColors;
 import com.wynntils.core.framework.rendering.colors.CustomColor;
 import com.wynntils.core.framework.rendering.textures.Texture;

--- a/src/main/java/com/wynntils/modules/map/rendering/PointRenderer.java
+++ b/src/main/java/com/wynntils/modules/map/rendering/PointRenderer.java
@@ -42,8 +42,8 @@ public class PointRenderer {
         int renderDistance = McIf.mc().gameSettings.renderDistanceChunks;
         for (int x = -renderDistance; x <= renderDistance; x++) {
             for (int z = -renderDistance; z <= renderDistance; z++) {
-                int playerChunkX = McIf.mc().player.chunkCoordX;
-                int playerChunkZ = McIf.mc().player.chunkCoordZ;
+                int playerChunkX = McIf.player().chunkCoordX;
+                int playerChunkZ = McIf.player().chunkCoordZ;
                 ChunkPos chunk = new ChunkPos(x + playerChunkX, z + playerChunkZ);
                 chunks.add(chunk);
             }
@@ -254,8 +254,8 @@ public class PointRenderer {
         int renderDistance = McIf.mc().gameSettings.renderDistanceChunks;
         for (int x = -renderDistance; x <= renderDistance; x++) {
             for (int z = -renderDistance; z <= renderDistance; z++) {
-                int playerChunkX = McIf.mc().player.chunkCoordX;
-                int playerChunkZ = McIf.mc().player.chunkCoordZ;
+                int playerChunkX = McIf.player().chunkCoordX;
+                int playerChunkZ = McIf.player().chunkCoordZ;
                 ChunkPos chunk = new ChunkPos(x + playerChunkX, z + playerChunkZ);
                 chunks.add(chunk);
             }

--- a/src/main/java/com/wynntils/modules/map/rendering/PointRenderer.java
+++ b/src/main/java/com/wynntils/modules/map/rendering/PointRenderer.java
@@ -56,7 +56,7 @@ public class PointRenderer {
         texture.bind();
 
         for (ChunkPos chunk : chunks) {
-            if (!McIf.mc().world.isChunkGeneratedAt(chunk.x, chunk.z)) {
+            if (!McIf.world().isChunkGeneratedAt(chunk.x, chunk.z)) {
                 continue;
             }
             List<List<LootRunPath.LootRunPathLocation>> pointsInChunk = points.get(ChunkPos.asLong(chunk.x, chunk.z));
@@ -69,7 +69,7 @@ public class PointRenderer {
                     List<Pair<LootRunPath.LootRunPathLocation, Vector3d>> toRender = new ArrayList<>();
                     for (int k = 0; k < pointsInRoute.size(); ++k) {
                         Point3d start = new Point3d(pointsInRoute.get(k).getLocation());
-                        World world = McIf.mc().world;
+                        World world = McIf.world();
                         BlockPos minPos = new BlockPos(start.x - 0.3D, start.y - 1D, start.z - 0.3D);
                         BlockPos maxPos = new BlockPos(start.x + 0.3D, start.y - 1D, start.z + 0.3D);
                         Iterable<BlockPos> blocks = BlockPos.getAllInBox(minPos, maxPos);
@@ -277,7 +277,7 @@ public class PointRenderer {
 
         {
             for (ChunkPos chunkPos : chunks) {
-                if (!McIf.mc().world.isChunkGeneratedAt(chunkPos.x, chunkPos.z)) {
+                if (!McIf.world().isChunkGeneratedAt(chunkPos.x, chunkPos.z)) {
                     continue;
                 }
                 List<List<LootRunPath.LootRunPathLocation>> locationsInChunk = locations.get(ChunkPos.asLong(chunkPos.x, chunkPos.z));
@@ -292,7 +292,7 @@ public class PointRenderer {
                             boolean pauseDraw = false;
                             BlockPos blockPos = loc.getLocation().toBlockPos();
 
-                            World world = McIf.mc().world;
+                            World world = McIf.world();
 
                             if (!blockPos.equals(lastBlockPos)) {
                                 BlockPos minPos = new BlockPos(loc.getLocation().x - 0.3D, loc.getLocation().y - 1D, loc.getLocation().z - 0.3D);
@@ -375,7 +375,7 @@ public class PointRenderer {
     }
 
     public static void drawCube(BlockPos point, CustomColor color) {
-        if (!McIf.mc().world.isBlockLoaded(point, false)) return;
+        if (!McIf.world().isBlockLoaded(point, false)) return;
 
         RenderManager renderManager = McIf.mc().getRenderManager();
 

--- a/src/main/java/com/wynntils/modules/music/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/music/events/ClientEvents.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.music.events;
 
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.*;
 import com.wynntils.core.framework.enums.ClassType;
@@ -73,7 +74,7 @@ public class ClientEvents implements Listener {
     public void dungeonTracks(PacketEvent<SPacketTitle> e) {
         if (!MusicConfig.INSTANCE.replaceJukebox || e.getPacket().getType() != SPacketTitle.Type.TITLE) return;
 
-        String title = TextFormatting.getTextWithoutFormattingCodes(e.getPacket().getMessage().getFormattedText());
+        String title = TextFormatting.getTextWithoutFormattingCodes(McIf.getFormattedText(e.getPacket().getMessage()));
         String songName = WebManager.getMusicLocations().getDungeonTrack(title);
         if (songName == null) return;
 

--- a/src/main/java/com/wynntils/modules/music/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/music/events/ClientEvents.java
@@ -93,20 +93,20 @@ public class ClientEvents implements Listener {
     public void areaTracks(SchedulerEvent.RegionUpdate e) {
         if (!MusicConfig.INSTANCE.replaceJukebox) return;
 
-        Minecraft.getMinecraft().addScheduledTask(BossTrackManager::update);
+        McIf.mc().addScheduledTask(BossTrackManager::update);
 
         if (BossTrackManager.isAlive()) return;
-        AreaTrackManager.update(new Location(Minecraft.getMinecraft().player));
+        AreaTrackManager.update(new Location(McIf.mc().player));
     }
 
     // mythic found sfx
     @SubscribeEvent
     public void onMythicFound(PacketEvent<SPacketWindowItems> e) {
         if (!MusicConfig.SoundEffects.INSTANCE.mythicFound) return;
-        if (Minecraft.getMinecraft().currentScreen == null) return;
-        if (!(Minecraft.getMinecraft().currentScreen instanceof ChestReplacer)) return;
+        if (McIf.mc().currentScreen == null) return;
+        if (!(McIf.mc().currentScreen instanceof ChestReplacer)) return;
 
-        ChestReplacer chest = (ChestReplacer) Minecraft.getMinecraft().currentScreen;
+        ChestReplacer chest = (ChestReplacer) McIf.mc().currentScreen;
         if (!chest.getLowerInv().getName().contains("Loot Chest") &&
                 !chest.getLowerInv().getName().contains("Daily Rewards") &&
                 !chest.getLowerInv().getName().contains("Objective Rewards")) return;

--- a/src/main/java/com/wynntils/modules/music/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/music/events/ClientEvents.java
@@ -96,7 +96,7 @@ public class ClientEvents implements Listener {
         McIf.mc().addScheduledTask(BossTrackManager::update);
 
         if (BossTrackManager.isAlive()) return;
-        AreaTrackManager.update(new Location(McIf.mc().player));
+        AreaTrackManager.update(new Location(McIf.player()));
     }
 
     // mythic found sfx

--- a/src/main/java/com/wynntils/modules/music/instances/MusicPlayer.java
+++ b/src/main/java/com/wynntils/modules/music/instances/MusicPlayer.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.music.instances;
 
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.MusicPlayerEvent;
 import com.wynntils.core.framework.FrameworkManager;
@@ -92,7 +93,7 @@ public class MusicPlayer {
         }
 
         // update the volume
-        float baseVolume = -36 + (36 * Minecraft.getMinecraft().gameSettings.getSoundLevel(SoundCategory.RECORDS));
+        float baseVolume = -36 + (36 * McIf.mc().gameSettings.getSoundLevel(SoundCategory.RECORDS));
         float expectedGain = (Display.isActive() && !STATUS.isCurrentQuiet()) ? baseVolume : Math.max(-30, baseVolume + MusicConfig.INSTANCE.focusOffset);
 
         if (STATUS.getCurrentGain() > expectedGain) {
@@ -150,7 +151,7 @@ public class MusicPlayer {
                 BufferedInputStream bis = new BufferedInputStream(fis);
 
                 // updating the volume
-                float baseVolume = -32 + (32 * Minecraft.getMinecraft().gameSettings.getSoundLevel(SoundCategory.RECORDS));
+                float baseVolume = -32 + (32 * McIf.mc().gameSettings.getSoundLevel(SoundCategory.RECORDS));
                 STATUS.setCurrentGain(STATUS.getCurrentSong().isFadeIn() ? -30f : baseVolume);
 
                 player = new AdvancedPlayer(bis, STATUS.getCurrentGain());

--- a/src/main/java/com/wynntils/modules/music/managers/BossTrackManager.java
+++ b/src/main/java/com/wynntils/modules/music/managers/BossTrackManager.java
@@ -36,7 +36,7 @@ public class BossTrackManager {
 
         // check if the boss is still alive
         Entity in = McIf.world().getEntityByID(bossEntityId);
-        if (in != null && Math.abs(McIf.mc().player.posY - in.posY) <= 15) return;
+        if (in != null && Math.abs(McIf.player().posY - in.posY) <= 15) return;
 
         // grace period for bosses that have multiple phases (somewhat a transition)
         if (gracePeriod == -1) gracePeriod = System.currentTimeMillis() + 3000;
@@ -59,7 +59,7 @@ public class BossTrackManager {
 
     private static boolean checkEntity(Entity entity, String name) {
         String soundTrack = WebManager.getMusicLocations().getBossTrack(name);
-        if (soundTrack == null || Math.abs(McIf.mc().player.posY - entity.posY) >= 15) return false;
+        if (soundTrack == null || Math.abs(McIf.player().posY - entity.posY) >= 15) return false;
 
         bossEntityId = entity.getEntityId();
         gracePeriod = -1;

--- a/src/main/java/com/wynntils/modules/music/managers/BossTrackManager.java
+++ b/src/main/java/com/wynntils/modules/music/managers/BossTrackManager.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.music.managers;
 
+import com.wynntils.McIf;
 import com.wynntils.modules.music.instances.QueuedTrack;
 import com.wynntils.webapi.WebManager;
 import net.minecraft.client.Minecraft;
@@ -23,7 +24,7 @@ public class BossTrackManager {
     private static QueuedTrack previousTrack = null;
 
     public static void update() {
-        for (Entity i : Minecraft.getMinecraft().world.loadedEntityList) {
+        for (Entity i : McIf.mc().world.loadedEntityList) {
             if (!i.hasCustomName()) continue;
 
             Matcher m = MOB_NAMETAG.matcher(TextFormatting.getTextWithoutFormattingCodes(i.getCustomNameTag()));
@@ -34,8 +35,8 @@ public class BossTrackManager {
         if (bossEntityId == -1) return;
 
         // check if the boss is still alive
-        Entity in = Minecraft.getMinecraft().world.getEntityByID(bossEntityId);
-        if (in != null && Math.abs(Minecraft.getMinecraft().player.posY - in.posY) <= 15) return;
+        Entity in = McIf.mc().world.getEntityByID(bossEntityId);
+        if (in != null && Math.abs(McIf.mc().player.posY - in.posY) <= 15) return;
 
         // grace period for bosses that have multiple phases (somewhat a transition)
         if (gracePeriod == -1) gracePeriod = System.currentTimeMillis() + 3000;
@@ -58,7 +59,7 @@ public class BossTrackManager {
 
     private static boolean checkEntity(Entity entity, String name) {
         String soundTrack = WebManager.getMusicLocations().getBossTrack(name);
-        if (soundTrack == null || Math.abs(Minecraft.getMinecraft().player.posY - entity.posY) >= 15) return false;
+        if (soundTrack == null || Math.abs(McIf.mc().player.posY - entity.posY) >= 15) return false;
 
         bossEntityId = entity.getEntityId();
         gracePeriod = -1;

--- a/src/main/java/com/wynntils/modules/music/managers/BossTrackManager.java
+++ b/src/main/java/com/wynntils/modules/music/managers/BossTrackManager.java
@@ -24,7 +24,7 @@ public class BossTrackManager {
     private static QueuedTrack previousTrack = null;
 
     public static void update() {
-        for (Entity i : McIf.mc().world.loadedEntityList) {
+        for (Entity i : McIf.world().loadedEntityList) {
             if (!i.hasCustomName()) continue;
 
             Matcher m = MOB_NAMETAG.matcher(TextFormatting.getTextWithoutFormattingCodes(i.getCustomNameTag()));
@@ -35,7 +35,7 @@ public class BossTrackManager {
         if (bossEntityId == -1) return;
 
         // check if the boss is still alive
-        Entity in = McIf.mc().world.getEntityByID(bossEntityId);
+        Entity in = McIf.world().getEntityByID(bossEntityId);
         if (in != null && Math.abs(McIf.mc().player.posY - in.posY) <= 15) return;
 
         // grace period for bosses that have multiple phases (somewhat a transition)

--- a/src/main/java/com/wynntils/modules/music/managers/SoundTrackManager.java
+++ b/src/main/java/com/wynntils/modules/music/managers/SoundTrackManager.java
@@ -177,9 +177,9 @@ public class SoundTrackManager {
 
         for (MusicProfile mp : availableMusics.values()) {
             if (!mp.getName().contains("(") || !mp.getName().contains(")")) continue;
-            Matcher mc = TERRITORY_NAME_REGEX.matcher(mp.getName());
-            while (mc.find()) {
-                String value = mc.group(1).replace("(", "").replace(")", "");
+            Matcher matcher = TERRITORY_NAME_REGEX.matcher(mp.getName());
+            while (matcher.find()) {
+                String value = matcher.group(1).replace("(", "").replace(")", "");
                 String toSearch = territoryName.contains(" ") ? territoryName.split(" ")[0] : territoryName;
 
                 if (value.equalsIgnoreCase(territoryName)) {  // perfect match

--- a/src/main/java/com/wynntils/modules/questbook/commands/CommandExportDiscoveries.java
+++ b/src/main/java/com/wynntils/modules/questbook/commands/CommandExportDiscoveries.java
@@ -4,7 +4,7 @@
 
 package com.wynntils.modules.questbook.commands;
 
-import com.wynntils.ModCore;
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.framework.FrameworkManager;
 import com.wynntils.core.framework.instances.PlayerInfo;
@@ -125,7 +125,7 @@ public class CommandExportDiscoveries extends CommandBase implements IClientComm
             fileText.getStyle().setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_FILE, exportFile.getCanonicalPath()));
             fileText.getStyle().setUnderlined(true);
             text.appendSibling(fileText);
-            ModCore.mc().addScheduledTask(() -> ModCore.mc().player.sendMessage(text));
+            McIf.mc().addScheduledTask(() -> McIf.mc().player.sendMessage(text));
         } catch (IOException ex) {
             ex.printStackTrace();
         } finally {

--- a/src/main/java/com/wynntils/modules/questbook/commands/CommandExportDiscoveries.java
+++ b/src/main/java/com/wynntils/modules/questbook/commands/CommandExportDiscoveries.java
@@ -125,7 +125,7 @@ public class CommandExportDiscoveries extends CommandBase implements IClientComm
             fileText.getStyle().setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_FILE, exportFile.getCanonicalPath()));
             fileText.getStyle().setUnderlined(true);
             text.appendSibling(fileText);
-            McIf.mc().addScheduledTask(() -> McIf.mc().player.sendMessage(text));
+            McIf.mc().addScheduledTask(() -> McIf.player().sendMessage(text));
         } catch (IOException ex) {
             ex.printStackTrace();
         } finally {

--- a/src/main/java/com/wynntils/modules/questbook/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/questbook/events/ClientEvents.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.questbook.events;
 
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.GameEvent;
 import com.wynntils.core.events.custom.PacketEvent;

--- a/src/main/java/com/wynntils/modules/questbook/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/questbook/events/ClientEvents.java
@@ -106,7 +106,7 @@ public class ClientEvents implements Listener {
     public void clickOnQuestBookItem(PacketEvent<CPacketPlayerTryUseItem> e) {
         if (!QuestBookConfig.INSTANCE.allowCustomQuestbook
                 || !Reference.onWorld || Reference.onNether || Reference.onWars
-                || McIf.mc().player.inventory.currentItem != 7) return;
+                || McIf.player().inventory.currentItem != 7) return;
 
         openQuestBook = true;
         e.setCanceled(true);
@@ -116,7 +116,7 @@ public class ClientEvents implements Listener {
     public void clickOnQuestBookItemOnBlock(PacketEvent<CPacketPlayerTryUseItemOnBlock> e) {
         if (!QuestBookConfig.INSTANCE.allowCustomQuestbook
                 || !Reference.onWorld || Reference.onNether || Reference.onWars
-                || McIf.mc().player.inventory.currentItem != 7) return;
+                || McIf.player().inventory.currentItem != 7) return;
 
         openQuestBook = true;
         e.setCanceled(true);
@@ -126,7 +126,7 @@ public class ClientEvents implements Listener {
     public void clickOnQuestBookEntity(PacketEvent<CPacketUseEntity> e) {
         if (!QuestBookConfig.INSTANCE.allowCustomQuestbook
                 || !Reference.onWorld || Reference.onNether || Reference.onWars
-                || McIf.mc().player.inventory.currentItem != 7) return;
+                || McIf.player().inventory.currentItem != 7) return;
 
         openQuestBook = true;
         e.setCanceled(true);
@@ -134,8 +134,8 @@ public class ClientEvents implements Listener {
 
     @SubscribeEvent
     public void updateQuestBook(TickEvent.ClientTickEvent e) {
-        if (e.phase == TickEvent.Phase.START || !Reference.onWorld || Reference.onNether || Reference.onWars || McIf.mc().player.inventory == null) return;
-        if (McIf.mc().player.inventory.getStackInSlot(7).isEmpty() || McIf.mc().player.inventory.getStackInSlot(7).getItem() != Items.WRITTEN_BOOK) return;
+        if (e.phase == TickEvent.Phase.START || !Reference.onWorld || Reference.onNether || Reference.onWars || McIf.player().inventory == null) return;
+        if (McIf.player().inventory.getStackInSlot(7).isEmpty() || McIf.player().inventory.getStackInSlot(7).getItem() != Items.WRITTEN_BOOK) return;
 
         if (!openQuestBook) return;
         openQuestBook = false;

--- a/src/main/java/com/wynntils/modules/questbook/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/questbook/events/ClientEvents.java
@@ -106,7 +106,7 @@ public class ClientEvents implements Listener {
     public void clickOnQuestBookItem(PacketEvent<CPacketPlayerTryUseItem> e) {
         if (!QuestBookConfig.INSTANCE.allowCustomQuestbook
                 || !Reference.onWorld || Reference.onNether || Reference.onWars
-                || Minecraft.getMinecraft().player.inventory.currentItem != 7) return;
+                || McIf.mc().player.inventory.currentItem != 7) return;
 
         openQuestBook = true;
         e.setCanceled(true);
@@ -116,7 +116,7 @@ public class ClientEvents implements Listener {
     public void clickOnQuestBookItemOnBlock(PacketEvent<CPacketPlayerTryUseItemOnBlock> e) {
         if (!QuestBookConfig.INSTANCE.allowCustomQuestbook
                 || !Reference.onWorld || Reference.onNether || Reference.onWars
-                || Minecraft.getMinecraft().player.inventory.currentItem != 7) return;
+                || McIf.mc().player.inventory.currentItem != 7) return;
 
         openQuestBook = true;
         e.setCanceled(true);
@@ -126,7 +126,7 @@ public class ClientEvents implements Listener {
     public void clickOnQuestBookEntity(PacketEvent<CPacketUseEntity> e) {
         if (!QuestBookConfig.INSTANCE.allowCustomQuestbook
                 || !Reference.onWorld || Reference.onNether || Reference.onWars
-                || Minecraft.getMinecraft().player.inventory.currentItem != 7) return;
+                || McIf.mc().player.inventory.currentItem != 7) return;
 
         openQuestBook = true;
         e.setCanceled(true);
@@ -134,8 +134,8 @@ public class ClientEvents implements Listener {
 
     @SubscribeEvent
     public void updateQuestBook(TickEvent.ClientTickEvent e) {
-        if (e.phase == TickEvent.Phase.START || !Reference.onWorld || Reference.onNether || Reference.onWars || Minecraft.getMinecraft().player.inventory == null) return;
-        if (Minecraft.getMinecraft().player.inventory.getStackInSlot(7).isEmpty() || Minecraft.getMinecraft().player.inventory.getStackInSlot(7).getItem() != Items.WRITTEN_BOOK) return;
+        if (e.phase == TickEvent.Phase.START || !Reference.onWorld || Reference.onNether || Reference.onWars || McIf.mc().player.inventory == null) return;
+        if (McIf.mc().player.inventory.getStackInSlot(7).isEmpty() || McIf.mc().player.inventory.getStackInSlot(7).getItem() != Items.WRITTEN_BOOK) return;
 
         if (!openQuestBook) return;
         openQuestBook = false;

--- a/src/main/java/com/wynntils/modules/questbook/instances/QuestBookPage.java
+++ b/src/main/java/com/wynntils/modules/questbook/instances/QuestBookPage.java
@@ -100,7 +100,7 @@ public class QuestBookPage extends GuiScreen {
         lastTick = Minecraft.getSystemTime();
 
         if (showSearchBar) {
-            textField = new GuiTextField(0, Minecraft.getMinecraft().fontRenderer, width / 2 + 32, height / 2 - 97, 113, 23);
+            textField = new GuiTextField(0, McIf.mc().fontRenderer, width / 2 + 32, height / 2 - 97, 113, 23);
             textField.setFocused(!QuestBookConfig.INSTANCE.searchBoxClickRequired);
             textField.setMaxStringLength(50);
             textField.setEnableBackgroundDrawing(false);
@@ -273,7 +273,7 @@ public class QuestBookPage extends GuiScreen {
         this.showAnimation = showAnimation;
 
         if (showAnimation) WynntilsSound.QUESTBOOK_OPENING.play(); // sfx
-        Minecraft.getMinecraft().displayGuiScreen(this);
+        McIf.mc().displayGuiScreen(this);
     }
 
     public void updateSearch() {

--- a/src/main/java/com/wynntils/modules/questbook/instances/QuestBookPage.java
+++ b/src/main/java/com/wynntils/modules/questbook/instances/QuestBookPage.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.questbook.instances;
 
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.framework.enums.wynntils.WynntilsSound;
 import com.wynntils.core.framework.rendering.ScreenRenderer;
@@ -54,7 +55,7 @@ public class QuestBookPage extends GuiScreen {
     protected long lastTick;
     protected boolean animationCompleted;
 
-    private long delay = Minecraft.getSystemTime();
+    private long delay = McIf.getSystemTime();
 
     // Colours
     protected static final CustomColor background_1 = CustomColor.fromInt(0x000000, 0.3f);
@@ -96,8 +97,8 @@ public class QuestBookPage extends GuiScreen {
         selected = 0;
         searchUpdate("");
         refreshAccepts();
-        time = Minecraft.getSystemTime();
-        lastTick = Minecraft.getSystemTime();
+        time = McIf.getSystemTime();
+        lastTick = McIf.getSystemTime();
 
         if (showSearchBar) {
             textField = new GuiTextField(0, McIf.mc().fontRenderer, width / 2 + 32, height / 2 - 97, 113, 23);
@@ -138,7 +139,7 @@ public class QuestBookPage extends GuiScreen {
         ScreenRenderer.beginGL(0, 0);
         {
             if (showAnimation) {
-                float animationTick = Easing.BACK_IN.ease((Minecraft.getSystemTime() - time) + 1000, 1f, 1f, 600f);
+                float animationTick = Easing.BACK_IN.ease((McIf.getSystemTime() - time) + 1000, 1f, 1f, 600f);
                 animationTick /= 10f;
 
                 if (animationTick <= 1) {
@@ -200,14 +201,14 @@ public class QuestBookPage extends GuiScreen {
     public void handleMouseInput() throws IOException {
         int mDWheel = Mouse.getEventDWheel() * CoreDBConfig.INSTANCE.scrollDirection.getScrollDirection();
 
-        if (mDWheel <= -1 && (Minecraft.getSystemTime() - delay >= 15)) {
+        if (mDWheel <= -1 && (McIf.getSystemTime() - delay >= 15)) {
             if (acceptNext) {
-                delay = Minecraft.getSystemTime();
+                delay = McIf.getSystemTime();
                 goForward();
             }
-        } else if (mDWheel >= 1 && (Minecraft.getSystemTime() - delay >= 15)) {
+        } else if (mDWheel >= 1 && (McIf.getSystemTime() - delay >= 15)) {
             if (acceptBack) {
-                delay = Minecraft.getSystemTime();
+                delay = McIf.getSystemTime();
                 goBack();
             }
         }

--- a/src/main/java/com/wynntils/modules/questbook/instances/QuestInfo.java
+++ b/src/main/java/com/wynntils/modules/questbook/instances/QuestInfo.java
@@ -95,8 +95,8 @@ public class QuestInfo {
 
         // friendly name
         friendlyName = this.name.replace("Mini-Quest - ", "");
-        if (Minecraft.getMinecraft().fontRenderer.getStringWidth(friendlyName) > 120) friendlyName += "...";
-        while (Minecraft.getMinecraft().fontRenderer.getStringWidth(friendlyName) > 120) {
+        if (McIf.mc().fontRenderer.getStringWidth(friendlyName) > 120) friendlyName += "...";
+        while (McIf.mc().fontRenderer.getStringWidth(friendlyName) > 120) {
             friendlyName = friendlyName.substring(0, friendlyName.length() - 4).trim() + "...";
         }
 

--- a/src/main/java/com/wynntils/modules/questbook/instances/QuestInfo.java
+++ b/src/main/java/com/wynntils/modules/questbook/instances/QuestInfo.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.questbook.instances;
 
+import com.wynntils.McIf;
 import com.wynntils.core.utils.ItemUtils;
 import com.wynntils.core.utils.StringUtils;
 import com.wynntils.core.utils.objects.Location;
@@ -102,7 +103,7 @@ public class QuestInfo {
 
         // location
         Matcher m = coordinatePattern.matcher(description);
-        if(m.find()) {
+        if (m.find()) {
             targetLocation = new Location(0, 0, 0);
 
             if(m.group(1) != null) targetLocation.setX(Integer.parseInt(m.group(1)));

--- a/src/main/java/com/wynntils/modules/questbook/managers/QuestManager.java
+++ b/src/main/java/com/wynntils/modules/questbook/managers/QuestManager.java
@@ -5,7 +5,7 @@
 package com.wynntils.modules.questbook.managers;
 
 
-import com.wynntils.ModCore;
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.framework.FrameworkManager;
 import com.wynntils.core.framework.enums.FilterType;
@@ -22,7 +22,6 @@ import com.wynntils.modules.questbook.enums.QuestStatus;
 import com.wynntils.modules.questbook.events.custom.QuestBookUpdateEvent;
 import com.wynntils.modules.questbook.instances.DiscoveryInfo;
 import com.wynntils.modules.questbook.instances.QuestInfo;
-import net.minecraft.client.Minecraft;
 import net.minecraft.inventory.ClickType;
 import net.minecraft.inventory.ContainerPlayer;
 import net.minecraft.item.ItemStack;
@@ -80,7 +79,7 @@ public class QuestManager {
     public static void readQuestBook() {
         if (!Reference.onWorld) return;
 
-        if (ModCore.mc().player.openContainer != null && !(ModCore.mc().player.openContainer instanceof ContainerPlayer)) {
+        if (McIf.mc().player.openContainer != null && !(McIf.mc().player.openContainer instanceof ContainerPlayer)) {
             interrupt();
             return;
         }

--- a/src/main/java/com/wynntils/modules/questbook/managers/QuestManager.java
+++ b/src/main/java/com/wynntils/modules/questbook/managers/QuestManager.java
@@ -79,7 +79,7 @@ public class QuestManager {
     public static void readQuestBook() {
         if (!Reference.onWorld) return;
 
-        if (McIf.mc().player.openContainer != null && !(McIf.mc().player.openContainer instanceof ContainerPlayer)) {
+        if (McIf.player().openContainer != null && !(McIf.player().openContainer instanceof ContainerPlayer)) {
             interrupt();
             return;
         }

--- a/src/main/java/com/wynntils/modules/questbook/managers/QuestManager.java
+++ b/src/main/java/com/wynntils/modules/questbook/managers/QuestManager.java
@@ -465,7 +465,7 @@ public class QuestManager {
 
     private static void sendMessage(String msg) {
         // Can be called from nio thread by FakeInventory
-        Minecraft.getMinecraft().addScheduledTask(() ->
+        McIf.mc().addScheduledTask(() ->
             ChatOverlay.getChat().printChatMessageWithOptionalDeletion(new TextComponentString(msg), MESSAGE_ID)
         );
     }

--- a/src/main/java/com/wynntils/modules/questbook/overlays/ui/DiscoveriesPage.java
+++ b/src/main/java/com/wynntils/modules/questbook/overlays/ui/DiscoveriesPage.java
@@ -317,19 +317,19 @@ public class DiscoveriesPage extends QuestBookPage {
                     case 0: // Left Click
                         if (QuestBookConfig.INSTANCE.spoilSecretDiscoveries.followsRule(overDiscovery.wasDiscovered())) {
                             locateSecretDiscovery(name, "compass");
-                            Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.BLOCK_ANVIL_PLACE, 1f));
+                            McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.BLOCK_ANVIL_PLACE, 1f));
                         }
                     break;
                     case 1: // Right Click
                         if (QuestBookConfig.INSTANCE.spoilSecretDiscoveries.followsRule(overDiscovery.wasDiscovered())) {
                             locateSecretDiscovery(name, "map");
-                            Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
+                            McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
                         }
                     break;
                     case 2: //Middle Click
                         String wikiUrl = "https://wynncraft.gamepedia.com/" + Utils.encodeForWikiTitle(name);
                         Utils.openUrl(wikiUrl);
-                        Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
+                        McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
                     break;
                 }
             } else if (overDiscovery.getGuildTerritoryProfile() != null) { // Guild territory actions
@@ -341,16 +341,16 @@ public class DiscoveriesPage extends QuestBookPage {
                 switch(mouseButton) {
                     case 0: // Left Click
                         CompassManager.setCompassLocation(new Location(x, 50, z));
-                        Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.BLOCK_ANVIL_PLACE, 1f));
+                        McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.BLOCK_ANVIL_PLACE, 1f));
                     break;
                     case 1: // Right Click
                         Utils.displayGuiScreen(new MainWorldMapUI(x, z));
-                        Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
+                        McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
                     break;
                     case 2: //Middle Click
                         Utils.displayGuiScreen(new MainWorldMapUI(x, z));
                         CompassManager.setCompassLocation(new Location(x, 50, z));
-                        Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
+                        McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
                     break;
                 }
             }
@@ -360,37 +360,37 @@ public class DiscoveriesPage extends QuestBookPage {
         checkForwardAndBackButtons(posX, posY);
 
         if (posX >= 100 && posX <= 130 && posY >= -45 && posY <= -15) { // Discovered Territory
-            Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
+            McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
             territory = !territory;
             updateSearch();
             return;
         } else if (posX >= 100 && posX <= 130 && posY >= -80 && posY <= -50) { // Undiscovered Territory
-            Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
+            McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
             undiscoveredTerritory = !undiscoveredTerritory;
             updateSearch();
             return;
         } else if (posX >= 65 && posX <= 95 && posY >= -45 && posY <= -15) { // Discovered World
-            Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
+            McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
             world = !world;
             updateSearch();
             return;
         } else if (posX >= 65 && posX <= 95 && posY >= -80 && posY <= -50) { // Undiscovered World
-            Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
+            McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
             undiscoveredWorld = !undiscoveredWorld;
             updateSearch();
             return;
         } else if (posX >= 30 && posX <= 60 && posY >= -45 && posY <= -15) { // Discovered Secret
-            Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
+            McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
             secret = !secret;
             updateSearch();
             return;
         } else if (posX >= 30 && posX <= 60 && posY >= -80 && posY <= -50) { // Undiscovered Secret
-            Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
+            McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
             undiscoveredSecret = !undiscoveredSecret;
             updateSearch();
             return;
         } else if (posX >= -157 && posX <= -147 && posY >= 89 && posY <= 99) { // Update Button
-            Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
+            McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
             QuestManager.updateAnalysis(EnumSet.of(AnalysePosition.DISCOVERIES, AnalysePosition.SECRET_DISCOVERIES), true, true);
             return;
         }
@@ -517,7 +517,7 @@ public class DiscoveriesPage extends QuestBookPage {
 
         handler.addAndDispatch(query.handleJsonObject(jsonOutput -> {
             if (jsonOutput.has("error")) { // Returns error if page does not exist
-                Minecraft.getMinecraft().player.sendMessage(new TextComponentString(TextFormatting.RED + "Unable to find discovery coordinates. (Wiki page not found)"));
+                McIf.mc().player.sendMessage(new TextComponentString(TextFormatting.RED + "Unable to find discovery coordinates. (Wiki page not found)"));
                 return true;
             }
 
@@ -536,12 +536,12 @@ public class DiscoveriesPage extends QuestBookPage {
                 x = Integer.parseInt(xlocation.substring(12, xend));
                 z = Integer.parseInt(zlocation.substring(12, zend));
             } catch (NumberFormatException e) {
-                Minecraft.getMinecraft().player.sendMessage(new TextComponentString(TextFormatting.RED + "Unable to find discovery coordinates. (Wiki template not located)"));
+                McIf.mc().player.sendMessage(new TextComponentString(TextFormatting.RED + "Unable to find discovery coordinates. (Wiki template not located)"));
                 return true;
             }
 
             if (x == 0 && z == 0) {
-                Minecraft.getMinecraft().player.sendMessage(new TextComponentString(TextFormatting.RED + "Unable to find discovery coordinates. (Wiki coordinates not located)"));
+                McIf.mc().player.sendMessage(new TextComponentString(TextFormatting.RED + "Unable to find discovery coordinates. (Wiki coordinates not located)"));
                 return true;
             }
 

--- a/src/main/java/com/wynntils/modules/questbook/overlays/ui/DiscoveriesPage.java
+++ b/src/main/java/com/wynntils/modules/questbook/overlays/ui/DiscoveriesPage.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.questbook.overlays.ui;
 
+import com.wynntils.McIf;
 import com.wynntils.core.framework.enums.wynntils.WynntilsSound;
 import com.wynntils.core.framework.instances.PlayerInfo;
 import com.wynntils.core.framework.instances.data.CharacterData;
@@ -304,7 +305,7 @@ public class DiscoveriesPage extends QuestBookPage {
 
     @Override
     public void mouseClicked(int mouseX, int mouseY, int mouseButton) throws IOException {
-        ScaledResolution res = new ScaledResolution(mc);
+        ScaledResolution res = new ScaledResolution(McIf.mc());
         int posX = ((res.getScaledWidth() / 2) - mouseX);
         int posY = ((res.getScaledHeight() / 2) - mouseY);
 

--- a/src/main/java/com/wynntils/modules/questbook/overlays/ui/DiscoveriesPage.java
+++ b/src/main/java/com/wynntils/modules/questbook/overlays/ui/DiscoveriesPage.java
@@ -518,7 +518,7 @@ public class DiscoveriesPage extends QuestBookPage {
 
         handler.addAndDispatch(query.handleJsonObject(jsonOutput -> {
             if (jsonOutput.has("error")) { // Returns error if page does not exist
-                McIf.mc().player.sendMessage(new TextComponentString(TextFormatting.RED + "Unable to find discovery coordinates. (Wiki page not found)"));
+                McIf.player().sendMessage(new TextComponentString(TextFormatting.RED + "Unable to find discovery coordinates. (Wiki page not found)"));
                 return true;
             }
 
@@ -537,12 +537,12 @@ public class DiscoveriesPage extends QuestBookPage {
                 x = Integer.parseInt(xlocation.substring(12, xend));
                 z = Integer.parseInt(zlocation.substring(12, zend));
             } catch (NumberFormatException e) {
-                McIf.mc().player.sendMessage(new TextComponentString(TextFormatting.RED + "Unable to find discovery coordinates. (Wiki template not located)"));
+                McIf.player().sendMessage(new TextComponentString(TextFormatting.RED + "Unable to find discovery coordinates. (Wiki template not located)"));
                 return true;
             }
 
             if (x == 0 && z == 0) {
-                McIf.mc().player.sendMessage(new TextComponentString(TextFormatting.RED + "Unable to find discovery coordinates. (Wiki coordinates not located)"));
+                McIf.player().sendMessage(new TextComponentString(TextFormatting.RED + "Unable to find discovery coordinates. (Wiki coordinates not located)"));
                 return true;
             }
 

--- a/src/main/java/com/wynntils/modules/questbook/overlays/ui/DiscoveriesPage.java
+++ b/src/main/java/com/wynntils/modules/questbook/overlays/ui/DiscoveriesPage.java
@@ -192,14 +192,14 @@ public class DiscoveriesPage extends QuestBookPage {
 
                     if (posX >= -146 && posX <= -13 && posY >= 87 - currentY && posY <= 96 - currentY && !showAnimation) {
                         if (lastTick == 0 && !animationCompleted) {
-                            lastTick = Minecraft.getSystemTime();
+                            lastTick = McIf.getSystemTime();
                         }
 
                         this.selected = i;
 
                         int animationTick;
                         if (!animationCompleted) {
-                            animationTick = (int) (Minecraft.getSystemTime() - lastTick) / 2;
+                            animationTick = (int) (McIf.getSystemTime() - lastTick) / 2;
                             if (animationTick >= 133) {
                                 animationCompleted = true;
                                 animationTick = 133;

--- a/src/main/java/com/wynntils/modules/questbook/overlays/ui/HUDConfigPage.java
+++ b/src/main/java/com/wynntils/modules/questbook/overlays/ui/HUDConfigPage.java
@@ -4,7 +4,7 @@
 
 package com.wynntils.modules.questbook.overlays.ui;
 
-import com.wynntils.ModCore;
+import com.wynntils.McIf;
 import com.wynntils.core.framework.settings.ui.OverlayPositionsUI;
 import com.wynntils.core.framework.ui.UI;
 import com.wynntils.modules.questbook.instances.IconContainer;
@@ -21,9 +21,9 @@ public class HUDConfigPage extends QuestBookPage {
 
     @Override
     public void open(boolean showAnimation) {
-        OverlayPositionsUI ui = new OverlayPositionsUI(ModCore.mc().currentScreen);
+        OverlayPositionsUI ui = new OverlayPositionsUI(McIf.mc().currentScreen);
         UI.setupUI(ui);
-        ModCore.mc().displayGuiScreen(ui);
+        McIf.mc().displayGuiScreen(ui);
     }
 
     @Override

--- a/src/main/java/com/wynntils/modules/questbook/overlays/ui/ItemPage.java
+++ b/src/main/java/com/wynntils/modules/questbook/overlays/ui/ItemPage.java
@@ -213,7 +213,7 @@ public class ItemPage extends QuestBookPage {
         checkForwardAndBackButtons(posX, posY);
 
         if (posX >= -157 && posX <= -147 && posY >= 89 && posY <= 99) { // search mode toggle button
-            Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
+            McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
             if (QuestBookConfig.INSTANCE.advancedItemSearch) {
                 QuestBookConfig.INSTANCE.advancedItemSearch = false;
                 initBasicSearch();
@@ -411,19 +411,19 @@ public class ItemPage extends QuestBookPage {
             switch (selected) { // is one of the sorting buttons hovered?
                 case 1:
                     if (sortFunction != SortFunction.ALPHABETICAL) {
-                        Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
+                        McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
                         sortFunction = SortFunction.ALPHABETICAL;
                     }
                     return true;
                 case 2:
                     if (sortFunction != SortFunction.BY_LEVEL) {
-                        Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
+                        McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
                         sortFunction = SortFunction.BY_LEVEL;
                     }
                     return true;
                 case 3:
                     if (sortFunction != SortFunction.BY_RARITY) {
-                        Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
+                        McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
                         sortFunction = SortFunction.BY_RARITY;
                     }
                     return true;
@@ -444,7 +444,7 @@ public class ItemPage extends QuestBookPage {
             } else {
                 allowedTypes.add(selectedType);
             }
-            Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
+            McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
 
             return true;
         }

--- a/src/main/java/com/wynntils/modules/questbook/overlays/ui/ItemPage.java
+++ b/src/main/java/com/wynntils/modules/questbook/overlays/ui/ItemPage.java
@@ -5,6 +5,7 @@
 package com.wynntils.modules.questbook.overlays.ui;
 
 import com.google.common.collect.ImmutableList;
+import com.wynntils.McIf;
 import com.wynntils.core.framework.enums.SortDirection;
 import com.wynntils.core.framework.enums.wynntils.WynntilsSound;
 import com.wynntils.core.framework.rendering.ScreenRenderer;
@@ -205,7 +206,7 @@ public class ItemPage extends QuestBookPage {
 
     @Override
     public void mouseClicked(int mouseX, int mouseY, int mouseButton) throws IOException {
-        ScaledResolution res = new ScaledResolution(mc);
+        ScaledResolution res = new ScaledResolution(McIf.mc());
         int posX = ((res.getScaledWidth() / 2) - mouseX);
         int posY = ((res.getScaledHeight() / 2) - mouseY);
 

--- a/src/main/java/com/wynntils/modules/questbook/overlays/ui/LootRunPage.java
+++ b/src/main/java/com/wynntils/modules/questbook/overlays/ui/LootRunPage.java
@@ -319,11 +319,11 @@ public class LootRunPage extends QuestBookPage {
     }
 
     public String getFriendlyName(String str, int width) {
-        if (!(Minecraft.getMinecraft().fontRenderer.getStringWidth(str) > width)) return str;
+        if (!(McIf.mc().fontRenderer.getStringWidth(str) > width)) return str;
 
         str += "...";
 
-        while (Minecraft.getMinecraft().fontRenderer.getStringWidth(str) > width) {
+        while (McIf.mc().fontRenderer.getStringWidth(str) > width) {
             str = str.substring(0, str.length() - 4).trim() + "...";
         }
 
@@ -363,11 +363,11 @@ public class LootRunPage extends QuestBookPage {
                             Location start = LootRunManager.getActivePath().getPoints().get(0);
                             String startingPointMsg = "Loot run " + LootRunManager.getActivePathName() + " starts at [" + (int) start.getX() + ", " + (int) start.getZ() + "]";
 
-                            Minecraft.getMinecraft().addScheduledTask(() ->
+                            McIf.mc().addScheduledTask(() ->
                                     ChatOverlay.getChat().printChatMessageWithOptionalDeletion(new TextComponentString(startingPointMsg), MESSAGE_ID)
                             );
 
-                            Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.BLOCK_ANVIL_PLACE, 1f));
+                            McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.BLOCK_ANVIL_PLACE, 1f));
                         } catch (Exception e) {
                             e.printStackTrace();
                         }
@@ -380,7 +380,7 @@ public class LootRunPage extends QuestBookPage {
                 if (result) {
                     names.remove(selected);
                     updateSelected();
-                    Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.ENTITY_IRONGOLEM_HURT, 1f));
+                    McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.ENTITY_IRONGOLEM_HURT, 1f));
                 }
 
                 return;

--- a/src/main/java/com/wynntils/modules/questbook/overlays/ui/LootRunPage.java
+++ b/src/main/java/com/wynntils/modules/questbook/overlays/ui/LootRunPage.java
@@ -201,14 +201,14 @@ public class LootRunPage extends QuestBookPage {
                     int animationTick = -1;
                     if (hovered && !showAnimation) {
                         if (lastTick == 0 && !animationCompleted) {
-                            lastTick = Minecraft.getSystemTime();
+                            lastTick = McIf.getSystemTime();
                         }
 
                         selected = i;
                         selectedName = currentName;
 
                         if (!animationCompleted) {
-                            animationTick = (int) (Minecraft.getSystemTime() - lastTick) / 2;
+                            animationTick = (int) (McIf.getSystemTime() - lastTick) / 2;
                             if (animationTick >= 133 && !toCrop) {
                                 animationCompleted = true;
                                 animationTick = 133;
@@ -217,7 +217,7 @@ public class LootRunPage extends QuestBookPage {
                             //reset animation to wait for scroll
                             if (toCrop) {
                                 animationCompleted = false;
-                                lastTick = Minecraft.getSystemTime() - 133 * 2;
+                                lastTick = McIf.getSystemTime() - 133 * 2;
                             }
 
                             animationTick = 133;

--- a/src/main/java/com/wynntils/modules/questbook/overlays/ui/LootRunPage.java
+++ b/src/main/java/com/wynntils/modules/questbook/overlays/ui/LootRunPage.java
@@ -1,5 +1,6 @@
 package com.wynntils.modules.questbook.overlays.ui;
 
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.framework.rendering.ScreenRenderer;
 import com.wynntils.core.framework.rendering.SmartFontRenderer;
@@ -337,7 +338,7 @@ public class LootRunPage extends QuestBookPage {
 
     @Override
     public void mouseClicked(int mouseX, int mouseY, int mouseButton) throws IOException {
-        ScaledResolution res = new ScaledResolution(mc);
+        ScaledResolution res = new ScaledResolution(McIf.mc());
         int posX = ((res.getScaledWidth() / 2) - mouseX);
         int posY = ((res.getScaledHeight() / 2) - mouseY);
 

--- a/src/main/java/com/wynntils/modules/questbook/overlays/ui/MainPage.java
+++ b/src/main/java/com/wynntils/modules/questbook/overlays/ui/MainPage.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.questbook.overlays.ui;
 
+import com.wynntils.McIf;
 import com.wynntils.core.framework.enums.wynntils.WynntilsSound;
 import com.wynntils.core.framework.instances.PlayerInfo;
 import com.wynntils.core.framework.instances.data.CharacterData;

--- a/src/main/java/com/wynntils/modules/questbook/overlays/ui/MainPage.java
+++ b/src/main/java/com/wynntils/modules/questbook/overlays/ui/MainPage.java
@@ -52,7 +52,7 @@ public class MainPage extends QuestBookPage {
             if (posY >= 109) up = 109;
             if (posY <= -109) up = -109;
 
-            GuiInventory.drawEntityOnScreen(x + 80, y + 30, 30, right, up, Minecraft.getMinecraft().player);
+            GuiInventory.drawEntityOnScreen(x + 80, y + 30, 30, right, up, McIf.mc().player);
         }
         ScreenRenderer.endGL();
 
@@ -66,7 +66,7 @@ public class MainPage extends QuestBookPage {
             else
                 guild = "";
             render.drawString(TextFormatting.DARK_AQUA + guild, x + 80, y - 53, CommonColors.CYAN, SmartFontRenderer.TextAlignment.MIDDLE, SmartFontRenderer.TextShadow.NONE);
-            render.drawString(Minecraft.getMinecraft().player.getName(), x + 80, y - 43, CommonColors.BLACK, SmartFontRenderer.TextAlignment.MIDDLE, SmartFontRenderer.TextShadow.NONE);
+            render.drawString(McIf.mc().player.getName(), x + 80, y - 43, CommonColors.BLACK, SmartFontRenderer.TextAlignment.MIDDLE, SmartFontRenderer.TextShadow.NONE);
             render.drawString(PlayerInfo.get(CharacterData.class).getCurrentClass().toString() + " Level " + PlayerInfo.get(CharacterData.class).getLevel(), x + 80, y + 40, CommonColors.PURPLE, SmartFontRenderer.TextAlignment.MIDDLE, SmartFontRenderer.TextShadow.NONE);
             render.drawString("In Development", x + 80, y + 50, CommonColors.RED, SmartFontRenderer.TextAlignment.MIDDLE, SmartFontRenderer.TextShadow.NONE);
             render.drawString(WebManager.getCurrentSplash(), x + 82, y + 70, CommonColors.RAINBOW, SmartFontRenderer.TextAlignment.MIDDLE, SmartFontRenderer.TextShadow.NONE);

--- a/src/main/java/com/wynntils/modules/questbook/overlays/ui/MainPage.java
+++ b/src/main/java/com/wynntils/modules/questbook/overlays/ui/MainPage.java
@@ -52,7 +52,7 @@ public class MainPage extends QuestBookPage {
             if (posY >= 109) up = 109;
             if (posY <= -109) up = -109;
 
-            GuiInventory.drawEntityOnScreen(x + 80, y + 30, 30, right, up, McIf.mc().player);
+            GuiInventory.drawEntityOnScreen(x + 80, y + 30, 30, right, up, McIf.player());
         }
         ScreenRenderer.endGL();
 
@@ -66,7 +66,7 @@ public class MainPage extends QuestBookPage {
             else
                 guild = "";
             render.drawString(TextFormatting.DARK_AQUA + guild, x + 80, y - 53, CommonColors.CYAN, SmartFontRenderer.TextAlignment.MIDDLE, SmartFontRenderer.TextShadow.NONE);
-            render.drawString(McIf.mc().player.getName(), x + 80, y - 43, CommonColors.BLACK, SmartFontRenderer.TextAlignment.MIDDLE, SmartFontRenderer.TextShadow.NONE);
+            render.drawString(McIf.player().getName(), x + 80, y - 43, CommonColors.BLACK, SmartFontRenderer.TextAlignment.MIDDLE, SmartFontRenderer.TextShadow.NONE);
             render.drawString(PlayerInfo.get(CharacterData.class).getCurrentClass().toString() + " Level " + PlayerInfo.get(CharacterData.class).getLevel(), x + 80, y + 40, CommonColors.PURPLE, SmartFontRenderer.TextAlignment.MIDDLE, SmartFontRenderer.TextShadow.NONE);
             render.drawString("In Development", x + 80, y + 50, CommonColors.RED, SmartFontRenderer.TextAlignment.MIDDLE, SmartFontRenderer.TextShadow.NONE);
             render.drawString(WebManager.getCurrentSplash(), x + 82, y + 70, CommonColors.RAINBOW, SmartFontRenderer.TextAlignment.MIDDLE, SmartFontRenderer.TextShadow.NONE);

--- a/src/main/java/com/wynntils/modules/questbook/overlays/ui/QuestsPage.java
+++ b/src/main/java/com/wynntils/modules/questbook/overlays/ui/QuestsPage.java
@@ -106,13 +106,13 @@ public class QuestsPage extends QuestBookPage {
                     int animationTick = -1;
                     if (posX >= -146 && posX <= -13 && posY >= 87 - currentY && posY <= 96 - currentY && !showAnimation) {
                         if (lastTick == 0 && !animationCompleted) {
-                            lastTick = Minecraft.getSystemTime();
+                            lastTick = McIf.getSystemTime();
                         }
 
                         this.selected = i;
 
                         if (!animationCompleted) {
-                            animationTick = (int) (Minecraft.getSystemTime() - lastTick) / 2;
+                            animationTick = (int) (McIf.getSystemTime() - lastTick) / 2;
                             if (animationTick >= 133 && selected.getFriendlyName().equals(selected.getName())) {
                                 animationCompleted = true;
                                 animationTick = 133;
@@ -120,7 +120,7 @@ public class QuestsPage extends QuestBookPage {
                         } else {
                             if (!selected.getFriendlyName().equals(selected.getName())) {
                                 animationCompleted = false;
-                                lastTick = Minecraft.getSystemTime() - 133 * 2;
+                                lastTick = McIf.getSystemTime() - 133 * 2;
                             }
 
                             animationTick = 133;

--- a/src/main/java/com/wynntils/modules/questbook/overlays/ui/QuestsPage.java
+++ b/src/main/java/com/wynntils/modules/questbook/overlays/ui/QuestsPage.java
@@ -267,14 +267,14 @@ public class QuestsPage extends QuestBookPage {
 
                 if (QuestManager.getTrackedQuest() != null && QuestManager.getTrackedQuest().getName().equals(overQuest.getName())) {
                     QuestManager.setTrackedQuest(null);
-                    Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.ENTITY_IRONGOLEM_HURT, 1f));
+                    McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.ENTITY_IRONGOLEM_HURT, 1f));
                     return;
                 }
-                Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.BLOCK_ANVIL_PLACE, 1f));
+                McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.BLOCK_ANVIL_PLACE, 1f));
                 QuestManager.setTrackedQuest(overQuest);
                 return;
             } else if (mouseButton == 1) { // right click
-                Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
+                McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
 
                 final String baseUrl = "https://wynncraft.gamepedia.com/";
 
@@ -312,17 +312,17 @@ public class QuestsPage extends QuestBookPage {
         checkForwardAndBackButtons(posX, posY);
 
         if (posX >= 71 && posX <= 87 && posY >= 84 && posY <= 100) { // Mini-Quest Switcher
-            Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
+            McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
             showingMiniQuests = !showingMiniQuests;
             textField.setText("");
             updateSearch();
             return;
         } else if (posX >= -157 && posX <= -147 && posY >= 89 && posY <= 99) { // Update Data
-            Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
+            McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
             QuestManager.updateAllAnalyses(true);
             return;
         } else if (-11 <= posX && posX <= -1 && 89 <= posY && posY <= 99 && (mouseButton == 0 || mouseButton == 1)) { // Change Sort Method
-            Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
+            McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
             sort = SortMethod.values()[(sort.ordinal() + (mouseButton == 0 ? 1 : SortMethod.values().length - 1)) % SortMethod.values().length];
             updateSearch();
             return;
@@ -381,7 +381,7 @@ public class QuestsPage extends QuestBookPage {
                 "Sort by Level", // Replace with translation keys during l10n
                 "Lowest level quests first")),
         DISTANCE(Comparator.comparing(QuestInfo::getStatus).thenComparingLong(q -> {
-            EntityPlayerSP player = Minecraft.getMinecraft().player;
+            EntityPlayerSP player = McIf.mc().player;
             if (player == null || !q.hasTargetLocation()) {
                 return 0;
             }

--- a/src/main/java/com/wynntils/modules/questbook/overlays/ui/QuestsPage.java
+++ b/src/main/java/com/wynntils/modules/questbook/overlays/ui/QuestsPage.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.questbook.overlays.ui;
 
+import com.wynntils.McIf;
 import com.wynntils.core.framework.enums.wynntils.WynntilsSound;
 import com.wynntils.core.framework.rendering.ScreenRenderer;
 import com.wynntils.core.framework.rendering.SmartFontRenderer;
@@ -255,7 +256,7 @@ public class QuestsPage extends QuestBookPage {
 
     @Override
     public void mouseClicked(int mouseX, int mouseY, int mouseButton) throws IOException {
-        ScaledResolution res = new ScaledResolution(mc);
+        ScaledResolution res = new ScaledResolution(McIf.mc());
         int posX = ((res.getScaledWidth() / 2) - mouseX);
         int posY = ((res.getScaledHeight() / 2) - mouseY);
 

--- a/src/main/java/com/wynntils/modules/questbook/overlays/ui/QuestsPage.java
+++ b/src/main/java/com/wynntils/modules/questbook/overlays/ui/QuestsPage.java
@@ -382,7 +382,7 @@ public class QuestsPage extends QuestBookPage {
                 "Sort by Level", // Replace with translation keys during l10n
                 "Lowest level quests first")),
         DISTANCE(Comparator.comparing(QuestInfo::getStatus).thenComparingLong(q -> {
-            EntityPlayerSP player = McIf.mc().player;
+            EntityPlayerSP player = McIf.player();
             if (player == null || !q.hasTargetLocation()) {
                 return 0;
             }

--- a/src/main/java/com/wynntils/modules/questbook/overlays/ui/SettingsPage.java
+++ b/src/main/java/com/wynntils/modules/questbook/overlays/ui/SettingsPage.java
@@ -4,7 +4,7 @@
 
 package com.wynntils.modules.questbook.overlays.ui;
 
-import com.wynntils.ModCore;
+import com.wynntils.McIf;
 import com.wynntils.core.framework.settings.ui.SettingsUI;
 import com.wynntils.modules.questbook.instances.IconContainer;
 import com.wynntils.modules.questbook.instances.QuestBookPage;
@@ -20,7 +20,7 @@ public class SettingsPage extends QuestBookPage {
 
     @Override
     public void open(boolean showAnimation) {
-        ModCore.mc().displayGuiScreen(SettingsUI.getInstance(ModCore.mc().currentScreen));
+        McIf.mc().displayGuiScreen(SettingsUI.getInstance(McIf.mc().currentScreen));
     }
 
     @Override

--- a/src/main/java/com/wynntils/modules/richpresence/events/RPCJoinHandler.java
+++ b/src/main/java/com/wynntils/modules/richpresence/events/RPCJoinHandler.java
@@ -68,11 +68,11 @@ public class RPCJoinHandler implements IDiscordActivityEvents.on_activity_join_c
         if (Reference.onWorld) {
             if (Reference.getUserWorld().replace("WC", "").replace("HB", "").equals(Integer.toString(lastSecret.getWorld())) && Reference.getUserWorld().replaceAll("\\d+", "").equals(lastSecret.getWorldType())) {
                 sentInvite = true;
-                McIf.mc().player.sendChatMessage("/msg " + lastSecret.getOwner() + " " + lastSecret.getRandomHash());
+                McIf.player().sendChatMessage("/msg " + lastSecret.getOwner() + " " + lastSecret.getRandomHash());
                 return;
             }
 
-            McIf.mc().player.sendChatMessage("/hub");
+            McIf.player().sendChatMessage("/hub");
             waitingLobby = true;
             return;
         }
@@ -95,7 +95,7 @@ public class RPCJoinHandler implements IDiscordActivityEvents.on_activity_join_c
         if (!waitingInvite) return;
         sentInvite = true;
         waitingInvite = false;
-        McIf.mc().player.sendChatMessage("/msg " + lastSecret.getOwner() + " " + lastSecret.getRandomHash());
+        McIf.player().sendChatMessage("/msg " + lastSecret.getOwner() + " " + lastSecret.getRandomHash());
     }
 
     @SubscribeEvent
@@ -104,14 +104,14 @@ public class RPCJoinHandler implements IDiscordActivityEvents.on_activity_join_c
 
         // handles the invitation
         if (lastSecret != null && McIf.getUnformattedText(e.getMessage()).startsWith("You have been invited to join " + lastSecret.getOwner())) {
-            McIf.mc().player.sendChatMessage("/party join " + lastSecret.getOwner());
+            McIf.player().sendChatMessage("/party join " + lastSecret.getOwner());
 
             lastSecret = null;
             return;
         }
 
         // handles the user join
-        if (sentInvite && McIf.getUnformattedText(e.getMessage()).startsWith("[" + McIf.mc().player.getName())) {
+        if (sentInvite && McIf.getUnformattedText(e.getMessage()).startsWith("[" + McIf.player().getName())) {
             sentInvite = false;
             e.setCanceled(true);
             return;
@@ -131,7 +131,7 @@ public class RPCJoinHandler implements IDiscordActivityEvents.on_activity_join_c
                 return;
 
             e.setCanceled(true);
-            McIf.mc().player.sendChatMessage("/party invite " + user);
+            McIf.player().sendChatMessage("/party invite " + user);
         }
     }
 

--- a/src/main/java/com/wynntils/modules/richpresence/events/RPCJoinHandler.java
+++ b/src/main/java/com/wynntils/modules/richpresence/events/RPCJoinHandler.java
@@ -141,7 +141,7 @@ public class RPCJoinHandler implements IDiscordActivityEvents.on_activity_join_c
         if ((text.equals("You are already connected to this server!") || text.equals("You're rejoining too quickly! Give us a moment to save your data.")) && waitingInvite) {
             waitingLobby = true;
             waitingInvite = false;
-            delayTime = Minecraft.getSystemTime() + 2000;
+            delayTime = McIf.getSystemTime() + 2000;
         }
     }
 

--- a/src/main/java/com/wynntils/modules/richpresence/events/RPCJoinHandler.java
+++ b/src/main/java/com/wynntils/modules/richpresence/events/RPCJoinHandler.java
@@ -59,7 +59,7 @@ public class RPCJoinHandler implements IDiscordActivityEvents.on_activity_join_c
 
         RichPresenceModule.getModule().getRichPresence().setJoinSecret(lastSecret);
 
-        Minecraft mc = Minecraft.getMinecraft();
+        Minecraft mc = McIf.mc();
 
         if (!Reference.onServer) {
             ServerData serverData = ServerUtils.getWynncraftServerData(true);
@@ -97,7 +97,7 @@ public class RPCJoinHandler implements IDiscordActivityEvents.on_activity_join_c
         if (!waitingInvite) return;
         sentInvite = true;
         waitingInvite = false;
-        Minecraft.getMinecraft().player.sendChatMessage("/msg " + lastSecret.getOwner() + " " + lastSecret.getRandomHash());
+        McIf.mc().player.sendChatMessage("/msg " + lastSecret.getOwner() + " " + lastSecret.getRandomHash());
     }
 
     @SubscribeEvent
@@ -106,14 +106,14 @@ public class RPCJoinHandler implements IDiscordActivityEvents.on_activity_join_c
 
         // handles the invitation
         if (lastSecret != null && McIf.getUnformattedText(e.getMessage()).startsWith("You have been invited to join " + lastSecret.getOwner())) {
-            Minecraft.getMinecraft().player.sendChatMessage("/party join " + lastSecret.getOwner());
+            McIf.mc().player.sendChatMessage("/party join " + lastSecret.getOwner());
 
             lastSecret = null;
             return;
         }
 
         // handles the user join
-        if (sentInvite && McIf.getUnformattedText(e.getMessage()).startsWith("[" + Minecraft.getMinecraft().player.getName())) {
+        if (sentInvite && McIf.getUnformattedText(e.getMessage()).startsWith("[" + McIf.mc().player.getName())) {
             sentInvite = false;
             e.setCanceled(true);
             return;
@@ -133,7 +133,7 @@ public class RPCJoinHandler implements IDiscordActivityEvents.on_activity_join_c
                 return;
 
             e.setCanceled(true);
-            Minecraft.getMinecraft().player.sendChatMessage("/party invite " + user);
+            McIf.mc().player.sendChatMessage("/party invite " + user);
         }
     }
 

--- a/src/main/java/com/wynntils/modules/richpresence/events/RPCJoinHandler.java
+++ b/src/main/java/com/wynntils/modules/richpresence/events/RPCJoinHandler.java
@@ -121,7 +121,7 @@ public class RPCJoinHandler implements IDiscordActivityEvents.on_activity_join_c
 
         // handles the party owner
         if (PlayerInfo.get(SocialData.class).getPlayerParty().isPartying()) {
-            String text = e.getMessage().getFormattedText();
+            String text = McIf.getFormattedText(e.getMessage());
             Matcher m = dmRegex.matcher(text);
 
             if (!m.matches()) return;

--- a/src/main/java/com/wynntils/modules/richpresence/events/RPCJoinHandler.java
+++ b/src/main/java/com/wynntils/modules/richpresence/events/RPCJoinHandler.java
@@ -5,6 +5,7 @@
 package com.wynntils.modules.richpresence.events;
 
 import com.sun.jna.Pointer;
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.WynnWorldEvent;
 import com.wynntils.core.framework.FrameworkManager;
@@ -104,7 +105,7 @@ public class RPCJoinHandler implements IDiscordActivityEvents.on_activity_join_c
         if (e.getType() != ChatType.CHAT && e.getType() != ChatType.SYSTEM) return;
 
         // handles the invitation
-        if (lastSecret != null && e.getMessage().getUnformattedText().startsWith("You have been invited to join " + lastSecret.getOwner())) {
+        if (lastSecret != null && McIf.getUnformattedText(e.getMessage()).startsWith("You have been invited to join " + lastSecret.getOwner())) {
             Minecraft.getMinecraft().player.sendChatMessage("/party join " + lastSecret.getOwner());
 
             lastSecret = null;
@@ -112,7 +113,7 @@ public class RPCJoinHandler implements IDiscordActivityEvents.on_activity_join_c
         }
 
         // handles the user join
-        if (sentInvite && e.getMessage().getUnformattedText().startsWith("[" + Minecraft.getMinecraft().player.getName())) {
+        if (sentInvite && McIf.getUnformattedText(e.getMessage()).startsWith("[" + Minecraft.getMinecraft().player.getName())) {
             sentInvite = false;
             e.setCanceled(true);
             return;
@@ -138,7 +139,7 @@ public class RPCJoinHandler implements IDiscordActivityEvents.on_activity_join_c
 
     @SubscribeEvent
     public void onTitle(ClientChatReceivedEvent e) {
-        String text = e.getMessage().getUnformattedText();
+        String text = McIf.getUnformattedText(e.getMessage());
         if ((text.equals("You are already connected to this server!") || text.equals("You're rejoining too quickly! Give us a moment to save your data.")) && waitingInvite) {
             waitingLobby = true;
             waitingInvite = false;

--- a/src/main/java/com/wynntils/modules/richpresence/events/RPCJoinHandler.java
+++ b/src/main/java/com/wynntils/modules/richpresence/events/RPCJoinHandler.java
@@ -59,8 +59,6 @@ public class RPCJoinHandler implements IDiscordActivityEvents.on_activity_join_c
 
         RichPresenceModule.getModule().getRichPresence().setJoinSecret(lastSecret);
 
-        Minecraft mc = McIf.mc();
-
         if (!Reference.onServer) {
             ServerData serverData = ServerUtils.getWynncraftServerData(true);
             ServerUtils.connect(serverData);
@@ -70,11 +68,11 @@ public class RPCJoinHandler implements IDiscordActivityEvents.on_activity_join_c
         if (Reference.onWorld) {
             if (Reference.getUserWorld().replace("WC", "").replace("HB", "").equals(Integer.toString(lastSecret.getWorld())) && Reference.getUserWorld().replaceAll("\\d+", "").equals(lastSecret.getWorldType())) {
                 sentInvite = true;
-                mc.player.sendChatMessage("/msg " + lastSecret.getOwner() + " " + lastSecret.getRandomHash());
+                McIf.mc().player.sendChatMessage("/msg " + lastSecret.getOwner() + " " + lastSecret.getRandomHash());
                 return;
             }
 
-            mc.player.sendChatMessage("/hub");
+            McIf.mc().player.sendChatMessage("/hub");
             waitingLobby = true;
             return;
         }

--- a/src/main/java/com/wynntils/modules/richpresence/events/ServerEvents.java
+++ b/src/main/java/com/wynntils/modules/richpresence/events/ServerEvents.java
@@ -5,7 +5,6 @@
 package com.wynntils.modules.richpresence.events;
 
 import com.wynntils.McIf;
-import com.wynntils.ModCore;
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.*;
 import com.wynntils.core.framework.enums.ClassType;
@@ -44,7 +43,7 @@ public class ServerEvents implements Listener {
 
     @SubscribeEvent
     public void onServerJoin(WynncraftServerEvent.Login e) {
-        if (!ModCore.mc().isSingleplayer() && ModCore.mc().getCurrentServerData() != null && Objects.requireNonNull(ModCore.mc().getCurrentServerData()).serverIP.contains("wynncraft") && RichPresenceConfig.INSTANCE.enableRichPresence) {
+        if (!McIf.mc().isSingleplayer() && McIf.mc().getCurrentServerData() != null && Objects.requireNonNull(McIf.mc().getCurrentServerData()).serverIP.contains("wynncraft") && RichPresenceConfig.INSTANCE.enableRichPresence) {
             String state = "In Lobby";
             RichPresenceModule.getModule().getRichPresence().updateRichPresence(state, null, null, OffsetDateTime.now());
         }
@@ -167,8 +166,7 @@ public class ServerEvents implements Listener {
      * @return RichPresence largeImageText
      */
     public static String getPlayerInfo() {
-        Minecraft mc = McIf.mc();
-        return RichPresenceConfig.INSTANCE.showUserInformation ? mc.player.getName() + " | Level " + mc.player.experienceLevel + " " + PlayerInfo.get(CharacterData.class).getCurrentClass().toString() : null;
+        return RichPresenceConfig.INSTANCE.showUserInformation ? McIf.mc().player.getName() + " | Level " + McIf.mc().player.experienceLevel + " " + PlayerInfo.get(CharacterData.class).getCurrentClass().toString() : null;
     }
 
 }

--- a/src/main/java/com/wynntils/modules/richpresence/events/ServerEvents.java
+++ b/src/main/java/com/wynntils/modules/richpresence/events/ServerEvents.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.richpresence.events;
 
+import com.wynntils.McIf;
 import com.wynntils.ModCore;
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.*;
@@ -104,7 +105,7 @@ public class ServerEvents implements Listener {
         if (!RichPresenceConfig.INSTANCE.enableRichPresence || !Reference.onWorld
                 || !PlayerInfo.get(CharacterData.class).isLoaded()) return;
 
-        if (e.getPacket().getLevel() != Minecraft.getMinecraft().player.experienceLevel) {
+        if (e.getPacket().getLevel() != McIf.mc().player.experienceLevel) {
             forceUpdate = true;
         }
     }
@@ -166,7 +167,7 @@ public class ServerEvents implements Listener {
      * @return RichPresence largeImageText
      */
     public static String getPlayerInfo() {
-        Minecraft mc = Minecraft.getMinecraft();
+        Minecraft mc = McIf.mc();
         return RichPresenceConfig.INSTANCE.showUserInformation ? mc.player.getName() + " | Level " + mc.player.experienceLevel + " " + PlayerInfo.get(CharacterData.class).getCurrentClass().toString() : null;
     }
 

--- a/src/main/java/com/wynntils/modules/richpresence/events/ServerEvents.java
+++ b/src/main/java/com/wynntils/modules/richpresence/events/ServerEvents.java
@@ -104,7 +104,7 @@ public class ServerEvents implements Listener {
         if (!RichPresenceConfig.INSTANCE.enableRichPresence || !Reference.onWorld
                 || !PlayerInfo.get(CharacterData.class).isLoaded()) return;
 
-        if (e.getPacket().getLevel() != McIf.mc().player.experienceLevel) {
+        if (e.getPacket().getLevel() != McIf.player().experienceLevel) {
             forceUpdate = true;
         }
     }
@@ -166,7 +166,7 @@ public class ServerEvents implements Listener {
      * @return RichPresence largeImageText
      */
     public static String getPlayerInfo() {
-        return RichPresenceConfig.INSTANCE.showUserInformation ? McIf.mc().player.getName() + " | Level " + McIf.mc().player.experienceLevel + " " + PlayerInfo.get(CharacterData.class).getCurrentClass().toString() : null;
+        return RichPresenceConfig.INSTANCE.showUserInformation ? McIf.player().getName() + " | Level " + McIf.player().experienceLevel + " " + PlayerInfo.get(CharacterData.class).getCurrentClass().toString() : null;
     }
 
 }

--- a/src/main/java/com/wynntils/modules/richpresence/profiles/RichProfile.java
+++ b/src/main/java/com/wynntils/modules/richpresence/profiles/RichProfile.java
@@ -9,7 +9,7 @@ import com.sun.jna.Native;
 import com.sun.jna.Platform;
 import com.sun.jna.Pointer;
 import com.sun.jna.ptr.IntByReference;
-import com.wynntils.ModCore;
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.framework.instances.PlayerInfo;
 import com.wynntils.core.framework.instances.data.SocialData;
@@ -86,7 +86,7 @@ public class RichProfile {
                             return;
                         }
 
-                        ModCore.mc().addScheduledTask(() -> setup(id));
+                        McIf.mc().addScheduledTask(() -> setup(id));
                     });
                     return true;
                 }));
@@ -111,15 +111,15 @@ public class RichProfile {
             IDiscordOverlayEvents.ByReference overlayEvents = new IDiscordOverlayEvents.ByReference();
             overlayEvents.on_toggle = (callbackData, closedAsByte) -> {
                 boolean opened = closedAsByte == 0;
-                if (opened && ModCore.mc().currentScreen == null) {
-                    ModCore.mc().displayGuiScreen(new GuiScreen() {
+                if (opened && McIf.mc().currentScreen == null) {
+                    McIf.mc().displayGuiScreen(new GuiScreen() {
                         public void onGuiClosed() {
                             isBlankGuiOpen = false;
                         }
                     });
                     isBlankGuiOpen = true;
                 } else if (!opened && isBlankGuiOpen) {
-                    ModCore.mc().displayGuiScreen(null);
+                    McIf.mc().displayGuiScreen(null);
                 }
             };
 

--- a/src/main/java/com/wynntils/modules/utilities/configs/OverlayConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/OverlayConfig.java
@@ -504,19 +504,19 @@ public class OverlayConfig extends SettingsClass {
             backgroundColor.setA(opacity / 100f);
 
             if (name.contentEquals("preset")) {
-                if (!(Minecraft.getMinecraft().currentScreen instanceof SettingsUI)) {
+                if (!(McIf.mc().currentScreen instanceof SettingsUI)) {
                     preset = Presets.CLICK_ME;
                 } else if (preset.value != null) {
                     Utils.copyToClipboard(preset.value);
                 }
             } else if (name.contentEquals("variables")) {
-                if (!(Minecraft.getMinecraft().currentScreen instanceof SettingsUI)) {
+                if (!(McIf.mc().currentScreen instanceof SettingsUI)) {
                     variables = Variables.CLICK_ME;
                 } else if (variables.value != null) {
                     Utils.copyToClipboard(variables.value);
                 }
             } else if (name.contentEquals("escapedChars")) {
-                if (!(Minecraft.getMinecraft().currentScreen instanceof SettingsUI)) {
+                if (!(McIf.mc().currentScreen instanceof SettingsUI)) {
                     escapedChars = Escaped.CLICK_ME;
                 } else if (escapedChars.value != null) {
                     Utils.copyToClipboard(escapedChars.value);

--- a/src/main/java/com/wynntils/modules/utilities/configs/OverlayConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/OverlayConfig.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.utilities.configs;
 
+import com.wynntils.McIf;
 import com.wynntils.core.framework.rendering.SmartFontRenderer;
 import com.wynntils.core.framework.rendering.SmartFontRenderer.TextAlignment;
 import com.wynntils.core.framework.rendering.colors.CommonColors;

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -136,7 +136,7 @@ public class ClientEvents implements Listener {
         afkProtectionEnabled = false;
         afkProtectionActivated = false;
 
-        lastHealth = McIf.mc().player.getHealth();
+        lastHealth = McIf.player().getHealth();
         lastUserInput = System.currentTimeMillis();
     }
 
@@ -147,7 +147,7 @@ public class ClientEvents implements Listener {
         if (Reference.onServer) WindowIconManager.update();
         if (!Reference.onWorld) return;
 
-        DailyReminderManager.checkDailyReminder(McIf.mc().player);
+        DailyReminderManager.checkDailyReminder(McIf.player());
 
         if (!UtilitiesConfig.AfkProtection.INSTANCE.afkProtection) return;
 
@@ -172,7 +172,7 @@ public class ClientEvents implements Listener {
                 if (!afkProtectionBlocked && timeSinceActivity >= longAfkThresholdMillis) {
                     // Enable AFK protection (but not if we're in a chest/inventory GUI)
                     afkProtectionRequested = false;
-                    lastHealth = McIf.mc().player.getHealth();
+                    lastHealth = McIf.player().getHealth();
                     if (OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectAfk) {
                         GameUpdateOverlay.queueMessage("AFK Protection enabled");
                     } else {
@@ -182,13 +182,13 @@ public class ClientEvents implements Listener {
                     afkProtectionEnabled = true;
                 }
             } else {
-                float currentHealth = McIf.mc().player.getHealth();
+                float currentHealth = McIf.player().getHealth();
                 if (currentHealth < (lastHealth  * UtilitiesConfig.AfkProtection.INSTANCE.healthPercentage / 100.0f)) {
                     // We're taking damage; activate AFK protection and go to class screen
                     afkProtectionActivated = true;
                     McIf.mc().addScheduledTask(() ->
                             ChatOverlay.getChat().printChatMessage(new TextComponentString(TextFormatting.GRAY + "AFK Protection activated due to player taking damage")));
-                    McIf.mc().player.sendChatMessage("/class");
+                    McIf.player().sendChatMessage("/class");
                 }
                 if (timeSinceActivity < longAfkThresholdMillis) {
                     if (OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectAfk) {
@@ -326,12 +326,12 @@ public class ClientEvents implements Listener {
             return;
         }
 
-        if (entity == McIf.mc().player.getRidingEntity()) {
+        if (entity == McIf.player().getRidingEntity()) {
             lastHorseId = thisId;
             return;
         }
 
-        EntityPlayerSP player = McIf.mc().player;
+        EntityPlayerSP player = McIf.player();
         String entityName = Utils.getNameFromMetadata(e.getPacket().getDataManagerEntries());
         if (entityName == null ||  entityName.isEmpty() ||
                 !MountHorseManager.isPlayersHorse(entityName, player.getName())) return;
@@ -465,7 +465,7 @@ public class ClientEvents implements Listener {
         if (!Reference.onWorld) return;
 
         if (e.getKeyCode() == KeyManager.getLockInventoryKey().getKeyBinding().getKeyCode()) {
-            if (e.getGui().getSlotUnderMouse() != null && McIf.mc().player.inventory == e.getGui().getSlotUnderMouse().inventory) {
+            if (e.getGui().getSlotUnderMouse() != null && McIf.player().inventory == e.getGui().getSlotUnderMouse().inventory) {
                 checkLockState(e.getGui().getSlotUnderMouse().getSlotIndex());
             }
 
@@ -477,7 +477,7 @@ public class ClientEvents implements Listener {
             return;
         }
 
-        if (e.getGui().getSlotUnderMouse() != null && McIf.mc().player.inventory == e.getGui().getSlotUnderMouse().inventory) {
+        if (e.getGui().getSlotUnderMouse() != null && McIf.player().inventory == e.getGui().getSlotUnderMouse().inventory) {
             if (!UtilitiesConfig.INSTANCE.locked_slots.containsKey(PlayerInfo.get(CharacterData.class).getClassId())) return;
 
             e.setCanceled(checkDropState(e.getGui().getSlotUnderMouse().getSlotIndex(), e.getKeyCode()));
@@ -503,7 +503,7 @@ public class ClientEvents implements Listener {
                         TextComponentString text = new TextComponentString("You cannot close this loot chest while there is a mythic in it!");
                         text.getStyle().setColor(TextFormatting.RED);
 
-                        McIf.mc().player.sendMessage(text);
+                        McIf.player().sendMessage(text);
                         McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.BLOCK_NOTE_BASS, 1f));
                         e.setCanceled(true);
                         break;
@@ -514,7 +514,7 @@ public class ClientEvents implements Listener {
         }
 
         if (e.getKeyCode() == KeyManager.getLockInventoryKey().getKeyBinding().getKeyCode()) {
-            if (e.getGui().getSlotUnderMouse() != null && McIf.mc().player.inventory == e.getGui().getSlotUnderMouse().inventory) {
+            if (e.getGui().getSlotUnderMouse() != null && McIf.player().inventory == e.getGui().getSlotUnderMouse().inventory) {
                 checkLockState(e.getGui().getSlotUnderMouse().getSlotIndex());
             }
 
@@ -526,7 +526,7 @@ public class ClientEvents implements Listener {
             return;
         }
 
-        if (e.getGui().getSlotUnderMouse() != null && McIf.mc().player.inventory == e.getGui().getSlotUnderMouse().inventory) {
+        if (e.getGui().getSlotUnderMouse() != null && McIf.player().inventory == e.getGui().getSlotUnderMouse().inventory) {
             if (!UtilitiesConfig.INSTANCE.locked_slots.containsKey(PlayerInfo.get(CharacterData.class).getClassId())) return;
 
             e.setCanceled(checkDropState(e.getGui().getSlotUnderMouse().getSlotIndex(), e.getKeyCode()));
@@ -538,7 +538,7 @@ public class ClientEvents implements Listener {
         if (!Reference.onWorld) return;
 
         if (e.getKeyCode() == KeyManager.getLockInventoryKey().getKeyBinding().getKeyCode()) {
-            if (e.getGui().getSlotUnderMouse() != null && McIf.mc().player.inventory == e.getGui().getSlotUnderMouse().inventory) {
+            if (e.getGui().getSlotUnderMouse() != null && McIf.player().inventory == e.getGui().getSlotUnderMouse().inventory) {
                 checkLockState(e.getGui().getSlotUnderMouse().getSlotIndex());
             }
 
@@ -550,7 +550,7 @@ public class ClientEvents implements Listener {
             return;
         }
 
-        if (e.getGui().getSlotUnderMouse() != null && McIf.mc().player.inventory == e.getGui().getSlotUnderMouse().inventory) {
+        if (e.getGui().getSlotUnderMouse() != null && McIf.player().inventory == e.getGui().getSlotUnderMouse().inventory) {
             if (!UtilitiesConfig.INSTANCE.locked_slots.containsKey(PlayerInfo.get(CharacterData.class).getClassId())) return;
 
             e.setCanceled(checkDropState(e.getGui().getSlotUnderMouse().getSlotIndex(), e.getKeyCode()));
@@ -563,14 +563,14 @@ public class ClientEvents implements Listener {
     public void clickOnInventory(GuiOverlapEvent.InventoryOverlap.HandleMouseClick e) {
         if(!Reference.onWorld) return;
 
-        if (UtilitiesConfig.INSTANCE.preventSlotClicking && e.getGui().getSlotUnderMouse() != null && e.getGui().getSlotUnderMouse().inventory == McIf.mc().player.inventory) {
+        if (UtilitiesConfig.INSTANCE.preventSlotClicking && e.getGui().getSlotUnderMouse() != null && e.getGui().getSlotUnderMouse().inventory == McIf.player().inventory) {
             if (checkDropState(e.getGui().getSlotUnderMouse().getSlotIndex(), McIf.mc().gameSettings.keyBindDrop.getKeyCode())) {
                 e.setCanceled(true);
                 return;
             }
         }
 
-        if (UtilitiesConfig.INSTANCE.shiftClickAccessories && e.getGui().isShiftKeyDown() && e.getGui().getSlotUnderMouse() != null && McIf.mc().player.inventory.getItemStack().isEmpty() && e.getGui().getSlotUnderMouse().inventory == McIf.mc().player.inventory) {
+        if (UtilitiesConfig.INSTANCE.shiftClickAccessories && e.getGui().isShiftKeyDown() && e.getGui().getSlotUnderMouse() != null && McIf.player().inventory.getItemStack().isEmpty() && e.getGui().getSlotUnderMouse().inventory == McIf.player().inventory) {
             if (e.getSlotId() >= 9 && e.getSlotId() <= 12) { // taking off accessory
                 // check if hotbar has open slot; if so, no action required
                 for (int i = 36; i < 45; i++) {
@@ -623,7 +623,7 @@ public class ClientEvents implements Listener {
             }
 
             // pick up accessory
-            CPacketClickWindow packet = new CPacketClickWindow(e.getGui().inventorySlots.windowId, e.getSlotId(), 0, ClickType.PICKUP, e.getSlotIn().getStack(), e.getGui().inventorySlots.getNextTransactionID(McIf.mc().player.inventory));
+            CPacketClickWindow packet = new CPacketClickWindow(e.getGui().inventorySlots.windowId, e.getSlotId(), 0, ClickType.PICKUP, e.getSlotIn().getStack(), e.getGui().inventorySlots.getNextTransactionID(McIf.player().inventory));
             McIf.mc().getConnection().sendPacket(packet);
         }
     }
@@ -641,7 +641,7 @@ public class ClientEvents implements Listener {
         InventoryReplacer gui = (InventoryReplacer) McIf.mc().currentScreen;
 
         // no item picked up
-        if (McIf.mc().player.inventory.getItemStack().isEmpty()) return;
+        if (McIf.player().inventory.getItemStack().isEmpty()) return;
 
         // destination slot was filled in the meantime
         if (gui.inventorySlots.getSlot(accessoryDestinationSlot).getHasStack() &&
@@ -698,7 +698,7 @@ public class ClientEvents implements Listener {
                     String itemName = item.getDisplayName();
                     String pageNumber = itemName.substring(9, itemName.indexOf(TextFormatting.RED + " >"));
                     ChestReplacer gui = e.getGui();
-                    CPacketClickWindow packet = new CPacketClickWindow(gui.inventorySlots.windowId, e.getSlotId(), e.getMouseButton(), e.getType(), item, e.getGui().inventorySlots.getNextTransactionID(McIf.mc().player.inventory));
+                    CPacketClickWindow packet = new CPacketClickWindow(gui.inventorySlots.windowId, e.getSlotId(), e.getMouseButton(), e.getType(), item, e.getGui().inventorySlots.getNextTransactionID(McIf.player().inventory));
                     McIf.mc().displayGuiScreen(new GuiYesNo((result, parentButtonID) -> {
                         McIf.mc().displayGuiScreen(gui);
                         if (result) {
@@ -716,7 +716,7 @@ public class ClientEvents implements Listener {
     public void onSetSlot(PacketEvent<SPacketSetSlot> event) {
         if (bankPageConfirmed && event.getPacket().getSlot() == 8) {
             bankPageConfirmed = false;
-            CPacketClickWindow packet = new CPacketClickWindow(McIf.mc().player.openContainer.windowId, 8, 0, ClickType.PICKUP, event.getPacket().getStack(), McIf.mc().player.openContainer.getNextTransactionID(McIf.mc().player.inventory));
+            CPacketClickWindow packet = new CPacketClickWindow(McIf.player().openContainer.windowId, 8, 0, ClickType.PICKUP, event.getPacket().getStack(), McIf.player().openContainer.getNextTransactionID(McIf.player().inventory));
             McIf.mc().getConnection().sendPacket(packet);
         }
     }
@@ -737,7 +737,7 @@ public class ClientEvents implements Listener {
             return;
 
         lastWasDrop = true;
-        if (UtilitiesConfig.INSTANCE.locked_slots.get(PlayerInfo.get(CharacterData.class).getClassId()).contains(McIf.mc().player.inventory.currentItem))
+        if (UtilitiesConfig.INSTANCE.locked_slots.get(PlayerInfo.get(CharacterData.class).getClassId()).contains(McIf.player().inventory.currentItem))
             e.setCanceled(true);
     }
 
@@ -747,9 +747,9 @@ public class ClientEvents implements Listener {
 
         // the reason of the +36, is because in the client the hotbar is handled between 0-8
         // the hotbar in the packet starts in 36, counting from up to down
-        if (e.getPacket().getSlot() != McIf.mc().player.inventory.currentItem + 36) return;
+        if (e.getPacket().getSlot() != McIf.player().inventory.currentItem + 36) return;
 
-        InventoryPlayer inventory = McIf.mc().player.inventory;
+        InventoryPlayer inventory = McIf.player().inventory;
         ItemStack oldStack = inventory.getStackInSlot(e.getPacket().getSlot() - 36);
         ItemStack newStack = e.getPacket().getStack();
 
@@ -820,11 +820,11 @@ public class ClientEvents implements Listener {
     // blocking healing pots below
     @SubscribeEvent
     public void onUseItem(PacketEvent<CPacketPlayerTryUseItem> e) {
-        ItemStack item = McIf.mc().player.getHeldItem(EnumHand.MAIN_HAND);
+        ItemStack item = McIf.player().getHeldItem(EnumHand.MAIN_HAND);
 
         if (item.isEmpty() || !item.hasDisplayName() || !item.getDisplayName().contains(TextFormatting.RED + "Potion of Healing") || !UtilitiesConfig.INSTANCE.blockHealingPots) return;
 
-        EntityPlayerSP player = McIf.mc().player;
+        EntityPlayerSP player = McIf.player();
         if (player.getHealth() != player.getMaxHealth()) return;
 
         e.setCanceled(true);
@@ -833,11 +833,11 @@ public class ClientEvents implements Listener {
 
     @SubscribeEvent
     public void onUseItemOnBlock(PacketEvent<CPacketPlayerTryUseItemOnBlock> e) {
-        ItemStack item = McIf.mc().player.getHeldItem(EnumHand.MAIN_HAND);
+        ItemStack item = McIf.player().getHeldItem(EnumHand.MAIN_HAND);
 
         if (item.isEmpty() || !item.hasDisplayName() || !item.getDisplayName().contains(TextFormatting.RED + "Potion of Healing") || !UtilitiesConfig.INSTANCE.blockHealingPots) return;
 
-        EntityPlayerSP player = McIf.mc().player;
+        EntityPlayerSP player = McIf.player();
         if (player.getHealth() != player.getMaxHealth()) return;
 
         e.setCanceled(true);
@@ -846,11 +846,11 @@ public class ClientEvents implements Listener {
 
     @SubscribeEvent
     public void onUseItemOnEntity(PacketEvent<CPacketUseEntity> e) {
-        ItemStack item = McIf.mc().player.getHeldItem(EnumHand.MAIN_HAND);
+        ItemStack item = McIf.player().getHeldItem(EnumHand.MAIN_HAND);
 
         if (item.isEmpty() || !item.hasDisplayName() || !item.getDisplayName().contains(TextFormatting.RED + "Potion of Healing") || !UtilitiesConfig.INSTANCE.blockHealingPots) return;
 
-        EntityPlayerSP player = McIf.mc().player;
+        EntityPlayerSP player = McIf.player();
         if (player.getHealth() != player.getMaxHealth()) return;
 
         e.setCanceled(true);
@@ -869,7 +869,7 @@ public class ClientEvents implements Listener {
     public void onShiftClickPlayer(PacketEvent<CPacketUseEntity> e) {
         if (!UtilitiesConfig.INSTANCE.preventTradesDuels) return;
 
-        EntityPlayerSP player = McIf.mc().player;
+        EntityPlayerSP player = McIf.player();
         if (!player.isSneaking()) return;
 
         Entity clicked = e.getPacket().getEntityFromWorld(player.world);

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -313,7 +313,7 @@ public class ClientEvents implements Listener {
         if (!McIf.getUnformattedText(packet.getMessage()).matches("^§a\\+\\d+ §7.+§a to pouch$")) return;
 
         e.setCanceled(true);
-        GameUpdateOverlay.queueMessage(packet.getMessage().getFormattedText());
+        GameUpdateOverlay.queueMessage(McIf.getFormattedText(packet.getMessage()));
     }
 
     @SubscribeEvent

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -319,8 +319,8 @@ public class ClientEvents implements Listener {
         if (!Reference.onServer || !Reference.onWorld) return;
 
         int thisId = e.getPacket().getEntityId();
-        if (thisId == lastHorseId || McIf.mc().world == null) return;
-        Entity entity = McIf.mc().world.getEntityByID(thisId);
+        if (thisId == lastHorseId || McIf.world() == null) return;
+        Entity entity = McIf.world().getEntityByID(thisId);
 
         if (!(entity instanceof AbstractHorse) || e.getPacket().getDataManagerEntries().isEmpty()) {
             return;

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -138,7 +138,7 @@ public class ClientEvents implements Listener {
         afkProtectionEnabled = false;
         afkProtectionActivated = false;
 
-        lastHealth = Minecraft.getMinecraft().player.getHealth();
+        lastHealth = McIf.mc().player.getHealth();
         lastUserInput = System.currentTimeMillis();
     }
 
@@ -174,29 +174,29 @@ public class ClientEvents implements Listener {
                 if (!afkProtectionBlocked && timeSinceActivity >= longAfkThresholdMillis) {
                     // Enable AFK protection (but not if we're in a chest/inventory GUI)
                     afkProtectionRequested = false;
-                    lastHealth = Minecraft.getMinecraft().player.getHealth();
+                    lastHealth = McIf.mc().player.getHealth();
                     if (OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectAfk) {
                         GameUpdateOverlay.queueMessage("AFK Protection enabled");
                     } else {
-                        Minecraft.getMinecraft().addScheduledTask(() ->
+                        McIf.mc().addScheduledTask(() ->
                                 ChatOverlay.getChat().printChatMessage(new TextComponentString(TextFormatting.GRAY + "AFK Protection enabled due to lack of movement")));
                     }
                     afkProtectionEnabled = true;
                 }
             } else {
-                float currentHealth = Minecraft.getMinecraft().player.getHealth();
+                float currentHealth = McIf.mc().player.getHealth();
                 if (currentHealth < (lastHealth  * UtilitiesConfig.AfkProtection.INSTANCE.healthPercentage / 100.0f)) {
                     // We're taking damage; activate AFK protection and go to class screen
                     afkProtectionActivated = true;
-                    Minecraft.getMinecraft().addScheduledTask(() ->
+                    McIf.mc().addScheduledTask(() ->
                             ChatOverlay.getChat().printChatMessage(new TextComponentString(TextFormatting.GRAY + "AFK Protection activated due to player taking damage")));
-                    Minecraft.getMinecraft().player.sendChatMessage("/class");
+                    McIf.mc().player.sendChatMessage("/class");
                 }
                 if (timeSinceActivity < longAfkThresholdMillis) {
                     if (OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectAfk) {
                         GameUpdateOverlay.queueMessage("AFK Protection disabled");
                     } else {
-                        Minecraft.getMinecraft().addScheduledTask(() ->
+                        McIf.mc().addScheduledTask(() ->
                                 ChatOverlay.getChat().printChatMessage(new TextComponentString(TextFormatting.GRAY + "AFK Protection disabled")));
                     }
                     afkProtectionEnabled = false;
@@ -288,8 +288,8 @@ public class ClientEvents implements Listener {
 
     @SubscribeEvent
     public void onSlotSet(PacketEvent<SPacketSetSlot> e) {
-        if (Minecraft.getMinecraft().currentScreen == null) return;
-        if (!(Minecraft.getMinecraft().currentScreen instanceof FakeGuiContainer)) return;
+        if (McIf.mc().currentScreen == null) return;
+        if (!(McIf.mc().currentScreen instanceof FakeGuiContainer)) return;
 
         e.setCanceled(true); // stops wynncraft from adding pouch to gui
     }
@@ -467,7 +467,7 @@ public class ClientEvents implements Listener {
         if (!Reference.onWorld) return;
 
         if (e.getKeyCode() == KeyManager.getLockInventoryKey().getKeyBinding().getKeyCode()) {
-            if (e.getGui().getSlotUnderMouse() != null && Minecraft.getMinecraft().player.inventory == e.getGui().getSlotUnderMouse().inventory) {
+            if (e.getGui().getSlotUnderMouse() != null && McIf.mc().player.inventory == e.getGui().getSlotUnderMouse().inventory) {
                 checkLockState(e.getGui().getSlotUnderMouse().getSlotIndex());
             }
 
@@ -479,7 +479,7 @@ public class ClientEvents implements Listener {
             return;
         }
 
-        if (e.getGui().getSlotUnderMouse() != null && Minecraft.getMinecraft().player.inventory == e.getGui().getSlotUnderMouse().inventory) {
+        if (e.getGui().getSlotUnderMouse() != null && McIf.mc().player.inventory == e.getGui().getSlotUnderMouse().inventory) {
             if (!UtilitiesConfig.INSTANCE.locked_slots.containsKey(PlayerInfo.get(CharacterData.class).getClassId())) return;
 
             e.setCanceled(checkDropState(e.getGui().getSlotUnderMouse().getSlotIndex(), e.getKeyCode()));
@@ -505,8 +505,8 @@ public class ClientEvents implements Listener {
                         TextComponentString text = new TextComponentString("You cannot close this loot chest while there is a mythic in it!");
                         text.getStyle().setColor(TextFormatting.RED);
 
-                        Minecraft.getMinecraft().player.sendMessage(text);
-                        Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.BLOCK_NOTE_BASS, 1f));
+                        McIf.mc().player.sendMessage(text);
+                        McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.BLOCK_NOTE_BASS, 1f));
                         e.setCanceled(true);
                         break;
                     }
@@ -516,7 +516,7 @@ public class ClientEvents implements Listener {
         }
 
         if (e.getKeyCode() == KeyManager.getLockInventoryKey().getKeyBinding().getKeyCode()) {
-            if (e.getGui().getSlotUnderMouse() != null && Minecraft.getMinecraft().player.inventory == e.getGui().getSlotUnderMouse().inventory) {
+            if (e.getGui().getSlotUnderMouse() != null && McIf.mc().player.inventory == e.getGui().getSlotUnderMouse().inventory) {
                 checkLockState(e.getGui().getSlotUnderMouse().getSlotIndex());
             }
 
@@ -528,7 +528,7 @@ public class ClientEvents implements Listener {
             return;
         }
 
-        if (e.getGui().getSlotUnderMouse() != null && Minecraft.getMinecraft().player.inventory == e.getGui().getSlotUnderMouse().inventory) {
+        if (e.getGui().getSlotUnderMouse() != null && McIf.mc().player.inventory == e.getGui().getSlotUnderMouse().inventory) {
             if (!UtilitiesConfig.INSTANCE.locked_slots.containsKey(PlayerInfo.get(CharacterData.class).getClassId())) return;
 
             e.setCanceled(checkDropState(e.getGui().getSlotUnderMouse().getSlotIndex(), e.getKeyCode()));
@@ -540,7 +540,7 @@ public class ClientEvents implements Listener {
         if (!Reference.onWorld) return;
 
         if (e.getKeyCode() == KeyManager.getLockInventoryKey().getKeyBinding().getKeyCode()) {
-            if (e.getGui().getSlotUnderMouse() != null && Minecraft.getMinecraft().player.inventory == e.getGui().getSlotUnderMouse().inventory) {
+            if (e.getGui().getSlotUnderMouse() != null && McIf.mc().player.inventory == e.getGui().getSlotUnderMouse().inventory) {
                 checkLockState(e.getGui().getSlotUnderMouse().getSlotIndex());
             }
 
@@ -552,7 +552,7 @@ public class ClientEvents implements Listener {
             return;
         }
 
-        if (e.getGui().getSlotUnderMouse() != null && Minecraft.getMinecraft().player.inventory == e.getGui().getSlotUnderMouse().inventory) {
+        if (e.getGui().getSlotUnderMouse() != null && McIf.mc().player.inventory == e.getGui().getSlotUnderMouse().inventory) {
             if (!UtilitiesConfig.INSTANCE.locked_slots.containsKey(PlayerInfo.get(CharacterData.class).getClassId())) return;
 
             e.setCanceled(checkDropState(e.getGui().getSlotUnderMouse().getSlotIndex(), e.getKeyCode()));
@@ -565,8 +565,8 @@ public class ClientEvents implements Listener {
     public void clickOnInventory(GuiOverlapEvent.InventoryOverlap.HandleMouseClick e) {
         if(!Reference.onWorld) return;
 
-        if (UtilitiesConfig.INSTANCE.preventSlotClicking && e.getGui().getSlotUnderMouse() != null && e.getGui().getSlotUnderMouse().inventory == Minecraft.getMinecraft().player.inventory) {
-            if (checkDropState(e.getGui().getSlotUnderMouse().getSlotIndex(), Minecraft.getMinecraft().gameSettings.keyBindDrop.getKeyCode())) {
+        if (UtilitiesConfig.INSTANCE.preventSlotClicking && e.getGui().getSlotUnderMouse() != null && e.getGui().getSlotUnderMouse().inventory == McIf.mc().player.inventory) {
+            if (checkDropState(e.getGui().getSlotUnderMouse().getSlotIndex(), McIf.mc().gameSettings.keyBindDrop.getKeyCode())) {
                 e.setCanceled(true);
                 return;
             }
@@ -663,9 +663,9 @@ public class ClientEvents implements Listener {
     public void clickOnChest(GuiOverlapEvent.ChestOverlap.HandleMouseClick e) {
         if (UtilitiesConfig.INSTANCE.preventSlotClicking && e.getSlotIn() != null) {
             if (e.getSlotId() - e.getGui().getLowerInv().getSizeInventory() >= 0 && e.getSlotId() - e.getGui().getLowerInv().getSizeInventory() < 27) {
-                e.setCanceled(checkDropState(e.getSlotId() - e.getGui().getLowerInv().getSizeInventory() + 9, Minecraft.getMinecraft().gameSettings.keyBindDrop.getKeyCode()));
+                e.setCanceled(checkDropState(e.getSlotId() - e.getGui().getLowerInv().getSizeInventory() + 9, McIf.mc().gameSettings.keyBindDrop.getKeyCode()));
             } else {
-                e.setCanceled(checkDropState(e.getSlotId() - e.getGui().getLowerInv().getSizeInventory() - 27, Minecraft.getMinecraft().gameSettings.keyBindDrop.getKeyCode()));
+                e.setCanceled(checkDropState(e.getSlotId() - e.getGui().getLowerInv().getSizeInventory() - 27, McIf.mc().gameSettings.keyBindDrop.getKeyCode()));
             }
         }
 
@@ -726,7 +726,7 @@ public class ClientEvents implements Listener {
     @SubscribeEvent
     public void clickOnHorse(GuiOverlapEvent.HorseOverlap.HandleMouseClick e) {
         if (UtilitiesConfig.INSTANCE.preventSlotClicking && e.getGui().getSlotUnderMouse() != null) {
-            e.setCanceled(checkDropState(e.getGui().getSlotUnderMouse().getSlotIndex(), Minecraft.getMinecraft().gameSettings.keyBindDrop.getKeyCode()));
+            e.setCanceled(checkDropState(e.getGui().getSlotUnderMouse().getSlotIndex(), McIf.mc().gameSettings.keyBindDrop.getKeyCode()));
         }
     }
 
@@ -739,7 +739,7 @@ public class ClientEvents implements Listener {
             return;
 
         lastWasDrop = true;
-        if (UtilitiesConfig.INSTANCE.locked_slots.get(PlayerInfo.get(CharacterData.class).getClassId()).contains(Minecraft.getMinecraft().player.inventory.currentItem))
+        if (UtilitiesConfig.INSTANCE.locked_slots.get(PlayerInfo.get(CharacterData.class).getClassId()).contains(McIf.mc().player.inventory.currentItem))
             e.setCanceled(true);
     }
 
@@ -749,9 +749,9 @@ public class ClientEvents implements Listener {
 
         // the reason of the +36, is because in the client the hotbar is handled between 0-8
         // the hotbar in the packet starts in 36, counting from up to down
-        if (e.getPacket().getSlot() != Minecraft.getMinecraft().player.inventory.currentItem + 36) return;
+        if (e.getPacket().getSlot() != McIf.mc().player.inventory.currentItem + 36) return;
 
-        InventoryPlayer inventory = Minecraft.getMinecraft().player.inventory;
+        InventoryPlayer inventory = McIf.mc().player.inventory;
         ItemStack oldStack = inventory.getStackInSlot(e.getPacket().getSlot() - 36);
         ItemStack newStack = e.getPacket().getStack();
 
@@ -782,7 +782,7 @@ public class ClientEvents implements Listener {
         if (oldUses - 1 != newUses) {
             return;
         }
-        Minecraft.getMinecraft().addScheduledTask(() -> ConsumableTimerOverlay.addConsumable(oldStack));
+        McIf.mc().addScheduledTask(() -> ConsumableTimerOverlay.addConsumable(oldStack));
     }
 
     @SubscribeEvent
@@ -795,7 +795,7 @@ public class ClientEvents implements Listener {
     private static boolean checkDropState(int slot, int key) {
         if (!Reference.onWorld) return false;
 
-        if (key == Minecraft.getMinecraft().gameSettings.keyBindDrop.getKeyCode()) {
+        if (key == McIf.mc().gameSettings.keyBindDrop.getKeyCode()) {
             if (!UtilitiesConfig.INSTANCE.locked_slots.containsKey(PlayerInfo.get(CharacterData.class).getClassId())) return false;
 
             return UtilitiesConfig.INSTANCE.locked_slots.get(PlayerInfo.get(CharacterData.class).getClassId()).contains(slot);
@@ -822,41 +822,41 @@ public class ClientEvents implements Listener {
     // blocking healing pots below
     @SubscribeEvent
     public void onUseItem(PacketEvent<CPacketPlayerTryUseItem> e) {
-        ItemStack item = Minecraft.getMinecraft().player.getHeldItem(EnumHand.MAIN_HAND);
+        ItemStack item = McIf.mc().player.getHeldItem(EnumHand.MAIN_HAND);
 
         if (item.isEmpty() || !item.hasDisplayName() || !item.getDisplayName().contains(TextFormatting.RED + "Potion of Healing") || !UtilitiesConfig.INSTANCE.blockHealingPots) return;
 
-        EntityPlayerSP player = Minecraft.getMinecraft().player;
+        EntityPlayerSP player = McIf.mc().player;
         if (player.getHealth() != player.getMaxHealth()) return;
 
         e.setCanceled(true);
-        Minecraft.getMinecraft().addScheduledTask(() -> GameUpdateOverlay.queueMessage(TextFormatting.DARK_RED + "You are already at full health!"));
+        McIf.mc().addScheduledTask(() -> GameUpdateOverlay.queueMessage(TextFormatting.DARK_RED + "You are already at full health!"));
     }
 
     @SubscribeEvent
     public void onUseItemOnBlock(PacketEvent<CPacketPlayerTryUseItemOnBlock> e) {
-        ItemStack item = Minecraft.getMinecraft().player.getHeldItem(EnumHand.MAIN_HAND);
+        ItemStack item = McIf.mc().player.getHeldItem(EnumHand.MAIN_HAND);
 
         if (item.isEmpty() || !item.hasDisplayName() || !item.getDisplayName().contains(TextFormatting.RED + "Potion of Healing") || !UtilitiesConfig.INSTANCE.blockHealingPots) return;
 
-        EntityPlayerSP player = Minecraft.getMinecraft().player;
+        EntityPlayerSP player = McIf.mc().player;
         if (player.getHealth() != player.getMaxHealth()) return;
 
         e.setCanceled(true);
-        Minecraft.getMinecraft().addScheduledTask(() -> GameUpdateOverlay.queueMessage(TextFormatting.DARK_RED + "You are already at full health!"));
+        McIf.mc().addScheduledTask(() -> GameUpdateOverlay.queueMessage(TextFormatting.DARK_RED + "You are already at full health!"));
     }
 
     @SubscribeEvent
     public void onUseItemOnEntity(PacketEvent<CPacketUseEntity> e) {
-        ItemStack item = Minecraft.getMinecraft().player.getHeldItem(EnumHand.MAIN_HAND);
+        ItemStack item = McIf.mc().player.getHeldItem(EnumHand.MAIN_HAND);
 
         if (item.isEmpty() || !item.hasDisplayName() || !item.getDisplayName().contains(TextFormatting.RED + "Potion of Healing") || !UtilitiesConfig.INSTANCE.blockHealingPots) return;
 
-        EntityPlayerSP player = Minecraft.getMinecraft().player;
+        EntityPlayerSP player = McIf.mc().player;
         if (player.getHealth() != player.getMaxHealth()) return;
 
         e.setCanceled(true);
-        Minecraft.getMinecraft().addScheduledTask(() -> GameUpdateOverlay.queueMessage(TextFormatting.DARK_RED + "You are already at full health!"));
+        McIf.mc().addScheduledTask(() -> GameUpdateOverlay.queueMessage(TextFormatting.DARK_RED + "You are already at full health!"));
     }
 
     @SubscribeEvent

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.utilities.events;
 
+import com.wynntils.McIf;
 import com.wynntils.ModCore;
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.*;
@@ -256,20 +257,20 @@ public class ClientEvents implements Listener {
 
     @SubscribeEvent
     public void onPostChatEvent(ChatEvent.Post e) {
-        if (e.getMessage().getUnformattedText().matches("Type the price in emeralds or type 'cancel' to cancel:")) {
+        if (McIf.getUnformattedText(e.getMessage()).matches("Type the price in emeralds or type 'cancel' to cancel:")) {
             priceInput = true;
             if (UtilitiesConfig.Market.INSTANCE.openChatMarket)
                 scheduledGuiScreen = new ChatGUI();
         }
 
         if (UtilitiesConfig.Market.INSTANCE.openChatMarket) {
-            if (e.getMessage().getUnformattedText().matches("Type the (item name|amount you wish to (buy|sell)) or type 'cancel' to cancel:")) {
+            if (McIf.getUnformattedText(e.getMessage()).matches("Type the (item name|amount you wish to (buy|sell)) or type 'cancel' to cancel:")) {
                 scheduledGuiScreen = new ChatGUI();
             }
         }
 
         if (UtilitiesConfig.Bank.INSTANCE.openChatBankSearch) {
-            if (e.getMessage().getUnformattedText().matches("Please type an item name in chat!")) {
+            if (McIf.getUnformattedText(e.getMessage()).matches("Please type an item name in chat!")) {
                 scheduledGuiScreen = new ChatGUI();
             }
         }
@@ -297,7 +298,7 @@ public class ClientEvents implements Listener {
     public void chatHandler(ClientChatReceivedEvent e) {
         if (e.isCanceled() || e.getType() == ChatType.GAME_INFO) return;
 
-        String msg = e.getMessage().getUnformattedText();
+        String msg = McIf.getUnformattedText(e.getMessage());
         if (msg.startsWith("[Daily Rewards:")) {
             DailyReminderManager.openedDaily();
         }
@@ -309,7 +310,7 @@ public class ClientEvents implements Listener {
 
         SPacketTitle packet = e.getPacket();
         if (packet.getType() != SPacketTitle.Type.SUBTITLE) return;
-        if (!packet.getMessage().getUnformattedText().matches("^§a\\+\\d+ §7.+§a to pouch$")) return;
+        if (!McIf.getUnformattedText(packet.getMessage()).matches("^§a\\+\\d+ §7.+§a to pouch$")) return;
 
         e.setCanceled(true);
         GameUpdateOverlay.queueMessage(packet.getMessage().getFormattedText());
@@ -492,9 +493,9 @@ public class ClientEvents implements Listener {
         if (UtilitiesConfig.INSTANCE.preventMythicChestClose) {
             if (e.getKeyCode() == 1 || e.getKeyCode() == ModCore.mc().gameSettings.keyBindInventory.getKeyCode()) {
                 IInventory inv = e.getGui().getLowerInv();
-                if (inv.getDisplayName().getUnformattedText().contains("Loot Chest") ||
-                        inv.getDisplayName().getUnformattedText().contains("Daily Rewards") ||
-                        inv.getDisplayName().getUnformattedText().contains("Objective Rewards")) {
+                if (McIf.getUnformattedText(inv.getDisplayName()).contains("Loot Chest") ||
+                        McIf.getUnformattedText(inv.getDisplayName()).contains("Daily Rewards") ||
+                        McIf.getUnformattedText(inv.getDisplayName()).contains("Objective Rewards")) {
                     for (int i = 0; i < inv.getSizeInventory(); i++) {
                         ItemStack stack = inv.getStackInSlot(i);
                         if (!stack.hasDisplayName() ||
@@ -670,7 +671,7 @@ public class ClientEvents implements Listener {
 
         if (UtilitiesConfig.Bank.INSTANCE.addBankConfirmation && e.getSlotIn() != null) {
             IInventory inventory = e.getSlotIn().inventory;
-            if (inventory.getDisplayName().getUnformattedText().contains("Bank") && e.getSlotIn().getHasStack()) {
+            if (McIf.getUnformattedText(inventory.getDisplayName()).contains("Bank") && e.getSlotIn().getHasStack()) {
                 ItemStack item = e.getSlotIn().getStack();
                 if (item.getDisplayName().contains(">" + TextFormatting.DARK_RED + ">" + TextFormatting.RED + ">" + TextFormatting.DARK_RED + ">" + TextFormatting.RED + ">")) {
                     String lore = TextFormatting.getTextWithoutFormattingCodes(ItemUtils.getStringLore(item));

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -5,7 +5,6 @@
 package com.wynntils.modules.utilities.events;
 
 import com.wynntils.McIf;
-import com.wynntils.ModCore;
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.*;
 import com.wynntils.core.framework.enums.wynntils.WynntilsSound;
@@ -32,7 +31,6 @@ import com.wynntils.modules.utilities.overlays.ui.FakeGuiContainer;
 import com.wynntils.webapi.WebManager;
 import com.wynntils.webapi.profiles.item.enums.ItemType;
 import com.wynntils.webapi.profiles.player.PlayerStatsProfile;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.audio.PositionedSoundRecord;
 import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.client.gui.GuiScreen;
@@ -149,7 +147,7 @@ public class ClientEvents implements Listener {
         if (Reference.onServer) WindowIconManager.update();
         if (!Reference.onWorld) return;
 
-        DailyReminderManager.checkDailyReminder(ModCore.mc().player);
+        DailyReminderManager.checkDailyReminder(McIf.mc().player);
 
         if (!UtilitiesConfig.AfkProtection.INSTANCE.afkProtection) return;
 
@@ -321,19 +319,19 @@ public class ClientEvents implements Listener {
         if (!Reference.onServer || !Reference.onWorld) return;
 
         int thisId = e.getPacket().getEntityId();
-        if (thisId == lastHorseId || ModCore.mc().world == null) return;
-        Entity entity = ModCore.mc().world.getEntityByID(thisId);
+        if (thisId == lastHorseId || McIf.mc().world == null) return;
+        Entity entity = McIf.mc().world.getEntityByID(thisId);
 
         if (!(entity instanceof AbstractHorse) || e.getPacket().getDataManagerEntries().isEmpty()) {
             return;
         }
 
-        if (entity == ModCore.mc().player.getRidingEntity()) {
+        if (entity == McIf.mc().player.getRidingEntity()) {
             lastHorseId = thisId;
             return;
         }
 
-        EntityPlayerSP player = ModCore.mc().player;
+        EntityPlayerSP player = McIf.mc().player;
         String entityName = Utils.getNameFromMetadata(e.getPacket().getDataManagerEntries());
         if (entityName == null ||  entityName.isEmpty() ||
                 !MountHorseManager.isPlayersHorse(entityName, player.getName())) return;
@@ -491,7 +489,7 @@ public class ClientEvents implements Listener {
         if (!Reference.onWorld) return;
 
         if (UtilitiesConfig.INSTANCE.preventMythicChestClose) {
-            if (e.getKeyCode() == 1 || e.getKeyCode() == ModCore.mc().gameSettings.keyBindInventory.getKeyCode()) {
+            if (e.getKeyCode() == 1 || e.getKeyCode() == McIf.mc().gameSettings.keyBindInventory.getKeyCode()) {
                 IInventory inv = e.getGui().getLowerInv();
                 if (McIf.getUnformattedText(inv.getDisplayName()).contains("Loot Chest") ||
                         McIf.getUnformattedText(inv.getDisplayName()).contains("Daily Rewards") ||
@@ -572,7 +570,7 @@ public class ClientEvents implements Listener {
             }
         }
 
-        if (UtilitiesConfig.INSTANCE.shiftClickAccessories && e.getGui().isShiftKeyDown() && e.getGui().getSlotUnderMouse() != null && ModCore.mc().player.inventory.getItemStack().isEmpty() && e.getGui().getSlotUnderMouse().inventory == ModCore.mc().player.inventory) {
+        if (UtilitiesConfig.INSTANCE.shiftClickAccessories && e.getGui().isShiftKeyDown() && e.getGui().getSlotUnderMouse() != null && McIf.mc().player.inventory.getItemStack().isEmpty() && e.getGui().getSlotUnderMouse().inventory == McIf.mc().player.inventory) {
             if (e.getSlotId() >= 9 && e.getSlotId() <= 12) { // taking off accessory
                 // check if hotbar has open slot; if so, no action required
                 for (int i = 36; i < 45; i++) {
@@ -625,8 +623,8 @@ public class ClientEvents implements Listener {
             }
 
             // pick up accessory
-            CPacketClickWindow packet = new CPacketClickWindow(e.getGui().inventorySlots.windowId, e.getSlotId(), 0, ClickType.PICKUP, e.getSlotIn().getStack(), e.getGui().inventorySlots.getNextTransactionID(ModCore.mc().player.inventory));
-            ModCore.mc().getConnection().sendPacket(packet);
+            CPacketClickWindow packet = new CPacketClickWindow(e.getGui().inventorySlots.windowId, e.getSlotId(), 0, ClickType.PICKUP, e.getSlotIn().getStack(), e.getGui().inventorySlots.getNextTransactionID(McIf.mc().player.inventory));
+            McIf.mc().getConnection().sendPacket(packet);
         }
     }
 
@@ -636,14 +634,14 @@ public class ClientEvents implements Listener {
         if (!Reference.onWorld || accessoryDestinationSlot == -1) return;
 
         // inventory was closed
-        if (!(ModCore.mc().currentScreen instanceof InventoryReplacer)) {
+        if (!(McIf.mc().currentScreen instanceof InventoryReplacer)) {
             accessoryDestinationSlot = -1;
             return;
         }
-        InventoryReplacer gui = (InventoryReplacer) ModCore.mc().currentScreen;
+        InventoryReplacer gui = (InventoryReplacer) McIf.mc().currentScreen;
 
         // no item picked up
-        if (ModCore.mc().player.inventory.getItemStack().isEmpty()) return;
+        if (McIf.mc().player.inventory.getItemStack().isEmpty()) return;
 
         // destination slot was filled in the meantime
         if (gui.inventorySlots.getSlot(accessoryDestinationSlot).getHasStack() &&
@@ -700,11 +698,11 @@ public class ClientEvents implements Listener {
                     String itemName = item.getDisplayName();
                     String pageNumber = itemName.substring(9, itemName.indexOf(TextFormatting.RED + " >"));
                     ChestReplacer gui = e.getGui();
-                    CPacketClickWindow packet = new CPacketClickWindow(gui.inventorySlots.windowId, e.getSlotId(), e.getMouseButton(), e.getType(), item, e.getGui().inventorySlots.getNextTransactionID(ModCore.mc().player.inventory));
-                    ModCore.mc().displayGuiScreen(new GuiYesNo((result, parentButtonID) -> {
-                        ModCore.mc().displayGuiScreen(gui);
+                    CPacketClickWindow packet = new CPacketClickWindow(gui.inventorySlots.windowId, e.getSlotId(), e.getMouseButton(), e.getType(), item, e.getGui().inventorySlots.getNextTransactionID(McIf.mc().player.inventory));
+                    McIf.mc().displayGuiScreen(new GuiYesNo((result, parentButtonID) -> {
+                        McIf.mc().displayGuiScreen(gui);
                         if (result) {
-                            ModCore.mc().getConnection().sendPacket(packet);
+                            McIf.mc().getConnection().sendPacket(packet);
                             bankPageConfirmed = true;
                         }
                     }, "Are you sure you want to purchase another bank page?", "Page number: " + pageNumber + "\nCost: " + priceDisplay, 0));
@@ -718,8 +716,8 @@ public class ClientEvents implements Listener {
     public void onSetSlot(PacketEvent<SPacketSetSlot> event) {
         if (bankPageConfirmed && event.getPacket().getSlot() == 8) {
             bankPageConfirmed = false;
-            CPacketClickWindow packet = new CPacketClickWindow(ModCore.mc().player.openContainer.windowId, 8, 0, ClickType.PICKUP, event.getPacket().getStack(), ModCore.mc().player.openContainer.getNextTransactionID(ModCore.mc().player.inventory));
-            ModCore.mc().getConnection().sendPacket(packet);
+            CPacketClickWindow packet = new CPacketClickWindow(McIf.mc().player.openContainer.windowId, 8, 0, ClickType.PICKUP, event.getPacket().getStack(), McIf.mc().player.openContainer.getNextTransactionID(McIf.mc().player.inventory));
+            McIf.mc().getConnection().sendPacket(packet);
         }
     }
 
@@ -871,7 +869,7 @@ public class ClientEvents implements Listener {
     public void onShiftClickPlayer(PacketEvent<CPacketUseEntity> e) {
         if (!UtilitiesConfig.INSTANCE.preventTradesDuels) return;
 
-        EntityPlayerSP player = ModCore.mc().player;
+        EntityPlayerSP player = McIf.mc().player;
         if (!player.isSneaking()) return;
 
         Entity clicked = e.getPacket().getEntityFromWorld(player.world);

--- a/src/main/java/com/wynntils/modules/utilities/events/ServerEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ServerEvents.java
@@ -4,7 +4,7 @@
 
 package com.wynntils.modules.utilities.events;
 
-import com.wynntils.ModCore;
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.events.ClientEvents;
 import com.wynntils.core.events.custom.PacketEvent;
@@ -30,7 +30,7 @@ public class ServerEvents implements Listener {
     public void leaveServer(WynncraftServerEvent.Leave e) {
         WindowIconManager.update();
         if (UtilitiesConfig.INSTANCE.changeWindowTitle) {
-            ModCore.mc().addScheduledTask(() -> Display.setTitle(oldWindowTitle));
+            McIf.mc().addScheduledTask(() -> Display.setTitle(oldWindowTitle));
         }
     }
 
@@ -44,7 +44,7 @@ public class ServerEvents implements Listener {
             oldWindowTitle = title;
         }
         if (UtilitiesConfig.INSTANCE.changeWindowTitle) {
-            ModCore.mc().addScheduledTask(() -> Display.setTitle("Wynncraft"));
+            McIf.mc().addScheduledTask(() -> Display.setTitle("Wynncraft"));
         }
         ClientEvents.setLoadingStatusMsg("Loading resources...");
         ServerResourcePackManager.applyOnServerJoin();

--- a/src/main/java/com/wynntils/modules/utilities/instances/ConsumableContainer.java
+++ b/src/main/java/com/wynntils/modules/utilities/instances/ConsumableContainer.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.utilities.instances;
 
+import com.wynntils.McIf;
 import com.wynntils.webapi.profiles.item.enums.IdentificationModifier;
 import net.minecraft.client.Minecraft;
 
@@ -95,7 +96,7 @@ public class ConsumableContainer {
      * @return if the consumable duration has already expired
      */
     public boolean hasExpired() {
-        return Minecraft.getSystemTime() >= expirationTime;
+        return McIf.getSystemTime() >= expirationTime;
     }
 
     public boolean isPersistent() {

--- a/src/main/java/com/wynntils/modules/utilities/instances/InfoFormatter.java
+++ b/src/main/java/com/wynntils/modules/utilities/instances/InfoFormatter.java
@@ -65,22 +65,22 @@ public class InfoFormatter {
 
         // X coordinate
         registerFormatter((input) ->
-                Integer.toString((int) McIf.mc().player.posX),
+                Integer.toString((int) McIf.player().posX),
                 "x");
 
         // Y coordinate
         registerFormatter((input) ->
-                Integer.toString((int) McIf.mc().player.posY),
+                Integer.toString((int) McIf.player().posY),
                 "y");
 
         // Z coordinate
         registerFormatter((input) ->
-                Integer.toString((int) McIf.mc().player.posZ),
+                Integer.toString((int) McIf.player().posZ),
                 "z");
 
         // The facing cardinal direction
         registerFormatter((input) ->
-                Utils.getPlayerDirection(McIf.mc().player.rotationYaw),
+                Utils.getPlayerDirection(McIf.player().rotationYaw),
                 "dir");
 
         // Frames per second
@@ -243,7 +243,7 @@ public class InfoFormatter {
         // Distance from compass beacon
         registerFormatter((input) ->{
             Location compass = CompassManager.getCompassLocation();
-            Location playerPos = new Location(McIf.mc().player);
+            Location playerPos = new Location(McIf.player());
 
             if (compass == null) return "";
             return String.valueOf((int) compass.distance(playerPos));

--- a/src/main/java/com/wynntils/modules/utilities/instances/InfoFormatter.java
+++ b/src/main/java/com/wynntils/modules/utilities/instances/InfoFormatter.java
@@ -32,7 +32,7 @@ import java.util.regex.Pattern;
 
 public class InfoFormatter {
 
-    private Minecraft mc = Minecraft.getMinecraft();
+    private Minecraft mc = McIf.mc();
 
     public Map<String, String> cache = new HashMap<>();
     public Map<String, InfoModule> formatters = new HashMap<>();
@@ -244,7 +244,7 @@ public class InfoFormatter {
         // Distance from compass beacon
         registerFormatter((input) ->{
             Location compass = CompassManager.getCompassLocation();
-            Location playerPos = new Location(Minecraft.getMinecraft().player);
+            Location playerPos = new Location(McIf.mc().player);
 
             if (compass == null) return "";
             return String.valueOf((int) compass.distance(playerPos));

--- a/src/main/java/com/wynntils/modules/utilities/instances/InfoFormatter.java
+++ b/src/main/java/com/wynntils/modules/utilities/instances/InfoFormatter.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.utilities.instances;
 
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.framework.instances.PlayerInfo;
 import com.wynntils.core.framework.instances.containers.UnprocessedAmount;
@@ -31,8 +32,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class InfoFormatter {
-
-    private Minecraft mc = McIf.mc();
 
     public Map<String, String> cache = new HashMap<>();
     public Map<String, InfoModule> formatters = new HashMap<>();
@@ -66,22 +65,22 @@ public class InfoFormatter {
 
         // X coordinate
         registerFormatter((input) ->
-                Integer.toString((int) mc.player.posX),
+                Integer.toString((int) McIf.mc().player.posX),
                 "x");
 
         // Y coordinate
         registerFormatter((input) ->
-                Integer.toString((int) mc.player.posY),
+                Integer.toString((int) McIf.mc().player.posY),
                 "y");
 
         // Z coordinate
         registerFormatter((input) ->
-                Integer.toString((int) mc.player.posZ),
+                Integer.toString((int) McIf.mc().player.posZ),
                 "z");
 
         // The facing cardinal direction
         registerFormatter((input) ->
-                Utils.getPlayerDirection(mc.player.rotationYaw),
+                Utils.getPlayerDirection(McIf.mc().player.rotationYaw),
                 "dir");
 
         // Frames per second

--- a/src/main/java/com/wynntils/modules/utilities/instances/ServerIcon.java
+++ b/src/main/java/com/wynntils/modules/utilities/instances/ServerIcon.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.utilities.instances;
 
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
@@ -49,7 +50,7 @@ public class ServerIcon {
         this.allowStale = allowStale;
 
         serverIcon = new ResourceLocation("servers/" + server.serverIP + "/icon");
-        icon = (DynamicTexture) Minecraft.getMinecraft().getTextureManager().getTexture(serverIcon);
+        icon = (DynamicTexture) McIf.mc().getTextureManager().getTexture(serverIcon);
 
         synchronized (ServerIcon.class) {
             instances.add(new WeakReference<>(this));
@@ -140,7 +141,7 @@ public class ServerIcon {
         lastIcon = currentIcon;
 
         if (currentIcon == null) {
-            Minecraft.getMinecraft().getTextureManager().deleteTexture(serverIcon);
+            McIf.mc().getTextureManager().deleteTexture(serverIcon);
             icon = null;
             onDone();
             return null;
@@ -158,7 +159,7 @@ public class ServerIcon {
 
         if (icon == null) {
             icon = new DynamicTexture(bufferedimage.getWidth(), bufferedimage.getHeight());
-            Minecraft.getMinecraft().getTextureManager().loadTexture(serverIcon, icon);
+            McIf.mc().getTextureManager().loadTexture(serverIcon, icon);
         }
 
         bufferedimage.getRGB(0, 0, bufferedimage.getWidth(), bufferedimage.getHeight(), icon.getTextureData(), 0, bufferedimage.getWidth());

--- a/src/main/java/com/wynntils/modules/utilities/instances/Toast.java
+++ b/src/main/java/com/wynntils/modules/utilities/instances/Toast.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.utilities.instances;
 
+import com.wynntils.McIf;
 import com.wynntils.core.utils.StringUtils;
 import net.minecraft.client.Minecraft;
 
@@ -20,7 +21,7 @@ public class Toast {
         this.title = title;
         this.subtitle = StringUtils.wrapText(subTitle, 24);
 
-        this.creationTime = Minecraft.getSystemTime();
+        this.creationTime = McIf.getSystemTime();
         this.animated = 160;
     }
 

--- a/src/main/java/com/wynntils/modules/utilities/managers/DailyReminderManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/DailyReminderManager.java
@@ -4,7 +4,7 @@
 
 package com.wynntils.modules.utilities.managers;
 
-import com.wynntils.ModCore;
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.utils.Utils;
 import com.wynntils.modules.utilities.UtilitiesModule;
@@ -43,7 +43,7 @@ public class DailyReminderManager {
             text.appendText("are available to claim!");
 
             p.sendMessage(text);
-            ModCore.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.BLOCK_NOTE_PLING, 1.0F));
+            McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.BLOCK_NOTE_PLING, 1.0F));
 
             UtilitiesConfig.Data.INSTANCE.dailyReminder = System.currentTimeMillis() + 1800000;
             UtilitiesConfig.Data.INSTANCE.saveSettings(UtilitiesModule.getModule());

--- a/src/main/java/com/wynntils/modules/utilities/managers/ItemScreenshotManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/ItemScreenshotManager.java
@@ -53,7 +53,7 @@ public class ItemScreenshotManager {
         ItemStack stack = slot.getStack();
         if (!stack.hasDisplayName()) return;
 
-        List<String> tooltip = stack.getTooltip(McIf.mc().player, ITooltipFlag.TooltipFlags.NORMAL);
+        List<String> tooltip = stack.getTooltip(McIf.player(), ITooltipFlag.TooltipFlags.NORMAL);
         removeItemLore(tooltip);
 
         FontRenderer fr = McIf.mc().fontRenderer;
@@ -104,7 +104,7 @@ public class ItemScreenshotManager {
         ClipboardImage ci = new ClipboardImage(bi);
         Toolkit.getDefaultToolkit().getSystemClipboard().setContents(ci, null);
 
-        McIf.mc().player.sendMessage(new TextComponentString(TextFormatting.GREEN + "Copied " + stack.getDisplayName() + TextFormatting.GREEN + " to the clipboard!"));
+        McIf.player().sendMessage(new TextComponentString(TextFormatting.GREEN + "Copied " + stack.getDisplayName() + TextFormatting.GREEN + " to the clipboard!"));
     }
 
     private static void removeItemLore(List<String> tooltip) {

--- a/src/main/java/com/wynntils/modules/utilities/managers/ItemScreenshotManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/ItemScreenshotManager.java
@@ -20,7 +20,7 @@ import java.util.regex.Pattern;
 import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL11;
 
-import com.wynntils.ModCore;
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 
 import net.minecraft.client.gui.FontRenderer;
@@ -40,36 +40,36 @@ import net.minecraft.util.text.TextComponentString;
 import net.minecraft.util.text.TextFormatting;
 
 public class ItemScreenshotManager {
-    
+
     private static Pattern ITEM_PATTERN = Pattern.compile("(Normal|Set|Unique|Rare|Legendary|Fabled|Mythic) Item.*");
-    
+
     public static void takeScreenshot() {
         if (!Reference.onWorld) return;
-        GuiScreen gui = ModCore.mc().currentScreen;
+        GuiScreen gui = McIf.mc().currentScreen;
         if (!(gui instanceof GuiContainer)) return;
-        
+
         Slot slot = ((GuiContainer) gui).getSlotUnderMouse();
         if (slot == null || !slot.getHasStack()) return;
         ItemStack stack = slot.getStack();
         if (!stack.hasDisplayName()) return;
-        
-        List<String> tooltip = stack.getTooltip(ModCore.mc().player, ITooltipFlag.TooltipFlags.NORMAL);
+
+        List<String> tooltip = stack.getTooltip(McIf.mc().player, ITooltipFlag.TooltipFlags.NORMAL);
         removeItemLore(tooltip);
-        
-        FontRenderer fr = ModCore.mc().fontRenderer;
+
+        FontRenderer fr = McIf.mc().fontRenderer;
         int width = 0;
         int height = 16;
-        
+
         // calculate width of tooltip
         for (String s : tooltip) {
             int w = fr.getStringWidth(s);
             if (w > width) width = w;
         }
         width += 8;
-        
+
         // calculate height of tooltip
         if (tooltip.size() > 1) height += 2 + (tooltip.size() - 1) * 10;
-        
+
         // account for text wrapping
         if (width > gui.width/2 + 8) {
             int wrappedWidth = 0;
@@ -85,11 +85,11 @@ public class ItemScreenshotManager {
             width = wrappedWidth + 8;
             height = 16 + (2 + (wrappedLines - 1) * 10);
         }
-        
+
         // calculate scale of tooltip to fit it to the framebuffer
         float scaleh = (float) gui.height/height;
         float scalew = (float) gui.width/width;
-        
+
         // draw tooltip to framebuffer, create image from it
         GlStateManager.pushMatrix();
         Framebuffer fb = new Framebuffer((int) (gui.width*(1/scalew)*2), (int) (gui.height*(1/scaleh)*2), true);
@@ -99,14 +99,14 @@ public class ItemScreenshotManager {
         BufferedImage bi = createScreenshot(width*2, height*2);
         fb.unbindFramebuffer();
         GlStateManager.popMatrix();
-        
+
         // copy to clipboard
         ClipboardImage ci = new ClipboardImage(bi);
         Toolkit.getDefaultToolkit().getSystemClipboard().setContents(ci, null);
-        
-        ModCore.mc().player.sendMessage(new TextComponentString(TextFormatting.GREEN + "Copied " + stack.getDisplayName() + TextFormatting.GREEN + " to the clipboard!"));
+
+        McIf.mc().player.sendMessage(new TextComponentString(TextFormatting.GREEN + "Copied " + stack.getDisplayName() + TextFormatting.GREEN + " to the clipboard!"));
     }
-    
+
     private static void removeItemLore(List<String> tooltip) {
         // iterate through each line of the tooltip and remove item lore
         List<String> temp = new ArrayList<>();
@@ -115,12 +115,12 @@ public class ItemScreenshotManager {
             // only remove text after the item type indicator
             Matcher m = ITEM_PATTERN.matcher(TextFormatting.getTextWithoutFormattingCodes(s));
             if (!lore && m.matches()) lore = true;
-            
+
             if (lore && s.contains("" + TextFormatting.DARK_GRAY)) temp.add(s);
         }
         tooltip.removeAll(temp);
     }
-    
+
     private static void drawTooltip(List<String> textLines, int maxTextWidth, FontRenderer font) {
         GlStateManager.disableRescaleNormal();
         RenderHelper.disableStandardItemLighting();
@@ -152,14 +152,14 @@ public class ItemScreenshotManager {
             for (int i = 0; i < textLines.size(); i++) {
                 String textLine = textLines.get(i);
                 List<String> wrappedLine = font.listFormattedStringToWidth(textLine, tooltipTextWidth);
-                if (i == 0) 
+                if (i == 0)
                     titleLinesCount = wrappedLine.size();
 
                 for (String line : wrappedLine) {
                     int lineWidth = font.getStringWidth(line);
                     if (lineWidth > wrappedTooltipWidth)
                         wrappedTooltipWidth = lineWidth;
-                    
+
                     wrappedTextLines.add(line);
                 }
             }
@@ -170,7 +170,7 @@ public class ItemScreenshotManager {
         int tooltipHeight = 8;
         if (textLines.size() > 1) {
             tooltipHeight += (textLines.size() - 1) * 10;
-            if (textLines.size() > titleLinesCount) 
+            if (textLines.size() > titleLinesCount)
                 tooltipHeight += 2; // gap between title lines and next lines
         }
 
@@ -205,7 +205,7 @@ public class ItemScreenshotManager {
         RenderHelper.enableStandardItemLighting();
         GlStateManager.enableRescaleNormal();
     }
-    
+
     private static void drawGradientRect(int zLevel, int left, int top, int right, int bottom, int startColor, int endColor) {
         float startAlpha = (float)(startColor >> 24 & 255) / 255.0F;
         float startRed   = (float)(startColor >> 16 & 255) / 255.0F;
@@ -236,7 +236,7 @@ public class ItemScreenshotManager {
         GlStateManager.enableAlpha();
         GlStateManager.enableTexture2D();
     }
-    
+
     private static BufferedImage createScreenshot(int width, int height) {
         // create pixel arrays
         int i = width * height;
@@ -255,11 +255,11 @@ public class ItemScreenshotManager {
         bufferedimage.setRGB(0, 0, width, height, pixelValues, 0, width);
         return bufferedimage;
     }
-    
+
     private static class ClipboardImage implements Transferable {
-        
+
         Image image;
-        
+
         public ClipboardImage(Image image) {
             this.image = image;
         }
@@ -279,7 +279,7 @@ public class ItemScreenshotManager {
             if (!DataFlavor.imageFlavor.equals(flavor)) throw new UnsupportedFlavorException(flavor);
             return this.image;
         }
-        
+
     }
 
 }

--- a/src/main/java/com/wynntils/modules/utilities/managers/KeyManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/KeyManager.java
@@ -69,13 +69,13 @@ public class KeyManager {
         CoreModule.getModule().registerKeyBinding("Mob Totem Menu", Keyboard.KEY_J, "Wynntils", KeyConflictContext.IN_GAME, true, () -> {
             if (!Reference.onWorld) return;
 
-            McIf.mc().player.sendChatMessage("/totem");
+            McIf.player().sendChatMessage("/totem");
         });
 
         CoreModule.getModule().registerKeyBinding("Open Ingredient Pouch", Keyboard.KEY_O, "Wynntils", KeyConflictContext.IN_GAME, true, () -> {
             if (!Reference.onWorld) return;
 
-            EntityPlayerSP player = McIf.mc().player;
+            EntityPlayerSP player = McIf.player();
             player.connection.sendPacket(new CPacketClickWindow(
                     player.inventoryContainer.windowId,
                     13, 0, ClickType.PICKUP, player.inventory.getStackInSlot(13),

--- a/src/main/java/com/wynntils/modules/utilities/managers/KeyManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/KeyManager.java
@@ -70,13 +70,13 @@ public class KeyManager {
         CoreModule.getModule().registerKeyBinding("Mob Totem Menu", Keyboard.KEY_J, "Wynntils", KeyConflictContext.IN_GAME, true, () -> {
             if (!Reference.onWorld) return;
 
-            Minecraft.getMinecraft().player.sendChatMessage("/totem");
+            McIf.mc().player.sendChatMessage("/totem");
         });
 
         CoreModule.getModule().registerKeyBinding("Open Ingredient Pouch", Keyboard.KEY_O, "Wynntils", KeyConflictContext.IN_GAME, true, () -> {
             if (!Reference.onWorld) return;
 
-            EntityPlayerSP player = Minecraft.getMinecraft().player;
+            EntityPlayerSP player = McIf.mc().player;
             player.connection.sendPacket(new CPacketClickWindow(
                     player.inventoryContainer.windowId,
                     13, 0, ClickType.PICKUP, player.inventory.getStackInSlot(13),

--- a/src/main/java/com/wynntils/modules/utilities/managers/KeyManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/KeyManager.java
@@ -4,7 +4,7 @@
 
 package com.wynntils.modules.utilities.managers;
 
-import com.wynntils.ModCore;
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.framework.enums.wynntils.WynntilsConflictContext;
 import com.wynntils.core.framework.instances.KeyHolder;
@@ -16,7 +16,6 @@ import com.wynntils.modules.utilities.events.ClientEvents;
 import com.wynntils.modules.utilities.overlays.hud.StopWatchOverlay;
 import com.wynntils.modules.utilities.overlays.ui.GearViewerUI;
 import com.wynntils.webapi.WebManager;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.inventory.ClickType;
 import net.minecraft.network.play.client.CPacketClickWindow;
@@ -38,18 +37,18 @@ public class KeyManager {
 
     public static void registerKeys() {
         UtilitiesModule.getModule().registerKeyBinding("Gammabright", Keyboard.KEY_G, "Wynntils", KeyConflictContext.IN_GAME, true, () -> {
-            if (ModCore.mc().gameSettings.gammaSetting < 1000) {
-                lastGamma = ModCore.mc().gameSettings.gammaSetting;
-                ModCore.mc().gameSettings.gammaSetting = 1000;
+            if (McIf.mc().gameSettings.gammaSetting < 1000) {
+                lastGamma = McIf.mc().gameSettings.gammaSetting;
+                McIf.mc().gameSettings.gammaSetting = 1000;
                 return;
             }
 
-            ModCore.mc().gameSettings.gammaSetting = lastGamma;
+            McIf.mc().gameSettings.gammaSetting = lastGamma;
         });
 
         checkForUpdatesKey = CoreModule.getModule().registerKeyBinding("Check for Updates", Keyboard.KEY_L, "Wynntils", true, WebManager::checkForUpdates);
 
-        CoreModule.getModule().registerKeyBinding("Open Settings", Keyboard.KEY_P, "Wynntils", KeyConflictContext.IN_GAME, true, () -> ModCore.mc().displayGuiScreen(SettingsUI.getInstance(ModCore.mc().currentScreen)));
+        CoreModule.getModule().registerKeyBinding("Open Settings", Keyboard.KEY_P, "Wynntils", KeyConflictContext.IN_GAME, true, () -> McIf.mc().displayGuiScreen(SettingsUI.getInstance(McIf.mc().currentScreen)));
 
         lockInventoryKey = UtilitiesModule.getModule().registerKeyBinding("Lock Slot", Keyboard.KEY_H, "Wynntils", KeyConflictContext.GUI, true, () -> {});
         favoriteTradeKey = UtilitiesModule.getModule().registerKeyBinding("Favorite Trade", Keyboard.KEY_F, "Wynntils", KeyConflictContext.GUI, true, () -> {});

--- a/src/main/java/com/wynntils/modules/utilities/managers/MountHorseManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/MountHorseManager.java
@@ -47,7 +47,7 @@ public class MountHorseManager {
     }
 
     private static Entity findHorseInRadius() {
-        EntityPlayerSP player = McIf.mc().player;
+        EntityPlayerSP player = McIf.player();
 
         List<Entity> horses = McIf.world().getEntitiesWithinAABB(AbstractHorse.class, new AxisAlignedBB(
                 player.posX - searchRadius, player.posY - searchRadius, player.posZ - searchRadius,
@@ -77,11 +77,11 @@ public class MountHorseManager {
             return;
         }
 
-        int prev = McIf.mc().player.inventory.currentItem;
+        int prev = McIf.player().inventory.currentItem;
         new Delay(() -> {
-            McIf.mc().player.inventory.currentItem = horse.getInventorySlot();
-            McIf.mc().playerController.processRightClick(McIf.mc().player, McIf.mc().player.world, EnumHand.MAIN_HAND);
-            McIf.mc().player.inventory.currentItem = prev;
+            McIf.player().inventory.currentItem = horse.getInventorySlot();
+            McIf.mc().playerController.processRightClick(McIf.player(), McIf.player().world, EnumHand.MAIN_HAND);
+            McIf.player().inventory.currentItem = prev;
 
             if (findHorseInRadius() != null) {
                 ClientEvents.isAwaitingHorseMount = true;
@@ -96,7 +96,7 @@ public class MountHorseManager {
     }
 
     public static MountHorseStatus mountHorse(boolean allowRetry) {
-        EntityPlayerSP player = McIf.mc().player;
+        EntityPlayerSP player = McIf.player();
         PlayerControllerMP playerController = McIf.mc().playerController;
 
         HorseData horse = PlayerInfo.get(HorseData.class);
@@ -148,7 +148,7 @@ public class MountHorseManager {
     public static String getMountHorseErrorMessage(MountHorseStatus status) {
         switch (status) {
             case ALREADY_RIDING:
-                Entity ridingEntity = McIf.mc().player.getRidingEntity();
+                Entity ridingEntity = McIf.player().getRidingEntity();
                 String ridingEntityType;
                 if (ridingEntity == null) {
                     ridingEntityType = "nothing?";

--- a/src/main/java/com/wynntils/modules/utilities/managers/MountHorseManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/MountHorseManager.java
@@ -49,7 +49,7 @@ public class MountHorseManager {
     private static Entity findHorseInRadius() {
         EntityPlayerSP player = McIf.mc().player;
 
-        List<Entity> horses = McIf.mc().world.getEntitiesWithinAABB(AbstractHorse.class, new AxisAlignedBB(
+        List<Entity> horses = McIf.world().getEntitiesWithinAABB(AbstractHorse.class, new AxisAlignedBB(
                 player.posX - searchRadius, player.posY - searchRadius, player.posZ - searchRadius,
                 player.posX + searchRadius, player.posY + searchRadius, player.posZ + searchRadius
         ));

--- a/src/main/java/com/wynntils/modules/utilities/managers/NametagManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/NametagManager.java
@@ -115,7 +115,7 @@ public class NametagManager {
         if (entity.isBeingRidden()) return false;
         if (!(entity instanceof EntityPlayer)) return entity.getAlwaysRenderNameTagForRender() && entity.hasCustomName();
 
-        EntityPlayerSP player = Minecraft.getMinecraft().player;
+        EntityPlayerSP player = McIf.mc().player;
         boolean isVisible = !entity.isInvisibleToPlayer(player);
 
         // we also need to consider the teams
@@ -227,7 +227,7 @@ public class NametagManager {
      * Draws the nametag, don't call this, use checkForNametags to add more nametags
      */
     private static void drawNametag(String input, CustomColor color, float x, float y, float z, int verticalShift, float viewerYaw, float viewerPitch, boolean isThirdPersonFrontal, boolean isSneaking, float scale) {
-        FontRenderer fontRenderer = Minecraft.getMinecraft().fontRenderer;  // since our fontrender ignores bold or italic texts we need to use the mc one
+        FontRenderer fontRenderer = McIf.mc().fontRenderer;  // since our fontrender ignores bold or italic texts we need to use the mc one
 
         pushMatrix();
         {
@@ -316,7 +316,7 @@ public class NametagManager {
         List<NametagLabel> labels = new ArrayList<>();
 
         // detects if the user is looking into the player
-        if (Minecraft.getMinecraft().objectMouseOver == null || Minecraft.getMinecraft().objectMouseOver.entityHit == null || Minecraft.getMinecraft().objectMouseOver.entityHit != player) return labels;
+        if (McIf.mc().objectMouseOver == null || McIf.mc().objectMouseOver.entityHit == null || McIf.mc().objectMouseOver.entityHit != player) return labels;
 
         for (ItemStack is : player.getEquipmentAndArmor()) {
             if (!is.hasDisplayName()) continue;

--- a/src/main/java/com/wynntils/modules/utilities/managers/NametagManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/NametagManager.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.utilities.managers;
 
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.framework.enums.professions.ProfessionType;
 import com.wynntils.core.framework.instances.PlayerInfo;
@@ -102,7 +103,7 @@ public class NametagManager {
         if (distance > range) return true;
 
         alphaFunc(516, 0.1F);
-        drawLabels(entity, entity.getDisplayName().getFormattedText(), e.getX(), e.getY(), e.getZ(), e.getRenderer().getRenderManager(), customLabels);
+        drawLabels(entity, McIf.getFormattedText(entity.getDisplayName()), e.getX(), e.getY(), e.getZ(), e.getRenderer().getRenderManager(), customLabels);
 
         return true;
     }

--- a/src/main/java/com/wynntils/modules/utilities/managers/NametagManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/NametagManager.java
@@ -115,7 +115,7 @@ public class NametagManager {
         if (entity.isBeingRidden()) return false;
         if (!(entity instanceof EntityPlayer)) return entity.getAlwaysRenderNameTagForRender() && entity.hasCustomName();
 
-        EntityPlayerSP player = McIf.mc().player;
+        EntityPlayerSP player = McIf.player();
         boolean isVisible = !entity.isInvisibleToPlayer(player);
 
         // we also need to consider the teams

--- a/src/main/java/com/wynntils/modules/utilities/managers/QuickCastManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/QuickCastManager.java
@@ -90,7 +90,7 @@ public class QuickCastManager {
         }
 
         if (PlayerInfo.get(CharacterData.class).getLevel() < spellUnlock[spell - 1]) {
-            McIf.mc().player.sendMessage(new TextComponentString(
+            McIf.player().sendMessage(new TextComponentString(
                     TextFormatting.GRAY + "You have not yet unlocked this spell! You need to be level " + spellUnlock[spell - 1]
             ));
             return false;

--- a/src/main/java/com/wynntils/modules/utilities/managers/QuickCastManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/QuickCastManager.java
@@ -90,7 +90,7 @@ public class QuickCastManager {
         }
 
         if (PlayerInfo.get(CharacterData.class).getLevel() < spellUnlock[spell - 1]) {
-            Minecraft.getMinecraft().player.sendMessage(new TextComponentString(
+            McIf.mc().player.sendMessage(new TextComponentString(
                     TextFormatting.GRAY + "You have not yet unlocked this spell! You need to be level " + spellUnlock[spell - 1]
             ));
             return false;

--- a/src/main/java/com/wynntils/modules/utilities/managers/QuickCastManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/QuickCastManager.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.utilities.managers;
 
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.framework.enums.ClassType;
 import com.wynntils.core.framework.instances.PlayerInfo;
@@ -111,7 +112,7 @@ public class QuickCastManager {
             SPacketChat title = (SPacketChat) input;
             if (title.getType() != ChatType.GAME_INFO) return false;
 
-            PlayerInfo.get(ActionBarData.class).updateActionBar(title.getChatComponent().getUnformattedText());
+            PlayerInfo.get(ActionBarData.class).updateActionBar(McIf.getUnformattedText(title.getChatComponent()));
 
             spell = data.getLastSpell();
         }

--- a/src/main/java/com/wynntils/modules/utilities/managers/QuickCastManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/QuickCastManager.java
@@ -107,7 +107,7 @@ public class QuickCastManager {
             SPacketTitle title = (SPacketTitle) input;
             if (title.getType() != SPacketTitle.Type.SUBTITLE) return false;
 
-            spell = data.parseSpellFromTitle(title.getMessage().getFormattedText());
+            spell = data.parseSpellFromTitle(McIf.getFormattedText(title.getMessage()));
         } else {
             SPacketChat title = (SPacketChat) input;
             if (title.getType() != ChatType.GAME_INFO) return false;

--- a/src/main/java/com/wynntils/modules/utilities/managers/ServerResourcePackManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/ServerResourcePackManager.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.utilities.managers;
 
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.modules.utilities.UtilitiesModule;
 import com.wynntils.modules.utilities.configs.UtilitiesConfig;

--- a/src/main/java/com/wynntils/modules/utilities/managers/ServerResourcePackManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/ServerResourcePackManager.java
@@ -24,8 +24,8 @@ public class ServerResourcePackManager {
     public static void applyOnServerJoin() {
         if (!Reference.onServer) return;
 
-        if (Minecraft.getMinecraft().getResourcePackRepository().getServerResourcePack() == null && UtilitiesConfig.INSTANCE.autoResource && !UtilitiesConfig.INSTANCE.lastServerResourcePack.isEmpty()) {
-            if (Minecraft.getMinecraft().getCurrentServerData().getResourceMode() != ServerData.ServerResourceMode.ENABLED) {
+        if (McIf.mc().getResourcePackRepository().getServerResourcePack() == null && UtilitiesConfig.INSTANCE.autoResource && !UtilitiesConfig.INSTANCE.lastServerResourcePack.isEmpty()) {
+            if (McIf.mc().getCurrentServerData().getResourceMode() != ServerData.ServerResourceMode.ENABLED) {
                 Reference.LOGGER.warn("Did not auto apply Wynncraft server resource pack because resource packs have not been enabled");
                 return;
             }
@@ -57,10 +57,10 @@ public class ServerResourcePackManager {
             UtilitiesConfig.INSTANCE.saveSettings(UtilitiesModule.getModule());
         }
 
-        IResourcePack current = Minecraft.getMinecraft().getResourcePackRepository().getServerResourcePack();
+        IResourcePack current = McIf.mc().getResourcePackRepository().getServerResourcePack();
         if (current != null && current.getPackName().equals(fileName)) {
             boolean hashMatches = false;
-            try (InputStream is = new FileInputStream(new File(new File(Minecraft.getMinecraft().gameDir, "server-resource-packs"), fileName))) {
+            try (InputStream is = new FileInputStream(new File(new File(McIf.mc().gameDir, "server-resource-packs"), fileName))) {
                 hashMatches = DigestUtils.sha1Hex(is).equalsIgnoreCase(hash);
             } catch (IOException err) {
                 err.printStackTrace();
@@ -75,7 +75,7 @@ public class ServerResourcePackManager {
     public static boolean isLoaded() {
         if (UtilitiesConfig.INSTANCE.lastServerResourcePack.isEmpty()) return false;
 
-        IResourcePack current = Minecraft.getMinecraft().getResourcePackRepository().getServerResourcePack();
+        IResourcePack current = McIf.mc().getResourcePackRepository().getServerResourcePack();
         if (current == null) return false;
 
         String resourcePack = UtilitiesConfig.INSTANCE.lastServerResourcePack;
@@ -83,7 +83,7 @@ public class ServerResourcePackManager {
         String fileName = DigestUtils.sha1Hex(resourcePack);
         if (!current.getPackName().equals(fileName)) return false;
 
-        try (InputStream is = new FileInputStream(new File(new File(Minecraft.getMinecraft().gameDir, "server-resource-packs"), fileName))) {
+        try (InputStream is = new FileInputStream(new File(new File(McIf.mc().gameDir, "server-resource-packs"), fileName))) {
             return DigestUtils.sha1Hex(is).equalsIgnoreCase(hash);
         } catch (IOException err) {
             err.printStackTrace();
@@ -95,7 +95,7 @@ public class ServerResourcePackManager {
     public static void loadServerResourcePack() {
         // Does not download if not found / invalid
         if (UtilitiesConfig.INSTANCE.lastServerResourcePack.isEmpty()) return;
-        IResourcePack current = Minecraft.getMinecraft().getResourcePackRepository().getServerResourcePack();
+        IResourcePack current = McIf.mc().getResourcePackRepository().getServerResourcePack();
 
         String resourcePack = UtilitiesConfig.INSTANCE.lastServerResourcePack;
         String hash = UtilitiesConfig.INSTANCE.lastServerResourcePackHash;
@@ -105,7 +105,7 @@ public class ServerResourcePackManager {
             return; // Already applied
         }
 
-        File f = new File(new File(Minecraft.getMinecraft().gameDir, "server-resource-packs"), fileName);
+        File f = new File(new File(McIf.mc().gameDir, "server-resource-packs"), fileName);
 
         boolean valid = false;
         try (InputStream is = new FileInputStream(f)) {
@@ -116,7 +116,7 @@ public class ServerResourcePackManager {
 
         if (!valid) return;
 
-        Minecraft.getMinecraft().getResourcePackRepository().setServerResourcePack(f);
+        McIf.mc().getResourcePackRepository().setServerResourcePack(f);
     }
 
     public static void downloadServerResourcePack() {
@@ -124,7 +124,7 @@ public class ServerResourcePackManager {
 
         if (UtilitiesConfig.INSTANCE.lastServerResourcePack.isEmpty()) return;
         try {
-            Minecraft.getMinecraft().getResourcePackRepository().downloadResourcePack(UtilitiesConfig.INSTANCE.lastServerResourcePack, UtilitiesConfig.INSTANCE.lastServerResourcePackHash).get();
+            McIf.mc().getResourcePackRepository().downloadResourcePack(UtilitiesConfig.INSTANCE.lastServerResourcePack, UtilitiesConfig.INSTANCE.lastServerResourcePackHash).get();
         } catch (InterruptedException ignored) {
         } catch (ExecutionException e) {
             Reference.LOGGER.error("Could not load server resource pack");

--- a/src/main/java/com/wynntils/modules/utilities/managers/SpeedometerManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/SpeedometerManager.java
@@ -11,7 +11,7 @@ import net.minecraft.util.math.MathHelper;
 public class SpeedometerManager {
 
     public static double getCurrentSpeed() {
-        EntityPlayerSP player = Minecraft.getMinecraft().player;
+        EntityPlayerSP player = McIf.mc().player;
 
         double distX = player.posX - player.prevPosX;
         double distZ = player.posZ - player.prevPosZ;

--- a/src/main/java/com/wynntils/modules/utilities/managers/SpeedometerManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/SpeedometerManager.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.utilities.managers;
 
+import com.wynntils.McIf;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.util.math.MathHelper;

--- a/src/main/java/com/wynntils/modules/utilities/managers/SpeedometerManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/SpeedometerManager.java
@@ -11,7 +11,7 @@ import net.minecraft.util.math.MathHelper;
 public class SpeedometerManager {
 
     public static double getCurrentSpeed() {
-        EntityPlayerSP player = McIf.mc().player;
+        EntityPlayerSP player = McIf.player();
 
         double distX = player.posX - player.prevPosX;
         double distZ = player.posZ - player.prevPosZ;

--- a/src/main/java/com/wynntils/modules/utilities/managers/WarManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/WarManager.java
@@ -39,7 +39,7 @@ public class WarManager {
     public static boolean allowClick(PacketEvent<CPacketUseEntity> e) {
         if (!UtilitiesConfig.Wars.INSTANCE.blockWorkstations || !Reference.onWars) return false;
 
-        Entity in = e.getPacket().getEntityFromWorld(McIf.mc().world);
+        Entity in = e.getPacket().getEntityFromWorld(McIf.world());
         return in instanceof EntityArmorStand || in instanceof EntitySlime;
     }
 

--- a/src/main/java/com/wynntils/modules/utilities/managers/WarManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/WarManager.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.utilities.managers;
 
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.PacketEvent;
 import com.wynntils.modules.utilities.configs.UtilitiesConfig;

--- a/src/main/java/com/wynntils/modules/utilities/managers/WarManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/WarManager.java
@@ -39,7 +39,7 @@ public class WarManager {
     public static boolean allowClick(PacketEvent<CPacketUseEntity> e) {
         if (!UtilitiesConfig.Wars.INSTANCE.blockWorkstations || !Reference.onWars) return false;
 
-        Entity in = e.getPacket().getEntityFromWorld(Minecraft.getMinecraft().world);
+        Entity in = e.getPacket().getEntityFromWorld(McIf.mc().world);
         return in instanceof EntityArmorStand || in instanceof EntitySlime;
     }
 

--- a/src/main/java/com/wynntils/modules/utilities/managers/WindowIconManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/WindowIconManager.java
@@ -22,14 +22,14 @@ public class WindowIconManager {
     private static boolean serverIconInvalid = false;
 
     private static void deleteIcon() {
-        Minecraft.getMinecraft().addScheduledTask(() -> ReflectionMethods.Minecraft$setWindowIcon.invoke(Minecraft.getMinecraft()));
+        McIf.mc().addScheduledTask(() -> ReflectionMethods.Minecraft$setWindowIcon.invoke(Minecraft.getMinecraft()));
         setToServerIcon = false;
         serverIconInvalid = false;
     }
 
     private static void setIcon() {
         BufferedImage bufferedimage;
-        ServerData server = Minecraft.getMinecraft().getCurrentServerData();
+        ServerData server = McIf.mc().getCurrentServerData();
         String base64;
         if (server == null || (base64 = server.getBase64EncodedIconData()) == null) {
             serverIconInvalid = true;
@@ -88,7 +88,7 @@ public class WindowIconManager {
         bytebuffer32.flip();
         bytebuffer16.flip();
 
-        Minecraft.getMinecraft().addScheduledTask(() -> Display.setIcon(new ByteBuffer[]{ bytebuffer128, bytebuffer64, bytebuffer32, bytebuffer16 }));
+        McIf.mc().addScheduledTask(() -> Display.setIcon(new ByteBuffer[]{ bytebuffer128, bytebuffer64, bytebuffer32, bytebuffer16 }));
         setToServerIcon = true;
         serverIconInvalid = false;
     }

--- a/src/main/java/com/wynntils/modules/utilities/managers/WindowIconManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/WindowIconManager.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.utilities.managers;
 
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.utils.reflections.ReflectionMethods;
 import com.wynntils.modules.utilities.configs.UtilitiesConfig;

--- a/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
@@ -119,7 +119,7 @@ public class OverlayEvents implements Listener {
             /*Inventory full message*/
             if (OverlayConfig.GameUpdate.GameUpdateInventoryMessages.INSTANCE.enabled) {
                 if (tickcounter % (int) (OverlayConfig.GameUpdate.GameUpdateInventoryMessages.INSTANCE.inventoryUpdateRate * 20f) == 0) {
-                    IInventory inv = McIf.mc().player.inventory;
+                    IInventory inv = McIf.player().inventory;
                     int itemCounter = 0;
                     for (int i = 0; i < inv.getSizeInventory(); i++) {
                         if (!inv.getStackInSlot(i).isEmpty()) {
@@ -176,7 +176,7 @@ public class OverlayEvents implements Listener {
             if (!wynnExpTimestampNotified) {
                 TextComponentString text = new TextComponentString("[" + Reference.NAME + "] WynnExpansion's chat timestamps detected, please use " + Reference.NAME + "' chat timestamps for full compatibility.");
                 text.getStyle().setColor(DARK_RED);
-                McIf.mc().player.sendMessage(text);
+                McIf.player().sendMessage(text);
                 wynnExpTimestampNotified = true;
             }
         }
@@ -770,7 +770,7 @@ public class OverlayEvents implements Listener {
         if (!Reference.onWorld || !OverlayConfig.ConsumableTimer.INSTANCE.showSpellEffects) return;
 
         SPacketEntityEffect effect = e.getPacket();
-        if (effect.getEntityId() != McIf.mc().player.getEntityId()) return;
+        if (effect.getEntityId() != McIf.player().getEntityId()) return;
 
         Potion potion = Potion.getPotionById(effect.getEffectId());
 
@@ -817,7 +817,7 @@ public class OverlayEvents implements Listener {
         if (!Reference.onWorld || !OverlayConfig.ConsumableTimer.INSTANCE.showSpellEffects) return;
 
         SPacketRemoveEntityEffect effect = e.getPacket();
-        if (effect.getEntity(McIf.world()) != McIf.mc().player) return;
+        if (effect.getEntity(McIf.world()) != McIf.player()) return;
 
         McIf.mc().addScheduledTask(() -> {
             Potion potion = effect.getPotion();

--- a/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
@@ -120,7 +120,7 @@ public class OverlayEvents implements Listener {
             /*Inventory full message*/
             if (OverlayConfig.GameUpdate.GameUpdateInventoryMessages.INSTANCE.enabled) {
                 if (tickcounter % (int) (OverlayConfig.GameUpdate.GameUpdateInventoryMessages.INSTANCE.inventoryUpdateRate * 20f) == 0) {
-                    IInventory inv = Minecraft.getMinecraft().player.inventory;
+                    IInventory inv = McIf.mc().player.inventory;
                     int itemCounter = 0;
                     for (int i = 0; i < inv.getSizeInventory(); i++) {
                         if (!inv.getStackInSlot(i).isEmpty()) {
@@ -177,7 +177,7 @@ public class OverlayEvents implements Listener {
             if (!wynnExpTimestampNotified) {
                 TextComponentString text = new TextComponentString("[" + Reference.NAME + "] WynnExpansion's chat timestamps detected, please use " + Reference.NAME + "' chat timestamps for full compatibility.");
                 text.getStyle().setColor(DARK_RED);
-                Minecraft.getMinecraft().player.sendMessage(text);
+                McIf.mc().player.sendMessage(text);
                 wynnExpTimestampNotified = true;
             }
         }
@@ -771,7 +771,7 @@ public class OverlayEvents implements Listener {
         if (!Reference.onWorld || !OverlayConfig.ConsumableTimer.INSTANCE.showSpellEffects) return;
 
         SPacketEntityEffect effect = e.getPacket();
-        if (effect.getEntityId() != Minecraft.getMinecraft().player.getEntityId()) return;
+        if (effect.getEntityId() != McIf.mc().player.getEntityId()) return;
 
         Potion potion = Potion.getPotionById(effect.getEffectId());
 
@@ -809,7 +809,7 @@ public class OverlayEvents implements Listener {
         }
 
         // create timer with name and duration (duration in ticks)/20 -> seconds
-        Minecraft.getMinecraft().addScheduledTask(() ->
+        McIf.mc().addScheduledTask(() ->
                 ConsumableTimerOverlay.addBasicTimer(timerName, effect.getDuration() / 20));
     }
 
@@ -818,9 +818,9 @@ public class OverlayEvents implements Listener {
         if (!Reference.onWorld || !OverlayConfig.ConsumableTimer.INSTANCE.showSpellEffects) return;
 
         SPacketRemoveEntityEffect effect = e.getPacket();
-        if (effect.getEntity(Minecraft.getMinecraft().world) != Minecraft.getMinecraft().player) return;
+        if (effect.getEntity(McIf.mc().world) != McIf.mc().player) return;
 
-        Minecraft.getMinecraft().addScheduledTask(() -> {
+        McIf.mc().addScheduledTask(() -> {
             Potion potion = effect.getPotion();
 
             // When removing speed boost from (archer)

--- a/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.utilities.overlays;
 
+import com.wynntils.McIf;
 import com.wynntils.ModCore;
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.*;
@@ -155,7 +156,7 @@ public class OverlayEvents implements Listener {
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onScrollUsed(ChatEvent.Post e) {
-        String messageText = e.getMessage().getUnformattedText();
+        String messageText = McIf.getUnformattedText(e.getMessage());
         if (messageText.matches(".*? for [0-9]* seconds\\]")) { //consumable message
             //10 tick delay, since chat event occurs before default consumable event
             new Delay(() -> ConsumableTimerOverlay.addExternalScroll(messageText), 10);
@@ -169,8 +170,8 @@ public class OverlayEvents implements Listener {
             return;
         }
 
-        if (!Reference.onWorld || e.getMessage().getUnformattedText().equals(" ")) return;
-        String messageText = e.getMessage().getUnformattedText();
+        if (!Reference.onWorld || McIf.getUnformattedText(e.getMessage()).equals(" ")) return;
+        String messageText = McIf.getUnformattedText(e.getMessage());
         String formattedText = e.getMessage().getFormattedText();
         if (messageText.split(" ")[0].matches("\\[\\d+:\\d+\\]")) {
             if (!wynnExpTimestampNotified) {

--- a/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
@@ -172,7 +172,7 @@ public class OverlayEvents implements Listener {
 
         if (!Reference.onWorld || McIf.getUnformattedText(e.getMessage()).equals(" ")) return;
         String messageText = McIf.getUnformattedText(e.getMessage());
-        String formattedText = e.getMessage().getFormattedText();
+        String formattedText = McIf.getFormattedText(e.getMessage());
         if (messageText.split(" ")[0].matches("\\[\\d+:\\d+\\]")) {
             if (!wynnExpTimestampNotified) {
                 TextComponentString text = new TextComponentString("[" + Reference.NAME + "] WynnExpansion's chat timestamps detected, please use " + Reference.NAME + "' chat timestamps for full compatibility.");

--- a/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
@@ -817,7 +817,7 @@ public class OverlayEvents implements Listener {
         if (!Reference.onWorld || !OverlayConfig.ConsumableTimer.INSTANCE.showSpellEffects) return;
 
         SPacketRemoveEntityEffect effect = e.getPacket();
-        if (effect.getEntity(McIf.mc().world) != McIf.mc().player) return;
+        if (effect.getEntity(McIf.world()) != McIf.mc().player) return;
 
         McIf.mc().addScheduledTask(() -> {
             Potion potion = effect.getPotion();

--- a/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
@@ -579,7 +579,7 @@ public class OverlayEvents implements Listener {
             }
 
             if (OverlayConfig.ConsumableTimer.INSTANCE.showCooldown) {
-                long timeNow = Minecraft.getSystemTime();
+                long timeNow = McIf.getSystemTime();
                 int timeLeft = seconds - (int)(timeNow - loginTime)/1000;
                 if (timeLeft > 0) {
                     ConsumableTimerOverlay.addBasicTimer("Gather cooldown", timeLeft, false);
@@ -756,7 +756,7 @@ public class OverlayEvents implements Listener {
     public void onClassChange(WynnClassChangeEvent e) {
         McIf.mc().addScheduledTask(GameUpdateOverlay::resetMessages);
         // WynnCraft seem to be off with its timer with around 10 seconds
-        loginTime = Minecraft.getSystemTime() + 10000;
+        loginTime = McIf.getSystemTime() + 10000;
         msgcounter = 0;
     }
 

--- a/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
@@ -5,7 +5,6 @@
 package com.wynntils.modules.utilities.overlays;
 
 import com.wynntils.McIf;
-import com.wynntils.ModCore;
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.*;
 import com.wynntils.core.framework.enums.professions.ProfessionType;
@@ -755,7 +754,7 @@ public class OverlayEvents implements Listener {
 
     @SubscribeEvent
     public void onClassChange(WynnClassChangeEvent e) {
-        ModCore.mc().addScheduledTask(GameUpdateOverlay::resetMessages);
+        McIf.mc().addScheduledTask(GameUpdateOverlay::resetMessages);
         // WynnCraft seem to be off with its timer with around 10 seconds
         loginTime = Minecraft.getSystemTime() + 10000;
         msgcounter = 0;

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/ActionBarOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/ActionBarOverlay.java
@@ -52,11 +52,11 @@ public class ActionBarOverlay extends Overlay {
         int padding = 3;
         int y = 0;
 
-        BlockPos blockPos = new BlockPos(McIf.mc().player);
+        BlockPos blockPos = new BlockPos(McIf.player());
         String lCoord = TextFormatting.GRAY.toString() + blockPos.getX();
         String middleCoord;
         if (!OverlayConfig.INSTANCE.replaceDirection) {
-            middleCoord = TextFormatting.GREEN + Utils.getPlayerDirection(McIf.mc().player.rotationYaw);
+            middleCoord = TextFormatting.GREEN + Utils.getPlayerDirection(McIf.player().rotationYaw);
         } else {
             middleCoord = TextFormatting.GRAY.toString() + blockPos.getY();
         }
@@ -79,7 +79,7 @@ public class ActionBarOverlay extends Overlay {
             String[] spaces = lastActionBar.split(" ");
             middle = spaces[5].replace(TextFormatting.UNDERLINE.toString(), "").replace(TextFormatting.RESET.toString(), "");
             preference = true;
-        } else if (TextFormatting.getTextWithoutFormattingCodes(lastActionBar).contains("Sprint") && McIf.mc().player.isSprinting()) {
+        } else if (TextFormatting.getTextWithoutFormattingCodes(lastActionBar).contains("Sprint") && McIf.player().isSprinting()) {
             String[] spaces = lastActionBar.split(" ");
             middle = spaces[5];
         } else if (OverlayConfig.INSTANCE.actionBarCoordinates && !OverlayConfig.INSTANCE.splitCoordinates) {

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/ActionBarOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/ActionBarOverlay.java
@@ -14,7 +14,6 @@ import com.wynntils.core.framework.rendering.colors.CommonColors;
 import com.wynntils.core.utils.Utils;
 import com.wynntils.core.utils.reflections.ReflectionFields;
 import com.wynntils.modules.utilities.configs.OverlayConfig;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
@@ -53,11 +52,11 @@ public class ActionBarOverlay extends Overlay {
         int padding = 3;
         int y = 0;
 
-        BlockPos blockPos = new BlockPos(ScreenRenderer.mc.player);
+        BlockPos blockPos = new BlockPos(McIf.mc().player);
         String lCoord = TextFormatting.GRAY.toString() + blockPos.getX();
         String middleCoord;
         if (!OverlayConfig.INSTANCE.replaceDirection) {
-            middleCoord = TextFormatting.GREEN + Utils.getPlayerDirection(ScreenRenderer.mc.player.rotationYaw);
+            middleCoord = TextFormatting.GREEN + Utils.getPlayerDirection(McIf.mc().player.rotationYaw);
         } else {
             middleCoord = TextFormatting.GRAY.toString() + blockPos.getY();
         }
@@ -80,7 +79,7 @@ public class ActionBarOverlay extends Overlay {
             String[] spaces = lastActionBar.split(" ");
             middle = spaces[5].replace(TextFormatting.UNDERLINE.toString(), "").replace(TextFormatting.RESET.toString(), "");
             preference = true;
-        } else if (TextFormatting.getTextWithoutFormattingCodes(lastActionBar).contains("Sprint") && ScreenRenderer.mc.player.isSprinting()) {
+        } else if (TextFormatting.getTextWithoutFormattingCodes(lastActionBar).contains("Sprint") && McIf.mc().player.isSprinting()) {
             String[] spaces = lastActionBar.split(" ");
             middle = spaces[5];
         } else if (OverlayConfig.INSTANCE.actionBarCoordinates && !OverlayConfig.INSTANCE.splitCoordinates) {
@@ -122,10 +121,10 @@ public class ActionBarOverlay extends Overlay {
                 s = TextFormatting.ITALIC + s;
             }
 
-            int i = ((int) (position.anchorX * ScreenRenderer.screen.getScaledWidth()) - ScreenRenderer.mc.fontRenderer.getStringWidth(s) / 2) + position.offsetX;
+            int i = ((int) (position.anchorX * ScreenRenderer.screen.getScaledWidth()) - McIf.mc().fontRenderer.getStringWidth(s) / 2) + position.offsetX;
             int j = (int) (position.anchorY * ScreenRenderer.screen.getScaledHeight()) + position.offsetY + (OverlayConfig.INSTANCE.splitCoordinates ? -11 : 0);
 
-            if (!ScreenRenderer.mc.playerController.shouldDrawHUD()) {
+            if (!McIf.mc().playerController.shouldDrawHUD()) {
                 j += 14;
             }
 
@@ -140,7 +139,7 @@ public class ActionBarOverlay extends Overlay {
                 GlStateManager.pushMatrix();
                 GlStateManager.enableBlend();
                 GlStateManager.tryBlendFuncSeparate(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA, GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ZERO);
-                ScreenRenderer.mc.fontRenderer.drawStringWithShadow(s, (float) i, (float) j, 16777215 + (k << 24));
+                McIf.mc().fontRenderer.drawStringWithShadow(s, (float) i, (float) j, 16777215 + (k << 24));
                 GlStateManager.disableBlend();
                 GlStateManager.popMatrix();
                 return true;

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/ActionBarOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/ActionBarOverlay.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.utilities.overlays.hud;
 
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.framework.instances.data.ActionBarData;
 import com.wynntils.core.framework.overlays.Overlay;
@@ -101,14 +102,14 @@ public class ActionBarOverlay extends Overlay {
     }
 
     private boolean renderItemName() {
-        int newHighlightTicks = ReflectionFields.GuiIngame_remainingHighlightTicks.getValue(Minecraft.getMinecraft().ingameGUI);
-        ItemStack newHighlightItem = ReflectionFields.GuiIngame_highlightingItemStack.getValue(Minecraft.getMinecraft().ingameGUI);
+        int newHighlightTicks = ReflectionFields.GuiIngame_remainingHighlightTicks.getValue(McIf.mc().ingameGUI);
+        ItemStack newHighlightItem = ReflectionFields.GuiIngame_highlightingItemStack.getValue(McIf.mc().ingameGUI);
 
         if (newHighlightTicks > 0) { // update item
             highlightTicks = newHighlightTicks*5; // this method ticks 5 times as fast as the default
             highlightItem = newHighlightItem;
 
-            ReflectionFields.GuiIngame_remainingHighlightTicks.setValue(Minecraft.getMinecraft().ingameGUI, 0);
+            ReflectionFields.GuiIngame_remainingHighlightTicks.setValue(McIf.mc().ingameGUI, 0);
         } else if (newHighlightItem.isEmpty()) { // clear highlight when player switches to an empty hand
             highlightTicks = 0;
         }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/BubblesOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/BubblesOverlay.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.utilities.overlays.hud;
 
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.framework.instances.PlayerInfo;
 import com.wynntils.core.framework.instances.data.CharacterData;
@@ -40,9 +41,9 @@ public class BubblesOverlay extends Overlay {
 
     @Override
     public void tick(TickEvent.ClientTickEvent event, long ticks) {
-        if (!(visible = (mc.player.getAir() != 300 && !Reference.onLobby))) return;
+        if (!(visible = (McIf.mc().player.getAir() != 300 && !Reference.onLobby))) return;
         if (OverlayConfig.Bubbles.INSTANCE.animated > 0.0f && OverlayConfig.Bubbles.INSTANCE.animated < 10.0f && !(amount >= 300))
-            amount -= (OverlayConfig.Bubbles.INSTANCE.animated * 0.1f) * (amount - mc.player.getAir());
+            amount -= (OverlayConfig.Bubbles.INSTANCE.animated * 0.1f) * (amount - McIf.mc().player.getAir());
         else amount = PlayerInfo.get(CharacterData.class).getCurrentHealth();
 
         if (amount <= 0) amount = 0;
@@ -76,7 +77,7 @@ public class BubblesOverlay extends Overlay {
 
     private void drawDefaultBar(int y1, int y2, int ty1, int ty2) {
         drawProgressBar(Textures.Overlays.bars_bubbles, -91, y1, 91, y2, 0, ty1, 182, ty2, (flip ? -amount : amount) / 300);
-        drawString(Integer.toString(Math.max(mc.player.getAir() / 3, 0)), textPositionOffset.a, textPositionOffset.b, textColor, SmartFontRenderer.TextAlignment.MIDDLE, OverlayConfig.Exp.INSTANCE.textShadow);
+        drawString(Integer.toString(Math.max(McIf.mc().player.getAir() / 3, 0)), textPositionOffset.a, textPositionOffset.b, textColor, SmartFontRenderer.TextAlignment.MIDDLE, OverlayConfig.Exp.INSTANCE.textShadow);
     }
 
 }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/BubblesOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/BubblesOverlay.java
@@ -41,9 +41,9 @@ public class BubblesOverlay extends Overlay {
 
     @Override
     public void tick(TickEvent.ClientTickEvent event, long ticks) {
-        if (!(visible = (McIf.mc().player.getAir() != 300 && !Reference.onLobby))) return;
+        if (!(visible = (McIf.player().getAir() != 300 && !Reference.onLobby))) return;
         if (OverlayConfig.Bubbles.INSTANCE.animated > 0.0f && OverlayConfig.Bubbles.INSTANCE.animated < 10.0f && !(amount >= 300))
-            amount -= (OverlayConfig.Bubbles.INSTANCE.animated * 0.1f) * (amount - McIf.mc().player.getAir());
+            amount -= (OverlayConfig.Bubbles.INSTANCE.animated * 0.1f) * (amount - McIf.player().getAir());
         else amount = PlayerInfo.get(CharacterData.class).getCurrentHealth();
 
         if (amount <= 0) amount = 0;
@@ -77,7 +77,7 @@ public class BubblesOverlay extends Overlay {
 
     private void drawDefaultBar(int y1, int y2, int ty1, int ty2) {
         drawProgressBar(Textures.Overlays.bars_bubbles, -91, y1, 91, y2, 0, ty1, 182, ty2, (flip ? -amount : amount) / 300);
-        drawString(Integer.toString(Math.max(McIf.mc().player.getAir() / 3, 0)), textPositionOffset.a, textPositionOffset.b, textColor, SmartFontRenderer.TextAlignment.MIDDLE, OverlayConfig.Exp.INSTANCE.textShadow);
+        drawString(Integer.toString(Math.max(McIf.player().getAir() / 3, 0)), textPositionOffset.a, textPositionOffset.b, textColor, SmartFontRenderer.TextAlignment.MIDDLE, OverlayConfig.Exp.INSTANCE.textShadow);
     }
 
 }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/ConsumableTimerOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/ConsumableTimerOverlay.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.utilities.overlays.hud;
 
+import com.wynntils.McIf;
 import com.wynntils.core.framework.enums.SkillPoint;
 import com.wynntils.core.framework.enums.SpellType;
 import com.wynntils.core.framework.overlays.Overlay;
@@ -82,7 +83,7 @@ public class ConsumableTimerOverlay extends Overlay {
                 Matcher m = DURATION_PATTERN.matcher(line);
                 if (m.matches() && m.group(1) != null) {
                     consumable.setExpirationTime(
-                            Minecraft.getSystemTime() + (Integer.parseInt(m.group(1)) * 1000)
+                            McIf.getSystemTime() + (Integer.parseInt(m.group(1)) * 1000)
                     ); // currentMillis + (seconds * 1000)
                     continue;
                 }
@@ -137,7 +138,7 @@ public class ConsumableTimerOverlay extends Overlay {
             Matcher m = DURATION_PATTERN.matcher(line);
             if (m.matches() && m.group(1) != null) {
                 consumable.setExpirationTime(
-                        Minecraft.getSystemTime() + (Integer.parseInt(m.group(1)) * 1000)
+                        McIf.getSystemTime() + (Integer.parseInt(m.group(1)) * 1000)
                 ); // currentMillis + (seconds * 1000)
                 continue;
             }
@@ -177,7 +178,7 @@ public class ConsumableTimerOverlay extends Overlay {
         Matcher m2 = CHAT_DURATION_PATTERN.matcher(duration);
         if (!m2.matches() || m2.group(1) == null) return;
 
-        long expiration = Minecraft.getSystemTime() + (Integer.parseInt(m2.group(1)) * 1000);
+        long expiration = McIf.getSystemTime() + (Integer.parseInt(m2.group(1)) * 1000);
         int value = Integer.parseInt(m.group("Value"));
         String shortIdName = ItemIdentificationOverlay.toShortIdName(m.group("ID"), m.group("Suffix") == null);
         ConsumableContainer consumable = null;
@@ -271,7 +272,7 @@ public class ConsumableTimerOverlay extends Overlay {
     public static void addBasicTimer(String name, int timeInSeconds, boolean persistent) {
         String formattedName = GRAY + name;
         // setExpirationTime adds an extra 1000 so compensate for that here
-        long expirationTime = Minecraft.getSystemTime() + timeInSeconds*1000 - 1000;
+        long expirationTime = McIf.getSystemTime() + timeInSeconds*1000 - 1000;
 
         for (ConsumableContainer c : activeConsumables) {
             if (c.getName().equals(formattedName)) {
@@ -319,7 +320,7 @@ public class ConsumableTimerOverlay extends Overlay {
                 continue;
             }
 
-            drawString(consumable.getName() + " (" + StringUtils.timeLeft(consumable.getExpirationTime() - Minecraft.getSystemTime() + 1000) + ")"
+            drawString(consumable.getName() + " (" + StringUtils.timeLeft(consumable.getExpirationTime() - McIf.getSystemTime() + 1000) + ")"
                     , 0, extraY, CommonColors.WHITE, OverlayConfig.ConsumableTimer.INSTANCE.textAlignment,
                     OverlayConfig.ConsumableTimer.INSTANCE.textShadow);
 

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/DrowningVignetteOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/DrowningVignetteOverlay.java
@@ -31,10 +31,10 @@ public class DrowningVignetteOverlay extends Overlay {
             return;
         }
 
-        if (McIf.mc().player.getAir() == 300 && animation >= 300) return;
+        if (McIf.player().getAir() == 300 && animation >= 300) return;
 
-        if (McIf.mc().player.getAir() == 300) animation = Utils.easeOut(animation, 300, 1.5f, 20f);
-        else animation = McIf.mc().player.getAir();
+        if (McIf.player().getAir() == 300) animation = Utils.easeOut(animation, 300, 1.5f, 20f);
+        else animation = McIf.player().getAir();
 
         float value = Math.abs((animation / 300.0f) - 1.0f);
 

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/DrowningVignetteOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/DrowningVignetteOverlay.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.utilities.overlays.hud;
 
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.framework.overlays.Overlay;
 import com.wynntils.core.framework.rendering.ScreenRenderer;
@@ -30,10 +31,10 @@ public class DrowningVignetteOverlay extends Overlay {
             return;
         }
 
-        if (ScreenRenderer.mc.player.getAir() == 300 && animation >= 300) return;
+        if (McIf.mc().player.getAir() == 300 && animation >= 300) return;
 
-        if (ScreenRenderer.mc.player.getAir() == 300) animation = Utils.easeOut(animation, 300, 1.5f, 20f);
-        else animation = ScreenRenderer.mc.player.getAir();
+        if (McIf.mc().player.getAir() == 300) animation = Utils.easeOut(animation, 300, 1.5f, 20f);
+        else animation = McIf.mc().player.getAir();
 
         float value = Math.abs((animation / 300.0f) - 1.0f);
 

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/ExpBarOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/ExpBarOverlay.java
@@ -4,7 +4,7 @@
 
 package com.wynntils.modules.utilities.overlays.hud;
 
-import com.wynntils.ModCore;
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.framework.instances.data.CharacterData;
 import com.wynntils.core.framework.overlays.Overlay;
@@ -47,13 +47,13 @@ public class ExpBarOverlay extends Overlay {
 
     @Override
     public void tick(TickEvent.ClientTickEvent event, long ticks) {
-        if (!(visible = (get(CharacterData.class).getExperiencePercentage() != -1 && !Reference.onLobby && mc.player.getAir() == 300))) return;
+        if (!(visible = (get(CharacterData.class).getExperiencePercentage() != -1 && !Reference.onLobby && McIf.mc().player.getAir() == 300))) return;
         if (OverlayConfig.Exp.INSTANCE.animated > 0.0f && OverlayConfig.Exp.INSTANCE.animated < 10.0f)
             exp -= (OverlayConfig.Exp.INSTANCE.animated * 0.1f) * (exp - get(CharacterData.class).getExperiencePercentage());
         else
             exp = get(CharacterData.class).getExperiencePercentage();
 
-        if (ModCore.mc().player.getHorseJumpPower() > 0) exp = ModCore.mc().player.getHorseJumpPower();
+        if (McIf.mc().player.getHorseJumpPower() > 0) exp = McIf.mc().player.getHorseJumpPower();
     }
 
     @Override

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/ExpBarOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/ExpBarOverlay.java
@@ -47,13 +47,13 @@ public class ExpBarOverlay extends Overlay {
 
     @Override
     public void tick(TickEvent.ClientTickEvent event, long ticks) {
-        if (!(visible = (get(CharacterData.class).getExperiencePercentage() != -1 && !Reference.onLobby && McIf.mc().player.getAir() == 300))) return;
+        if (!(visible = (get(CharacterData.class).getExperiencePercentage() != -1 && !Reference.onLobby && McIf.player().getAir() == 300))) return;
         if (OverlayConfig.Exp.INSTANCE.animated > 0.0f && OverlayConfig.Exp.INSTANCE.animated < 10.0f)
             exp -= (OverlayConfig.Exp.INSTANCE.animated * 0.1f) * (exp - get(CharacterData.class).getExperiencePercentage());
         else
             exp = get(CharacterData.class).getExperiencePercentage();
 
-        if (McIf.mc().player.getHorseJumpPower() > 0) exp = McIf.mc().player.getHorseJumpPower();
+        if (McIf.player().getHorseJumpPower() > 0) exp = McIf.player().getHorseJumpPower();
     }
 
     @Override

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/GameUpdateOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/GameUpdateOverlay.java
@@ -4,7 +4,7 @@
 
 package com.wynntils.modules.utilities.overlays.hud;
 
-import com.wynntils.ModCore;
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.framework.instances.PlayerInfo;
 import com.wynntils.core.framework.instances.data.CharacterData;
@@ -100,7 +100,7 @@ public class GameUpdateOverlay extends Overlay {
 
         String processedMessage = message;
         LogManager.getFormatterLogger("GameTicker").info("Message Queued: " + processedMessage);
-        ModCore.mc().addScheduledTask(() -> {
+        McIf.mc().addScheduledTask(() -> {
             messageQueue.add(new MessageContainer(processedMessage));
 
             if (OverlayConfig.GameUpdate.INSTANCE.overrideNewMessages && messageQueue.size() > OverlayConfig.GameUpdate.INSTANCE.messageLimit)
@@ -109,7 +109,7 @@ public class GameUpdateOverlay extends Overlay {
     }
 
     public static void resetMessages() {
-        ModCore.mc().addScheduledTask(() -> messageQueue.clear());
+        McIf.mc().addScheduledTask(() -> messageQueue.clear());
     }
 
 

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/GammaOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/GammaOverlay.java
@@ -4,8 +4,8 @@
 
 package com.wynntils.modules.utilities.overlays.hud;
 
+import com.wynntils.McIf;
 import com.wynntils.core.framework.overlays.Overlay;
-import com.wynntils.core.framework.rendering.ScreenRenderer;
 import com.wynntils.core.framework.rendering.SmartFontRenderer;
 import com.wynntils.core.framework.rendering.colors.CommonColors;
 import com.wynntils.modules.utilities.configs.OverlayConfig;
@@ -23,7 +23,7 @@ public class GammaOverlay extends Overlay {
             return;
         }
 
-        if (ScreenRenderer.mc.gameSettings.gammaSetting >= 1000) {
+        if (McIf.mc().gameSettings.gammaSetting >= 1000) {
             drawString("GammaBright", 0, 0, CommonColors.ORANGE, SmartFontRenderer.TextAlignment.RIGHT_LEFT, OverlayConfig.INSTANCE.textShadow);
         }
     }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/HotbarOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/HotbarOverlay.java
@@ -31,7 +31,7 @@ public class HotbarOverlay extends Overlay {
     public void render(RenderGameOverlayEvent.Pre event) {
         if (!WIDGETS_TEXTURE.loaded) WIDGETS_TEXTURE.load();
 
-        EntityPlayerSP player = McIf.mc().player;
+        EntityPlayerSP player = McIf.player();
         int textureY = 0;
 
         if (OverlayConfig.Hotbar.INSTANCE.hotbarTexture == OverlayConfig.Hotbar.HotbarTextures.Resource_Pack) {

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/HotbarOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/HotbarOverlay.java
@@ -4,7 +4,7 @@
 
 package com.wynntils.modules.utilities.overlays.hud;
 
-import com.wynntils.ModCore;
+import com.wynntils.McIf;
 import com.wynntils.core.framework.overlays.Overlay;
 import com.wynntils.core.framework.rendering.colors.CustomColor;
 import com.wynntils.core.framework.rendering.textures.AssetsTexture;
@@ -31,7 +31,7 @@ public class HotbarOverlay extends Overlay {
     public void render(RenderGameOverlayEvent.Pre event) {
         if (!WIDGETS_TEXTURE.loaded) WIDGETS_TEXTURE.load();
 
-        EntityPlayerSP player = ModCore.mc().player;
+        EntityPlayerSP player = McIf.mc().player;
         int textureY = 0;
 
         if (OverlayConfig.Hotbar.INSTANCE.hotbarTexture == OverlayConfig.Hotbar.HotbarTextures.Resource_Pack) {

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/LowHealthVignetteOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/LowHealthVignetteOverlay.java
@@ -68,7 +68,7 @@ public class LowHealthVignetteOverlay extends Overlay {
 
     @Override
     public void tick(TickEvent.ClientTickEvent event, long ticks) {
-        currentHealth = McIf.mc().player.getHealth() / McIf.mc().player.getMaxHealth();
+        currentHealth = McIf.player().getHealth() / McIf.player().getMaxHealth();
         threshold = (float) OverlayConfig.Health.INSTANCE.lowHealthThreshold / 100;
         if (currentHealth > threshold) return;
 

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/LowHealthVignetteOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/LowHealthVignetteOverlay.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.utilities.overlays.hud;
 
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.framework.overlays.Overlay;
 import com.wynntils.core.framework.rendering.ScreenRenderer;
@@ -67,7 +68,7 @@ public class LowHealthVignetteOverlay extends Overlay {
 
     @Override
     public void tick(TickEvent.ClientTickEvent event, long ticks) {
-        currentHealth = ScreenRenderer.mc.player.getHealth() / ScreenRenderer.mc.player.getMaxHealth();
+        currentHealth = McIf.mc().player.getHealth() / McIf.mc().player.getMaxHealth();
         threshold = (float) OverlayConfig.Health.INSTANCE.lowHealthThreshold / 100;
         if (currentHealth > threshold) return;
 

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/ObjectivesOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/ObjectivesOverlay.java
@@ -7,6 +7,7 @@ package com.wynntils.modules.utilities.overlays.hud;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.GuiOverlapEvent;
 import com.wynntils.core.framework.overlays.Overlay;
@@ -167,7 +168,7 @@ public class ObjectivesOverlay extends Overlay {
     public static void checkObjectiveReached(ClientChatReceivedEvent e) {
         if (e.getType() != ChatType.CHAT) return;
 
-        String msg = e.getMessage().getUnformattedText();
+        String msg = McIf.getUnformattedText(e.getMessage());
         if (msg.contains("Click here to claim your rewards")) {
             objectives[0] = new Objective("Claim your reward with /daily");
         }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/PlayerInfoOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/PlayerInfoOverlay.java
@@ -33,13 +33,13 @@ public class PlayerInfoOverlay extends Overlay {
     @Override
     public void render(RenderGameOverlayEvent.Post event) {
         if (!Reference.onWorld || !OverlayConfig.PlayerInfo.INSTANCE.replaceVanilla) return;
-        if (!mc.gameSettings.keyBindPlayerList.isKeyDown() && animationProgress <= 0.0) return;
+        if (!McIf.mc().gameSettings.keyBindPlayerList.isKeyDown() && animationProgress <= 0.0) return;
 
         double animation = 1;
         if (OverlayConfig.PlayerInfo.INSTANCE.openingDuration > 0) { // Animation Detection
             if (lastTime == -1) lastTime += Minecraft.getSystemTime();
 
-            if (mc.gameSettings.keyBindPlayerList.isKeyDown()) {
+            if (McIf.mc().gameSettings.keyBindPlayerList.isKeyDown()) {
                 animationProgress += (Minecraft.getSystemTime() - lastTime) / OverlayConfig.PlayerInfo.INSTANCE.openingDuration;
                 animationProgress = Math.min(1, animationProgress);
             } else if (animationProgress > 0.0) {

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/PlayerInfoOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/PlayerInfoOverlay.java
@@ -126,7 +126,7 @@ public class PlayerInfoOverlay extends Overlay {
         nextExecution = Minecraft.getSystemTime() + 250;
 
         List<NetworkPlayerInfo> players = TabManager.getEntryOrdering()
-                .sortedCopy(McIf.mc().player.connection.getPlayerInfoMap());
+                .sortedCopy(McIf.player().connection.getPlayerInfoMap());
 
         if (players.isEmpty()) return lastPlayers;
 

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/PlayerInfoOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/PlayerInfoOverlay.java
@@ -126,7 +126,7 @@ public class PlayerInfoOverlay extends Overlay {
         nextExecution = Minecraft.getSystemTime() + 250;
 
         List<NetworkPlayerInfo> players = TabManager.getEntryOrdering()
-                .sortedCopy(Minecraft.getMinecraft().player.connection.getPlayerInfoMap());
+                .sortedCopy(McIf.mc().player.connection.getPlayerInfoMap());
 
         if (players.isEmpty()) return lastPlayers;
 

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/PlayerInfoOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/PlayerInfoOverlay.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.utilities.overlays.hud;
 
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.framework.overlays.Overlay;
 import com.wynntils.core.framework.rendering.SmartFontRenderer;
@@ -131,7 +132,7 @@ public class PlayerInfoOverlay extends Overlay {
 
         lastPlayers = players.stream()
                 .filter(c -> c.getDisplayName() != null)
-                .map(c -> wrapText(c.getDisplayName().getUnformattedText().replace("§7", "§0"), 73))
+                .map(c -> wrapText(McIf.getUnformattedText(c.getDisplayName()).replace("§7", "§0"), 73))
                 .collect(Collectors.toList());
 
         return lastPlayers;

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/PlayerInfoOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/PlayerInfoOverlay.java
@@ -37,18 +37,18 @@ public class PlayerInfoOverlay extends Overlay {
 
         double animation = 1;
         if (OverlayConfig.PlayerInfo.INSTANCE.openingDuration > 0) { // Animation Detection
-            if (lastTime == -1) lastTime += Minecraft.getSystemTime();
+            if (lastTime == -1) lastTime += McIf.getSystemTime();
 
             if (McIf.mc().gameSettings.keyBindPlayerList.isKeyDown()) {
-                animationProgress += (Minecraft.getSystemTime() - lastTime) / OverlayConfig.PlayerInfo.INSTANCE.openingDuration;
+                animationProgress += (McIf.getSystemTime() - lastTime) / OverlayConfig.PlayerInfo.INSTANCE.openingDuration;
                 animationProgress = Math.min(1, animationProgress);
             } else if (animationProgress > 0.0) {
-                animationProgress -= (Minecraft.getSystemTime() - lastTime) / OverlayConfig.PlayerInfo.INSTANCE.openingDuration;
+                animationProgress -= (McIf.getSystemTime() - lastTime) / OverlayConfig.PlayerInfo.INSTANCE.openingDuration;
                 animationProgress = Math.max(0, animationProgress);
             }
             animation = MathHelper.sin((float) (animationProgress * 1f / 2f * Math.PI));
 
-            lastTime = animationProgress <= 0.0 ? -1 : Minecraft.getSystemTime();
+            lastTime = animationProgress <= 0.0 ? -1 : McIf.getSystemTime();
 
             if (OverlayConfig.PlayerInfo.INSTANCE.openingDuration == 0 && animationProgress <= 0.0) return;
         }
@@ -121,9 +121,9 @@ public class PlayerInfoOverlay extends Overlay {
     transient long nextExecution = 0;
 
     private List<String> getAvailablePlayers() {
-        if (Minecraft.getSystemTime() < nextExecution && !lastPlayers.isEmpty()) return lastPlayers;
+        if (McIf.getSystemTime() < nextExecution && !lastPlayers.isEmpty()) return lastPlayers;
 
-        nextExecution = Minecraft.getSystemTime() + 250;
+        nextExecution = McIf.getSystemTime() + 250;
 
         List<NetworkPlayerInfo> players = TabManager.getEntryOrdering()
                 .sortedCopy(McIf.player().connection.getPlayerInfoMap());

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/ScoreboardOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/ScoreboardOverlay.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.framework.overlays.Overlay;
 import com.wynntils.core.framework.rendering.colors.CommonColors;
@@ -32,9 +33,9 @@ public class ScoreboardOverlay extends Overlay {
                 event.getType() != RenderGameOverlayEvent.ElementType.ALL) return;
 
         // vanilla fontrenderer
-        FontRenderer fontRenderer = mc.fontRenderer;
+        FontRenderer fontRenderer = McIf.mc().fontRenderer;
 
-        ScoreObjective objective = mc.world.getScoreboard().getObjectiveInDisplaySlot(1); // sidebar objective
+        ScoreObjective objective = McIf.mc().world.getScoreboard().getObjectiveInDisplaySlot(1); // sidebar objective
         if (objective == null) return;
 
         // get the 15 highest scores

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/ScoreboardOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/ScoreboardOverlay.java
@@ -35,7 +35,7 @@ public class ScoreboardOverlay extends Overlay {
         // vanilla fontrenderer
         FontRenderer fontRenderer = McIf.mc().fontRenderer;
 
-        ScoreObjective objective = McIf.mc().world.getScoreboard().getObjectiveInDisplaySlot(1); // sidebar objective
+        ScoreObjective objective = McIf.world().getScoreboard().getObjectiveInDisplaySlot(1); // sidebar objective
         if (objective == null) return;
 
         // get the 15 highest scores

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/ToastOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/ToastOverlay.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.utilities.overlays.hud;
 
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.framework.overlays.Overlay;
 import com.wynntils.core.framework.rendering.SmartFontRenderer;
@@ -88,13 +89,13 @@ public class ToastOverlay extends Overlay {
                 }
                 // Animation
                 if (OverlayConfig.ToastsSettings.INSTANCE.flipToast) {
-                    if ((Minecraft.getSystemTime() - displayedToast[j].getCreationTime()) > 5000L) {
+                    if ((McIf.getSystemTime() - displayedToast[j].getCreationTime()) > 5000L) {
                         displayedToast[j].setAnimated(displayedToast[j].getAnimated() - .3f);
                     } else if (displayedToast[j].getAnimated() < 0) {
                         displayedToast[j].setAnimated(Math.min(displayedToast[j].getAnimated() + .3f, 0));
                     }
                 } else {
-                    if ((Minecraft.getSystemTime() - displayedToast[j].getCreationTime()) > 5000L) {
+                    if ((McIf.getSystemTime() - displayedToast[j].getCreationTime()) > 5000L) {
                         displayedToast[j].setAnimated(displayedToast[j].getAnimated() + .3f);
                     } else if (displayedToast[j].getAnimated() > 0) {
                         displayedToast[j].setAnimated(Math.max(displayedToast[j].getAnimated() - .3f, 0));
@@ -134,7 +135,7 @@ public class ToastOverlay extends Overlay {
                     toastList.remove(0);
                 }
                 if (displayedToast[j] == null) continue;
-                if ((displayedToast[j].getAnimated() > 160 || displayedToast[j].getAnimated() < -160) && (Minecraft.getSystemTime() - displayedToast[j].getCreationTime()) > 5000L)
+                if ((displayedToast[j].getAnimated() > 160 || displayedToast[j].getAnimated() < -160) && (McIf.getSystemTime() - displayedToast[j].getCreationTime()) > 5000L)
                     toBeRemoved.add(j);
             }
             // Removes expired toasts

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/ToastOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/ToastOverlay.java
@@ -106,7 +106,7 @@ public class ToastOverlay extends Overlay {
 
     @Override
     public void tick(TickEvent.ClientTickEvent event, long ticks) {
-        if (Minecraft.getMinecraft().currentScreen != null) return;  // HeyZeer0: This will avoid toasts being processed when the user can't view them
+        if (McIf.mc().currentScreen != null) return;  // HeyZeer0: This will avoid toasts being processed when the user can't view them
 
         if (OverlayConfig.ToastsSettings.INSTANCE.enableToast) {
             // Flip coordinates:

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/WarTimerOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/WarTimerOverlay.java
@@ -5,7 +5,6 @@
 package com.wynntils.modules.utilities.overlays.hud;
 
 import com.wynntils.McIf;
-import com.wynntils.ModCore;
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.PacketEvent;
 import com.wynntils.core.events.custom.WarStageEvent;
@@ -162,7 +161,7 @@ public class WarTimerOverlay extends Overlay {
                 changeWarStage(WarStage.WAITING_FOR_MOB_TIMER);
                 time = -1;
                 if (territory == null) {
-                    EntityPlayerSP pl = ModCore.mc().player;
+                    EntityPlayerSP pl = McIf.mc().player;
                     for (TerritoryProfile pf : WebManager.getTerritories().values()) {
                         if (pf.insideArea((int)pl.posX, (int)pl.posZ)) {
                             territory = pf.getFriendlyName();

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/WarTimerOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/WarTimerOverlay.java
@@ -161,7 +161,7 @@ public class WarTimerOverlay extends Overlay {
                 changeWarStage(WarStage.WAITING_FOR_MOB_TIMER);
                 time = -1;
                 if (territory == null) {
-                    EntityPlayerSP pl = McIf.mc().player;
+                    EntityPlayerSP pl = McIf.player();
                     for (TerritoryProfile pf : WebManager.getTerritories().values()) {
                         if (pf.insideArea((int)pl.posX, (int)pl.posZ)) {
                             territory = pf.getFriendlyName();

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/WarTimerOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/WarTimerOverlay.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.utilities.overlays.hud;
 
+import com.wynntils.McIf;
 import com.wynntils.ModCore;
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.PacketEvent;
@@ -100,7 +101,7 @@ public class WarTimerOverlay extends Overlay {
     public static void warMessage(ClientChatReceivedEvent event) {
         if (!Reference.onWorld || Reference.onNether) return;
 
-        String message = event.getMessage().getUnformattedText();
+        String message = McIf.getUnformattedText(event.getMessage());
         if (message.startsWith("[WAR] ")) {
             message = message.replaceFirst("\\[WAR\\] ", "");
         }
@@ -182,7 +183,7 @@ public class WarTimerOverlay extends Overlay {
     }
 
     public static void onTitle(PacketEvent<SPacketTitle> event) {
-        if (event.getPacket().getType() == Type.SUBTITLE && event.getPacket().getMessage().getUnformattedText().equals(TextFormatting.GOLD + "0 Mobs Left")) {
+        if (event.getPacket().getType() == Type.SUBTITLE && McIf.getUnformattedText(event.getPacket().getMessage()).equals(TextFormatting.GOLD + "0 Mobs Left")) {
             lastTimePassed = System.currentTimeMillis() - time;
             lastTerritory = territory;
             resetTimer();

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/BankOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/BankOverlay.java
@@ -13,7 +13,6 @@ import java.util.regex.Pattern;
 import com.wynntils.McIf;
 import org.lwjgl.input.Keyboard;
 
-import com.wynntils.ModCore;
 import com.wynntils.core.events.custom.GuiOverlapEvent;
 import com.wynntils.core.framework.interfaces.Listener;
 import com.wynntils.core.framework.rendering.ScreenRenderer;
@@ -27,7 +26,6 @@ import com.wynntils.modules.core.overlays.inventories.ChestReplacer;
 import com.wynntils.modules.utilities.UtilitiesModule;
 import com.wynntils.modules.utilities.configs.UtilitiesConfig;
 
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Gui;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.texture.ITextureObject;
@@ -129,7 +127,7 @@ public class BankOverlay implements Listener {
             Slot s = e.getGui().inventorySlots.getSlot(QA_SLOTS[i]);
 
             s.putStack(new ItemStack(Blocks.SNOW_LAYER));
-            ModCore.mc().getTextureManager().bindTexture(COLUMN_ARROW);
+            McIf.mc().getTextureManager().bindTexture(COLUMN_ARROW);
 
             GlStateManager.pushMatrix();
             {
@@ -316,7 +314,7 @@ public class BankOverlay implements Listener {
             } else {
                 searchField.textboxKeyTyped(e.getTypedChar(), e.getKeyCode());
             }
-        } else if (e.getKeyCode() == Keyboard.KEY_ESCAPE || e.getKeyCode() == ModCore.mc().gameSettings.keyBindInventory.getKeyCode()) { // bank was closed by player
+        } else if (e.getKeyCode() == Keyboard.KEY_ESCAPE || e.getKeyCode() == McIf.mc().gameSettings.keyBindInventory.getKeyCode()) { // bank was closed by player
             destinationPage = 0;
             searchField = null;
             searching = 0;
@@ -339,7 +337,7 @@ public class BankOverlay implements Listener {
     private void updateName(IInventory bankGui) {
         String name = (UtilitiesConfig.Bank.INSTANCE.pageNames.containsKey(page))
                 ? UtilitiesConfig.Bank.INSTANCE.pageNames.get(page) : TextFormatting.DARK_GRAY
-                        + ModCore.mc().player.getName() + "'s" + TextFormatting.BLACK + " Bank";
+                        + McIf.mc().player.getName() + "'s" + TextFormatting.BLACK + " Bank";
 
         ((InventoryBasic) bankGui).setCustomName(TextFormatting.BLACK + "[Pg. " + page + "] " + name);
     }
@@ -368,7 +366,7 @@ public class BankOverlay implements Listener {
                     return;
                 }
                 packet = new CPacketClickWindow(bankGui.inventorySlots.windowId, PAGE_FORWARD, 0, ClickType.PICKUP, is,
-                                bankGui.inventorySlots.getNextTransactionID(ModCore.mc().player.inventory));
+                                bankGui.inventorySlots.getNextTransactionID(McIf.mc().player.inventory));
             } else {
                 ItemStack is = bankGui.inventorySlots.getSlot(PAGE_BACK).getStack();
 
@@ -379,15 +377,15 @@ public class BankOverlay implements Listener {
                     return;
                 }
                 packet = new CPacketClickWindow(bankGui.inventorySlots.windowId, PAGE_BACK, 0, ClickType.PICKUP, is,
-                                bankGui.inventorySlots.getNextTransactionID(ModCore.mc().player.inventory));
+                                bankGui.inventorySlots.getNextTransactionID(McIf.mc().player.inventory));
             }
         } else { // attempt to hop using default quick access buttons
             int slotId = QA_SLOTS[(hop / 4)];
             packet = new CPacketClickWindow(bankGui.inventorySlots.windowId, slotId, 0, ClickType.PICKUP, bankGui.inventorySlots.getSlot(slotId).getStack(),
-                            bankGui.inventorySlots.getNextTransactionID(ModCore.mc().player.inventory));
+                            bankGui.inventorySlots.getNextTransactionID(McIf.mc().player.inventory));
         }
 
-        ModCore.mc().getConnection().sendPacket(packet);
+        McIf.mc().getConnection().sendPacket(packet);
     }
 
     private void searchPageForItems(ChestReplacer bankGui) {
@@ -419,9 +417,9 @@ public class BankOverlay implements Listener {
     }
 
     private boolean isTextureLoaded(ResourceLocation resourceLocation) {
-        ITextureObject texture = ModCore.mc().getTextureManager().getTexture(resourceLocation);
+        ITextureObject texture = McIf.mc().getTextureManager().getTexture(resourceLocation);
         if (texture == null) {
-            return ModCore.mc().getTextureManager().loadTexture(resourceLocation, new SimpleTexture(resourceLocation));
+            return McIf.mc().getTextureManager().loadTexture(resourceLocation, new SimpleTexture(resourceLocation));
         }
         return (!texture.equals(TextureUtil.MISSING_TEXTURE));
     }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/BankOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/BankOverlay.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.wynntils.McIf;
 import org.lwjgl.input.Keyboard;
 
 import com.wynntils.ModCore;
@@ -97,7 +98,7 @@ public class BankOverlay implements Listener {
         if (destinationPage == page) destinationPage = 0; // if we've already arrived, reset destination
 
         if (searchField == null && UtilitiesConfig.Bank.INSTANCE.showBankSearchBar) {
-            int nameWidth = Minecraft.getMinecraft().fontRenderer.getStringWidth(e.getGui().getUpperInv().getDisplayName().getUnformattedText());
+            int nameWidth = Minecraft.getMinecraft().fontRenderer.getStringWidth(McIf.getUnformattedText(e.getGui().getUpperInv().getDisplayName()));
             searchField = new GuiTextFieldWynn(201, Minecraft.getMinecraft().fontRenderer, nameWidth + 13, 128, 157 - nameWidth, 10);
             searchField.setText("Search...");
         }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/BankOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/BankOverlay.java
@@ -98,8 +98,8 @@ public class BankOverlay implements Listener {
         if (destinationPage == page) destinationPage = 0; // if we've already arrived, reset destination
 
         if (searchField == null && UtilitiesConfig.Bank.INSTANCE.showBankSearchBar) {
-            int nameWidth = Minecraft.getMinecraft().fontRenderer.getStringWidth(McIf.getUnformattedText(e.getGui().getUpperInv().getDisplayName()));
-            searchField = new GuiTextFieldWynn(201, Minecraft.getMinecraft().fontRenderer, nameWidth + 13, 128, 157 - nameWidth, 10);
+            int nameWidth = McIf.mc().fontRenderer.getStringWidth(McIf.getUnformattedText(e.getGui().getUpperInv().getDisplayName()));
+            searchField = new GuiTextFieldWynn(201, McIf.mc().fontRenderer, nameWidth + 13, 128, 157 - nameWidth, 10);
             searchField.setText("Search...");
         }
 
@@ -269,7 +269,7 @@ public class BankOverlay implements Listener {
             }
 
             ((InventoryBasic) e.getGui().getLowerInv()).setCustomName("");
-            nameField = new GuiTextFieldWynn(200, Minecraft.getMinecraft().fontRenderer, 8, 5, 120, 10);
+            nameField = new GuiTextFieldWynn(200, McIf.mc().fontRenderer, 8, 5, 120, 10);
             nameField.setFocused(true);
 
             if (UtilitiesConfig.Bank.INSTANCE.pageNames.containsKey(page))

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/BankOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/BankOverlay.java
@@ -337,7 +337,7 @@ public class BankOverlay implements Listener {
     private void updateName(IInventory bankGui) {
         String name = (UtilitiesConfig.Bank.INSTANCE.pageNames.containsKey(page))
                 ? UtilitiesConfig.Bank.INSTANCE.pageNames.get(page) : TextFormatting.DARK_GRAY
-                        + McIf.mc().player.getName() + "'s" + TextFormatting.BLACK + " Bank";
+                        + McIf.player().getName() + "'s" + TextFormatting.BLACK + " Bank";
 
         ((InventoryBasic) bankGui).setCustomName(TextFormatting.BLACK + "[Pg. " + page + "] " + name);
     }
@@ -366,7 +366,7 @@ public class BankOverlay implements Listener {
                     return;
                 }
                 packet = new CPacketClickWindow(bankGui.inventorySlots.windowId, PAGE_FORWARD, 0, ClickType.PICKUP, is,
-                                bankGui.inventorySlots.getNextTransactionID(McIf.mc().player.inventory));
+                                bankGui.inventorySlots.getNextTransactionID(McIf.player().inventory));
             } else {
                 ItemStack is = bankGui.inventorySlots.getSlot(PAGE_BACK).getStack();
 
@@ -377,12 +377,12 @@ public class BankOverlay implements Listener {
                     return;
                 }
                 packet = new CPacketClickWindow(bankGui.inventorySlots.windowId, PAGE_BACK, 0, ClickType.PICKUP, is,
-                                bankGui.inventorySlots.getNextTransactionID(McIf.mc().player.inventory));
+                                bankGui.inventorySlots.getNextTransactionID(McIf.player().inventory));
             }
         } else { // attempt to hop using default quick access buttons
             int slotId = QA_SLOTS[(hop / 4)];
             packet = new CPacketClickWindow(bankGui.inventorySlots.windowId, slotId, 0, ClickType.PICKUP, bankGui.inventorySlots.getSlot(slotId).getStack(),
-                            bankGui.inventorySlots.getNextTransactionID(McIf.mc().player.inventory));
+                            bankGui.inventorySlots.getNextTransactionID(McIf.player().inventory));
         }
 
         McIf.mc().getConnection().sendPacket(packet);

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/FavoriteTradesOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/FavoriteTradesOverlay.java
@@ -34,7 +34,7 @@ public class FavoriteTradesOverlay implements Listener {
         if (!Reference.onWorld || !McIf.getFormattedText(e.getGui().getLowerInv().getDisplayName()).contains("Marketplace")) return;
         if (e.getKeyCode() != KeyManager.getFavoriteTradeKey().getKeyBinding().getKeyCode()) return;
 
-        if (e.getGui().getSlotUnderMouse() != null && McIf.mc().player.inventory != e.getGui().getSlotUnderMouse().inventory) {
+        if (e.getGui().getSlotUnderMouse() != null && McIf.player().inventory != e.getGui().getSlotUnderMouse().inventory) {
             toggleLockState(e.getGui().getSlotUnderMouse().getStack());
         }
     }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/FavoriteTradesOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/FavoriteTradesOverlay.java
@@ -34,7 +34,7 @@ public class FavoriteTradesOverlay implements Listener {
         if (!Reference.onWorld || !McIf.getFormattedText(e.getGui().getLowerInv().getDisplayName()).contains("Marketplace")) return;
         if (e.getKeyCode() != KeyManager.getFavoriteTradeKey().getKeyBinding().getKeyCode()) return;
 
-        if (e.getGui().getSlotUnderMouse() != null && Minecraft.getMinecraft().player.inventory != e.getGui().getSlotUnderMouse().inventory) {
+        if (e.getGui().getSlotUnderMouse() != null && McIf.mc().player.inventory != e.getGui().getSlotUnderMouse().inventory) {
             toggleLockState(e.getGui().getSlotUnderMouse().getStack());
         }
     }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/FavoriteTradesOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/FavoriteTradesOverlay.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.utilities.overlays.inventories;
 
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.GuiOverlapEvent;
 import com.wynntils.core.framework.interfaces.Listener;
@@ -30,7 +31,7 @@ public class FavoriteTradesOverlay implements Listener {
 
     @SubscribeEvent
     public void onKeyPress(GuiOverlapEvent.ChestOverlap.KeyTyped e) {
-        if (!Reference.onWorld || !e.getGui().getLowerInv().getDisplayName().getFormattedText().contains("Marketplace")) return;
+        if (!Reference.onWorld || !McIf.getFormattedText(e.getGui().getLowerInv().getDisplayName()).contains("Marketplace")) return;
         if (e.getKeyCode() != KeyManager.getFavoriteTradeKey().getKeyBinding().getKeyCode()) return;
 
         if (e.getGui().getSlotUnderMouse() != null && Minecraft.getMinecraft().player.inventory != e.getGui().getSlotUnderMouse().inventory) {
@@ -41,7 +42,7 @@ public class FavoriteTradesOverlay implements Listener {
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     public void onChestGui(GuiOverlapEvent.ChestOverlap.HoveredToolTip.Pre e) {
         if (!Reference.onWorld) return;
-        if (!e.getGui().getLowerInv().getDisplayName().getFormattedText().contains("Marketplace")) {
+        if (!McIf.getFormattedText(e.getGui().getLowerInv().getDisplayName()).contains("Marketplace")) {
             if (!favorites_trade_items_lore.isEmpty())
                 favorites_trade_items_lore.clear();
             return;

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/IngredientFilterOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/IngredientFilterOverlay.java
@@ -4,7 +4,7 @@
 
 package com.wynntils.modules.utilities.overlays.inventories;
 
-import com.wynntils.ModCore;
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.GuiOverlapEvent;
 import com.wynntils.core.framework.interfaces.Listener;
@@ -60,7 +60,7 @@ public class IngredientFilterOverlay implements Listener {
                     RarityColorOverlay.setProfessionFilter("-");
                     gb.displayString = "-";
                 }
-                gb.playPressSound(ModCore.mc().getSoundHandler());
+                gb.playPressSound(McIf.mc().getSoundHandler());
             }
         });
     }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemIdentificationOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemIdentificationOverlay.java
@@ -311,7 +311,7 @@ public class ItemIdentificationOverlay implements Listener {
         if (item.getLore() != null && !item.getLore().isEmpty()) {
             if (wynntils.hasKey("purchaseInfo")) newLore.add(" ");
 
-            newLore.addAll(Minecraft.getMinecraft().fontRenderer.listFormattedStringToWidth(DARK_GRAY + item.getLore(), 150));
+            newLore.addAll(McIf.mc().fontRenderer.listFormattedStringToWidth(DARK_GRAY + item.getLore(), 150));
         }
 
         // Special displayname

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemIdentificationOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemIdentificationOverlay.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.utilities.overlays.inventories;
 
+import com.wynntils.McIf;
 import com.wynntils.core.events.custom.GuiOverlapEvent;
 import com.wynntils.core.framework.enums.ClassType;
 import com.wynntils.core.framework.enums.SpellType;

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemLevelOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemLevelOverlay.java
@@ -26,7 +26,7 @@ public class ItemLevelOverlay implements Listener {
 
     @SubscribeEvent
     public void onItemOverlay(RenderEvent.DrawItemOverlay event) {
-        if (!UtilitiesConfig.Items.INSTANCE.itemLevelOverlayOutsideGui && Minecraft.getMinecraft().currentScreen == null) return;
+        if (!UtilitiesConfig.Items.INSTANCE.itemLevelOverlayOutsideGui && McIf.mc().currentScreen == null) return;
         if (!KeyManager.getShowLevelOverlayKey().isKeyDown()) return;
 
         ItemStack stack = event.getStack();

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemLevelOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemLevelOverlay.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.utilities.overlays.inventories;
 
+import com.wynntils.McIf;
 import com.wynntils.core.events.custom.RenderEvent;
 import com.wynntils.core.framework.interfaces.Listener;
 import com.wynntils.core.utils.ItemUtils;

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/MenuButtonsOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/MenuButtonsOverlay.java
@@ -96,13 +96,13 @@ public class MenuButtonsOverlay implements Listener {
         int id = e.getButton().id;
         switch (id) {
             case 753:
-                Minecraft.getMinecraft().player.sendChatMessage("/class");
+                McIf.mc().player.sendChatMessage("/class");
                 break;
             case 754:
-                Minecraft.getMinecraft().player.sendChatMessage("/hub");
+                McIf.mc().player.sendChatMessage("/hub");
                 break;
             case 755:
-                Minecraft.getMinecraft().displayGuiScreen(SettingsUI.getInstance(Minecraft.getMinecraft().currentScreen));
+                McIf.mc().displayGuiScreen(SettingsUI.getInstance(McIf.mc().currentScreen));
                 break;
             case 756:
                 QuestBookPages.MAIN.getPage().open(true);

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/MenuButtonsOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/MenuButtonsOverlay.java
@@ -96,10 +96,10 @@ public class MenuButtonsOverlay implements Listener {
         int id = e.getButton().id;
         switch (id) {
             case 753:
-                McIf.mc().player.sendChatMessage("/class");
+                McIf.player().sendChatMessage("/class");
                 break;
             case 754:
-                McIf.mc().player.sendChatMessage("/hub");
+                McIf.player().sendChatMessage("/hub");
                 break;
             case 755:
                 McIf.mc().displayGuiScreen(SettingsUI.getInstance(McIf.mc().currentScreen));

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/MenuButtonsOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/MenuButtonsOverlay.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.utilities.overlays.inventories;
 
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.GuiOverlapEvent;
 import com.wynntils.core.framework.interfaces.Listener;

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/RarityColorOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/RarityColorOverlay.java
@@ -4,7 +4,7 @@
 
 package com.wynntils.modules.utilities.overlays.inventories;
 
-import com.wynntils.ModCore;
+import com.wynntils.McIf;
 import com.wynntils.core.events.custom.GuiOverlapEvent;
 import com.wynntils.core.framework.interfaces.Listener;
 import com.wynntils.core.framework.rendering.ScreenRenderer;
@@ -81,7 +81,7 @@ public class RarityColorOverlay implements Listener {
         int playerInvSlotNumber = 0;
 
         for (Slot s : guiContainer.inventorySlots.inventorySlots) {
-            if (s.inventory.getDisplayName().equals(ModCore.mc().player.inventory.getDisplayName())) {
+            if (s.inventory.getDisplayName().equals(McIf.mc().player.inventory.getDisplayName())) {
                 playerInvSlotNumber++;
                 if (playerInvSlotNumber <= 4 && playerInvSlotNumber >= 1 && !UtilitiesConfig.Items.INSTANCE.accesoryHighlight)
                     continue;

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/RarityColorOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/RarityColorOverlay.java
@@ -81,7 +81,7 @@ public class RarityColorOverlay implements Listener {
         int playerInvSlotNumber = 0;
 
         for (Slot s : guiContainer.inventorySlots.inventorySlots) {
-            if (s.inventory.getDisplayName().equals(McIf.mc().player.inventory.getDisplayName())) {
+            if (s.inventory.getDisplayName().equals(McIf.player().inventory.getDisplayName())) {
                 playerInvSlotNumber++;
                 if (playerInvSlotNumber <= 4 && playerInvSlotNumber >= 1 && !UtilitiesConfig.Items.INSTANCE.accesoryHighlight)
                     continue;

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ServerSelectorOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ServerSelectorOverlay.java
@@ -88,15 +88,15 @@ public class ServerSelectorOverlay implements Listener {
         if (nbt.hasKey("wynntilsBlock")) {
             TextComponentString text = new TextComponentString("Your version of Wynntils is currently blocked from joining the Hero Beta due to instability. Trying changing update stream to cutting edge, or removing Wynntils while on the Hero Beta until support is added.");
             text.getStyle().setColor(TextFormatting.RED);
-            Minecraft.getMinecraft().player.sendMessage(text);
-            Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.BLOCK_NOTE_BASS, 1f));
+            McIf.mc().player.sendMessage(text);
+            McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.BLOCK_NOTE_BASS, 1f));
 
             e.setCanceled(true);
         } else if (nbt.hasKey("wynntilsWarn")) {
             TextComponentString text = new TextComponentString("Your version of Wynntils is currently unstable on the Hero Beta. Expect frequent crashes and bugs!");
             text.getStyle().setColor(TextFormatting.RED);
             text.getStyle().setBold(true);
-            Minecraft.getMinecraft().player.sendMessage(text);
+            McIf.mc().player.sendMessage(text);
 
             text = new TextComponentString("Please report any issues you do experience on the Wynntils discord ");
             text.getStyle().setColor(TextFormatting.GREEN);
@@ -107,9 +107,9 @@ public class ServerSelectorOverlay implements Listener {
                 linkText.getStyle().setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, discordInvite));
                 text.appendSibling(linkText);
             }
-            Minecraft.getMinecraft().player.sendMessage(text);
+            McIf.mc().player.sendMessage(text);
 
-            Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.BLOCK_NOTE_BASS, 1f));
+            McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.BLOCK_NOTE_BASS, 1f));
         }
     }
 }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ServerSelectorOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ServerSelectorOverlay.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.utilities.overlays.inventories;
 
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.GuiOverlapEvent;
 import com.wynntils.core.framework.interfaces.Listener;

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ServerSelectorOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ServerSelectorOverlay.java
@@ -88,7 +88,7 @@ public class ServerSelectorOverlay implements Listener {
         if (nbt.hasKey("wynntilsBlock")) {
             TextComponentString text = new TextComponentString("Your version of Wynntils is currently blocked from joining the Hero Beta due to instability. Trying changing update stream to cutting edge, or removing Wynntils while on the Hero Beta until support is added.");
             text.getStyle().setColor(TextFormatting.RED);
-            McIf.mc().player.sendMessage(text);
+            McIf.player().sendMessage(text);
             McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.BLOCK_NOTE_BASS, 1f));
 
             e.setCanceled(true);
@@ -96,7 +96,7 @@ public class ServerSelectorOverlay implements Listener {
             TextComponentString text = new TextComponentString("Your version of Wynntils is currently unstable on the Hero Beta. Expect frequent crashes and bugs!");
             text.getStyle().setColor(TextFormatting.RED);
             text.getStyle().setBold(true);
-            McIf.mc().player.sendMessage(text);
+            McIf.player().sendMessage(text);
 
             text = new TextComponentString("Please report any issues you do experience on the Wynntils discord ");
             text.getStyle().setColor(TextFormatting.GREEN);
@@ -107,7 +107,7 @@ public class ServerSelectorOverlay implements Listener {
                 linkText.getStyle().setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, discordInvite));
                 text.appendSibling(linkText);
             }
-            McIf.mc().player.sendMessage(text);
+            McIf.player().sendMessage(text);
 
             McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.BLOCK_NOTE_BASS, 1f));
         }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/SkillPointOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/SkillPointOverlay.java
@@ -351,7 +351,7 @@ public class SkillPointOverlay implements Listener {
             TextComponentString text = new TextComponentString("Not enough free skill points!");
             text.getStyle().setColor(TextFormatting.RED);
 
-            McIf.mc().player.sendMessage(text);
+            McIf.player().sendMessage(text);
             McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.BLOCK_ANVIL_PLACE, 1f));
             return;
         }
@@ -378,7 +378,7 @@ public class SkillPointOverlay implements Listener {
 
             CPacketClickWindow packet = new CPacketClickWindow(gui.inventorySlots.windowId, 9 + i, button,
                     ClickType.PICKUP, gui.inventorySlots.getSlot(9 + i).getStack(),
-                    gui.inventorySlots.getNextTransactionID(McIf.mc().player.inventory));
+                    gui.inventorySlots.getNextTransactionID(McIf.player().inventory));
 
             McIf.mc().getSoundHandler().playSound(
                     PositionedSoundRecord.getMasterRecord(SoundEvents.ENTITY_ITEM_PICKUP, 0.3f + (1.2f * buildPercentage)));

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/SkillPointOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/SkillPointOverlay.java
@@ -191,7 +191,7 @@ public class SkillPointOverlay implements Listener {
         if (!Reference.onWorld || !Utils.isCharacterInfoPage(e.getGui())) return;
 
         if (e.getSlotId() == SAVE_SLOT) {
-            nameField = new GuiTextFieldWynn(200, Minecraft.getMinecraft().fontRenderer, 8, 5, 130, 10);
+            nameField = new GuiTextFieldWynn(200, McIf.mc().fontRenderer, 8, 5, 130, 10);
             nameField.setFocused(true);
             nameField.setText("Enter build name");
             Keyboard.enableRepeatEvents(true);
@@ -381,14 +381,14 @@ public class SkillPointOverlay implements Listener {
                     ClickType.PICKUP, gui.inventorySlots.getSlot(9 + i).getStack(),
                     gui.inventorySlots.getNextTransactionID(ModCore.mc().player.inventory));
 
-            Minecraft.getMinecraft().getSoundHandler().playSound(
+            McIf.mc().getSoundHandler().playSound(
                     PositionedSoundRecord.getMasterRecord(SoundEvents.ENTITY_ITEM_PICKUP, 0.3f + (1.2f * buildPercentage)));
 
             ModCore.mc().getConnection().sendPacket(packet);
             return; // can only click once at a time
         }
 
-        Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.ENTITY_PLAYER_LEVELUP, 1f));
+        McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.ENTITY_PLAYER_LEVELUP, 1f));
         loadedBuild = null; // we've fully loaded the build if we reach this point
         buildPercentage = 0.0f;
     }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/SkillPointOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/SkillPointOverlay.java
@@ -4,7 +4,7 @@
 
 package com.wynntils.modules.utilities.overlays.inventories;
 
-import com.wynntils.ModCore;
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.GuiOverlapEvent;
 import com.wynntils.core.events.custom.PacketEvent;
@@ -25,7 +25,6 @@ import com.wynntils.modules.utilities.UtilitiesModule;
 import com.wynntils.modules.utilities.configs.UtilitiesConfig;
 import com.wynntils.modules.utilities.instances.SkillPointAllocation;
 import com.wynntils.modules.utilities.overlays.ui.SkillPointLoadoutUI;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.audio.PositionedSoundRecord;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.RenderHelper;
@@ -198,8 +197,8 @@ public class SkillPointOverlay implements Listener {
 
             e.setCanceled(true);
         } else if (e.getSlotId() == LOAD_SLOT) {
-            ModCore.mc().displayGuiScreen(
-                    new SkillPointLoadoutUI(this, ModCore.mc().currentScreen,
+            McIf.mc().displayGuiScreen(
+                    new SkillPointLoadoutUI(this, McIf.mc().currentScreen,
                             new InventoryBasic("Skill Points Loadouts", false, 54))
             );
 
@@ -243,7 +242,7 @@ public class SkillPointOverlay implements Listener {
             name = name.replaceAll("&([a-f0-9k-or])", "§$1");
             UtilitiesConfig.INSTANCE.skillPointLoadouts.put(name, getSkillPoints(e.getGui()));
             UtilitiesConfig.INSTANCE.saveSettings(UtilitiesModule.getModule());
-            ModCore.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.BLOCK_NOTE_PLING, 1f));
+            McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.BLOCK_NOTE_PLING, 1f));
         } else if (e.getKeyCode() == Keyboard.KEY_ESCAPE) {
             nameField = null;
             loadedBuild = null;
@@ -352,8 +351,8 @@ public class SkillPointOverlay implements Listener {
             TextComponentString text = new TextComponentString("Not enough free skill points!");
             text.getStyle().setColor(TextFormatting.RED);
 
-            ModCore.mc().player.sendMessage(text);
-            ModCore.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.BLOCK_ANVIL_PLACE, 1f));
+            McIf.mc().player.sendMessage(text);
+            McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.BLOCK_ANVIL_PLACE, 1f));
             return;
         }
 
@@ -379,12 +378,12 @@ public class SkillPointOverlay implements Listener {
 
             CPacketClickWindow packet = new CPacketClickWindow(gui.inventorySlots.windowId, 9 + i, button,
                     ClickType.PICKUP, gui.inventorySlots.getSlot(9 + i).getStack(),
-                    gui.inventorySlots.getNextTransactionID(ModCore.mc().player.inventory));
+                    gui.inventorySlots.getNextTransactionID(McIf.mc().player.inventory));
 
             McIf.mc().getSoundHandler().playSound(
                     PositionedSoundRecord.getMasterRecord(SoundEvents.ENTITY_ITEM_PICKUP, 0.3f + (1.2f * buildPercentage)));
 
-            ModCore.mc().getConnection().sendPacket(packet);
+            McIf.mc().getConnection().sendPacket(packet);
             return; // can only click once at a time
         }
 

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/WynnDataOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/WynnDataOverlay.java
@@ -90,7 +90,7 @@ public class WynnDataOverlay implements Listener {
 
     private int locateWeaponSlot() {
         for (int i = 0; i < 9; i++) {
-            String lore = ItemUtils.getStringLore(Minecraft.getMinecraft().player.inventory.mainInventory.get(i));
+            String lore = ItemUtils.getStringLore(McIf.mc().player.inventory.mainInventory.get(i));
             // Assume that only weapons have class requirements
             if (lore.contains("Class Req: " + PlayerInfo.get(CharacterData.class).getCurrentClass().getDisplayName())) {
                 return i;
@@ -104,17 +104,17 @@ public class WynnDataOverlay implements Listener {
         e.getButtonList().forEach(gb -> {
             if (gb.id != 12 || !gb.isMouseOver() || e.getMouseButton() != 0) return;
 
-            Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
+            McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1f));
 
             Map<String, String> urlData = new HashMap<>();
 
-            NonNullList<ItemStack> armorInventory = Minecraft.getMinecraft().player.inventory.armorInventory;
+            NonNullList<ItemStack> armorInventory = McIf.mc().player.inventory.armorInventory;
             getItemNameFromInventory(urlData, "helmet", armorInventory, 3);
             getItemNameFromInventory(urlData, "chestplate", armorInventory, 2);
             getItemNameFromInventory(urlData, "leggings", armorInventory, 1);
             getItemNameFromInventory(urlData, "boots", armorInventory, 0);
 
-            NonNullList<ItemStack> mainInventory = Minecraft.getMinecraft().player.inventory.mainInventory;
+            NonNullList<ItemStack> mainInventory = McIf.mc().player.inventory.mainInventory;
             getItemNameFromInventory(urlData, "ring1", mainInventory, 9);
             getItemNameFromInventory(urlData, "ring2", mainInventory, 10);
             getItemNameFromInventory(urlData, "bracelet", mainInventory, 11);

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/WynnDataOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/WynnDataOverlay.java
@@ -90,7 +90,7 @@ public class WynnDataOverlay implements Listener {
 
     private int locateWeaponSlot() {
         for (int i = 0; i < 9; i++) {
-            String lore = ItemUtils.getStringLore(McIf.mc().player.inventory.mainInventory.get(i));
+            String lore = ItemUtils.getStringLore(McIf.player().inventory.mainInventory.get(i));
             // Assume that only weapons have class requirements
             if (lore.contains("Class Req: " + PlayerInfo.get(CharacterData.class).getCurrentClass().getDisplayName())) {
                 return i;
@@ -108,13 +108,13 @@ public class WynnDataOverlay implements Listener {
 
             Map<String, String> urlData = new HashMap<>();
 
-            NonNullList<ItemStack> armorInventory = McIf.mc().player.inventory.armorInventory;
+            NonNullList<ItemStack> armorInventory = McIf.player().inventory.armorInventory;
             getItemNameFromInventory(urlData, "helmet", armorInventory, 3);
             getItemNameFromInventory(urlData, "chestplate", armorInventory, 2);
             getItemNameFromInventory(urlData, "leggings", armorInventory, 1);
             getItemNameFromInventory(urlData, "boots", armorInventory, 0);
 
-            NonNullList<ItemStack> mainInventory = McIf.mc().player.inventory.mainInventory;
+            NonNullList<ItemStack> mainInventory = McIf.player().inventory.mainInventory;
             getItemNameFromInventory(urlData, "ring1", mainInventory, 9);
             getItemNameFromInventory(urlData, "ring2", mainInventory, 10);
             getItemNameFromInventory(urlData, "bracelet", mainInventory, 11);

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/WynnDataOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/WynnDataOverlay.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.utilities.overlays.inventories;
 
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.GuiOverlapEvent;
 import com.wynntils.core.framework.enums.Powder;

--- a/src/main/java/com/wynntils/modules/utilities/overlays/ui/GearViewerUI.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/ui/GearViewerUI.java
@@ -331,7 +331,7 @@ public class GearViewerUI extends FakeGuiContainer {
 
         // item lore
         if (item.getLore() != null && !item.getLore().isEmpty()) {
-            itemLore.addAll(Minecraft.getMinecraft().fontRenderer.listFormattedStringToWidth(DARK_GRAY + item.getLore(), 150));
+            itemLore.addAll(McIf.mc().fontRenderer.listFormattedStringToWidth(DARK_GRAY + item.getLore(), 150));
         }
 
         ItemUtils.replaceLore(stack, itemLore);

--- a/src/main/java/com/wynntils/modules/utilities/overlays/ui/GearViewerUI.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/ui/GearViewerUI.java
@@ -8,7 +8,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
-import com.wynntils.ModCore;
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.framework.enums.ClassType;
 import com.wynntils.core.framework.enums.SpellType;
@@ -26,7 +26,6 @@ import com.wynntils.webapi.profiles.item.ItemProfile;
 import com.wynntils.webapi.profiles.item.enums.MajorIdentification;
 import com.wynntils.webapi.profiles.item.objects.IdentificationContainer;
 import com.wynntils.webapi.profiles.item.objects.ItemRequirementsContainer;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityOtherPlayerMP;
 import net.minecraft.client.gui.inventory.GuiInventory;
 import net.minecraft.client.renderer.GlStateManager;
@@ -58,7 +57,7 @@ public class GearViewerUI extends FakeGuiContainer {
     private EntityPlayer player;
 
     public GearViewerUI(InventoryBasic inventory, EntityPlayer player) {
-        super(new ContainerGearViewer(inventory, ModCore.mc().player));
+        super(new ContainerGearViewer(inventory, McIf.mc().player));
         this.inventory = inventory;
 
         // create copy of given player and inventory to keep items and models separate
@@ -118,7 +117,7 @@ public class GearViewerUI extends FakeGuiContainer {
     @Override
     protected void drawGuiContainerBackgroundLayer(float partialTicks, int mouseX, int mouseY) {
         GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
-        this.mc.getTextureManager().bindTexture(INVENTORY_GUI_TEXTURE);
+        McIf.mc().getTextureManager().bindTexture(INVENTORY_GUI_TEXTURE);
         int i = (this.width - this.xSize) / 2;
         int j = (this.height - this.ySize) / 2;
         this.drawTexturedModalRect(i, j, 0, 0, 96, 83);
@@ -348,13 +347,13 @@ public class GearViewerUI extends FakeGuiContainer {
     public static void openGearViewer() {
         if (!Reference.onWorld) return;
 
-        if (ModCore.mc().objectMouseOver == null) return;
-        Entity e = ModCore.mc().objectMouseOver.entityHit;
+        if (McIf.mc().objectMouseOver == null) return;
+        Entity e = McIf.mc().objectMouseOver.entityHit;
         if (!(e instanceof EntityPlayer)) return;
         EntityPlayer ep = (EntityPlayer) e;
         if (ep.getTeam() == null) return; // player model npc
 
-        ModCore.mc().displayGuiScreen(new GearViewerUI(new InventoryBasic("", false, 5), ep));
+        McIf.mc().displayGuiScreen(new GearViewerUI(new InventoryBasic("", false, 5), ep));
     }
 
 }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/ui/GearViewerUI.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/ui/GearViewerUI.java
@@ -57,7 +57,7 @@ public class GearViewerUI extends FakeGuiContainer {
     private EntityPlayer player;
 
     public GearViewerUI(InventoryBasic inventory, EntityPlayer player) {
-        super(new ContainerGearViewer(inventory, McIf.mc().player));
+        super(new ContainerGearViewer(inventory, McIf.player()));
         this.inventory = inventory;
 
         // create copy of given player and inventory to keep items and models separate

--- a/src/main/java/com/wynntils/modules/utilities/overlays/ui/SkillPointLoadoutUI.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/ui/SkillPointLoadoutUI.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.utilities.overlays.ui;
 
+import com.wynntils.McIf;
 import com.wynntils.ModCore;
 import com.wynntils.core.framework.enums.SkillPoint;
 import com.wynntils.core.framework.instances.PlayerInfo;
@@ -145,7 +146,7 @@ public class SkillPointLoadoutUI extends FakeGuiContainer {
 
     @Override
     protected void drawGuiContainerForegroundLayer(int mouseX, int mouseY) {
-        this.fontRenderer.drawString(this.inventory.getDisplayName().getUnformattedText(), 8, 6, 4210752);
+        this.fontRenderer.drawString(McIf.getUnformattedText(this.inventory.getDisplayName()), 8, 6, 4210752);
     }
 
     @Override

--- a/src/main/java/com/wynntils/modules/utilities/overlays/ui/SkillPointLoadoutUI.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/ui/SkillPointLoadoutUI.java
@@ -117,14 +117,14 @@ public class SkillPointLoadoutUI extends FakeGuiContainer {
         if (mouseButton == 1) { // right click <-> delete
             List<String> lore = ItemUtils.getLore(slotIn.getStack());
             if (lore.get(lore.size() - 1).contains("confirm")) { // confirm deletion
-                Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.ENTITY_IRONGOLEM_HURT, 1f));
+                McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.ENTITY_IRONGOLEM_HURT, 1f));
 
                 removeLoadout(name);
                 this.initGui();
                 return;
             }
 
-            Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.BLOCK_ANVIL_LAND, 1f));
+            McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.BLOCK_ANVIL_LAND, 1f));
             lore.set(lore.size() -1, TextFormatting.DARK_RED + "> Right-click to confirm deletion");
             ItemUtils.replaceLore(slotIn.getStack(), lore);
         }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/ui/SkillPointLoadoutUI.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/ui/SkillPointLoadoutUI.java
@@ -43,7 +43,7 @@ public class SkillPointLoadoutUI extends FakeGuiContainer {
     private final int inventoryRows;
 
     public SkillPointLoadoutUI(SkillPointOverlay parent, GuiScreen spMenu, InventoryBasic inventory) {
-        super(new ContainerBuilds(inventory, McIf.mc().player));
+        super(new ContainerBuilds(inventory, McIf.player()));
         this.parent = parent;
         this.spMenu = spMenu;
         this.inventory = inventory;

--- a/src/main/java/com/wynntils/modules/utilities/overlays/ui/SkillPointLoadoutUI.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/ui/SkillPointLoadoutUI.java
@@ -5,7 +5,6 @@
 package com.wynntils.modules.utilities.overlays.ui;
 
 import com.wynntils.McIf;
-import com.wynntils.ModCore;
 import com.wynntils.core.framework.enums.SkillPoint;
 import com.wynntils.core.framework.instances.PlayerInfo;
 import com.wynntils.core.framework.instances.data.CharacterData;
@@ -15,7 +14,6 @@ import com.wynntils.modules.utilities.configs.UtilitiesConfig;
 import com.wynntils.modules.utilities.instances.ContainerBuilds;
 import com.wynntils.modules.utilities.instances.SkillPointAllocation;
 import com.wynntils.modules.utilities.overlays.inventories.SkillPointOverlay;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.audio.PositionedSoundRecord;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.renderer.GlStateManager;
@@ -45,7 +43,7 @@ public class SkillPointLoadoutUI extends FakeGuiContainer {
     private final int inventoryRows;
 
     public SkillPointLoadoutUI(SkillPointOverlay parent, GuiScreen spMenu, InventoryBasic inventory) {
-        super(new ContainerBuilds(inventory, ModCore.mc().player));
+        super(new ContainerBuilds(inventory, McIf.mc().player));
         this.parent = parent;
         this.spMenu = spMenu;
         this.inventory = inventory;
@@ -110,7 +108,7 @@ public class SkillPointLoadoutUI extends FakeGuiContainer {
 
             parent.loadBuild(aloc); // sends the allocated loadout into
 
-            ModCore.mc().displayGuiScreen(spMenu);
+            McIf.mc().displayGuiScreen(spMenu);
             return;
         }
 
@@ -132,8 +130,8 @@ public class SkillPointLoadoutUI extends FakeGuiContainer {
 
     @Override
     protected void keyTyped(char typedChar, int keyCode) {
-        if (keyCode == Keyboard.KEY_ESCAPE || keyCode == ModCore.mc().gameSettings.keyBindInventory.getKeyCode()) {
-            ModCore.mc().displayGuiScreen(spMenu);
+        if (keyCode == Keyboard.KEY_ESCAPE || keyCode == McIf.mc().gameSettings.keyBindInventory.getKeyCode()) {
+            McIf.mc().displayGuiScreen(spMenu);
         }
     }
 
@@ -152,7 +150,7 @@ public class SkillPointLoadoutUI extends FakeGuiContainer {
     @Override
     protected void drawGuiContainerBackgroundLayer(float partialTicks, int mouseX, int mouseY) {
         GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
-        this.mc.getTextureManager().bindTexture(CHEST_GUI_TEXTURE);
+        McIf.mc().getTextureManager().bindTexture(CHEST_GUI_TEXTURE);
         int i = (this.width - this.xSize) / 2;
         int j = (this.height - this.ySize) / 2;
         this.drawTexturedModalRect(i, j, 0, 0, this.xSize, this.inventoryRows * 18 + 17);

--- a/src/main/java/com/wynntils/modules/visual/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/visual/events/ClientEvents.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.visual.events;
 
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.GameEvent;
 import com.wynntils.core.events.custom.PacketEvent;
@@ -33,13 +34,12 @@ public class ClientEvents implements Listener {
     public void cacheChunks(PacketEvent<SPacketChunkData> event) {
         if (!Reference.onWorld || !VisualConfig.CachedChunks.INSTANCE.enabled) return;
 
-        Minecraft mc = McIf.mc();
         SPacketChunkData packet = event.getPacket();
 
         // Requests the chunk to be unloaded if loaded before loading (???)
         // this fixes some weird ass issue with optifine, don't ask too much
-        if (packet.isFullChunk() && mc.world.getChunk(packet.getChunkX(), packet.getChunkZ()).isLoaded()) {
-            mc.addScheduledTask(() -> mc.world.getChunkProvider().unloadChunk(packet.getChunkX(), packet.getChunkZ()));
+        if (packet.isFullChunk() && McIf.mc().world.getChunk(packet.getChunkX(), packet.getChunkZ()).isLoaded()) {
+            McIf.mc().addScheduledTask(() -> McIf.mc().world.getChunkProvider().unloadChunk(packet.getChunkX(), packet.getChunkZ()));
         }
 
         CachedChunkManager.asyncCacheChunk(packet);

--- a/src/main/java/com/wynntils/modules/visual/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/visual/events/ClientEvents.java
@@ -33,7 +33,7 @@ public class ClientEvents implements Listener {
     public void cacheChunks(PacketEvent<SPacketChunkData> event) {
         if (!Reference.onWorld || !VisualConfig.CachedChunks.INSTANCE.enabled) return;
 
-        Minecraft mc = Minecraft.getMinecraft();
+        Minecraft mc = McIf.mc();
         SPacketChunkData packet = event.getPacket();
 
         // Requests the chunk to be unloaded if loaded before loading (???)

--- a/src/main/java/com/wynntils/modules/visual/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/visual/events/ClientEvents.java
@@ -38,8 +38,8 @@ public class ClientEvents implements Listener {
 
         // Requests the chunk to be unloaded if loaded before loading (???)
         // this fixes some weird ass issue with optifine, don't ask too much
-        if (packet.isFullChunk() && McIf.mc().world.getChunk(packet.getChunkX(), packet.getChunkZ()).isLoaded()) {
-            McIf.mc().addScheduledTask(() -> McIf.mc().world.getChunkProvider().unloadChunk(packet.getChunkX(), packet.getChunkZ()));
+        if (packet.isFullChunk() && McIf.world().getChunk(packet.getChunkX(), packet.getChunkZ()).isLoaded()) {
+            McIf.mc().addScheduledTask(() -> McIf.world().getChunkProvider().unloadChunk(packet.getChunkX(), packet.getChunkZ()));
         }
 
         CachedChunkManager.asyncCacheChunk(packet);

--- a/src/main/java/com/wynntils/modules/visual/instances/SplashProfile.java
+++ b/src/main/java/com/wynntils/modules/visual/instances/SplashProfile.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.visual.instances;
 
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.webapi.downloader.DownloaderManager;
 import com.wynntils.webapi.downloader.enums.DownloadAction;

--- a/src/main/java/com/wynntils/modules/visual/instances/SplashProfile.java
+++ b/src/main/java/com/wynntils/modules/visual/instances/SplashProfile.java
@@ -44,8 +44,8 @@ public class SplashProfile {
 
     private void setReadyToUse() {
         // make sure this is being called from the main thread
-        if (!Minecraft.getMinecraft().isCallingFromMinecraftThread()) {
-            Minecraft.getMinecraft().addScheduledTask(this::setReadyToUse);
+        if (!McIf.mc().isCallingFromMinecraftThread()) {
+            McIf.mc().addScheduledTask(this::setReadyToUse);
             return;
         }
         readyToUse = true;

--- a/src/main/java/com/wynntils/modules/visual/managers/CachedChunkManager.java
+++ b/src/main/java/com/wynntils/modules/visual/managers/CachedChunkManager.java
@@ -131,7 +131,7 @@ public class CachedChunkManager {
      * This method is thread safe
      */
     private static void startChunkLoader() {
-        Minecraft mc = Minecraft.getMinecraft();
+        Minecraft mc = McIf.mc();
         while (Reference.onWorld && VisualConfig.CachedChunks.INSTANCE.enabled) {
             // Sleep the thread for 1 second, we don't care about precision for this
             try {

--- a/src/main/java/com/wynntils/modules/visual/managers/CachedChunkManager.java
+++ b/src/main/java/com/wynntils/modules/visual/managers/CachedChunkManager.java
@@ -139,7 +139,7 @@ public class CachedChunkManager {
             } catch (Exception ignored) { }
 
             int renderDistance = McIf.mc().gameSettings.renderDistanceChunks;
-            ChunkPos player = new ChunkPos(McIf.mc().player.chunkCoordX, McIf.mc().player.chunkCoordZ);
+            ChunkPos player = new ChunkPos(McIf.player().chunkCoordX, McIf.player().chunkCoordZ);
 
             // Start by removing chunks that are not in the render distance
             Iterator<ChunkPos> it = loadedChunks.iterator();

--- a/src/main/java/com/wynntils/modules/visual/managers/CachedChunkManager.java
+++ b/src/main/java/com/wynntils/modules/visual/managers/CachedChunkManager.java
@@ -5,6 +5,7 @@
 package com.wynntils.modules.visual.managers;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.modules.visual.configs.VisualConfig;
 import io.netty.buffer.ByteBuf;
@@ -131,15 +132,14 @@ public class CachedChunkManager {
      * This method is thread safe
      */
     private static void startChunkLoader() {
-        Minecraft mc = McIf.mc();
         while (Reference.onWorld && VisualConfig.CachedChunks.INSTANCE.enabled) {
             // Sleep the thread for 1 second, we don't care about precision for this
             try {
                 Thread.sleep(1000);
             } catch (Exception ignored) { }
 
-            int renderDistance = mc.gameSettings.renderDistanceChunks;
-            ChunkPos player = new ChunkPos(mc.player.chunkCoordX, mc.player.chunkCoordZ);
+            int renderDistance = McIf.mc().gameSettings.renderDistanceChunks;
+            ChunkPos player = new ChunkPos(McIf.mc().player.chunkCoordX, McIf.mc().player.chunkCoordZ);
 
             // Start by removing chunks that are not in the render distance
             Iterator<ChunkPos> it = loadedChunks.iterator();
@@ -167,7 +167,7 @@ public class CachedChunkManager {
                     ChunkPos pos = new ChunkPos(player.x + x, player.z + z);
 
                     if (loadedChunks.contains(pos)) continue;
-                    if (mc.world.getChunk(pos.x, pos.z).isLoaded()) continue;
+                    if (McIf.mc().world.getChunk(pos.x, pos.z).isLoaded()) continue;
 
                     toLoad.add(pos);
                 }
@@ -220,7 +220,7 @@ public class CachedChunkManager {
                     packet.readPacketData(packetBuffer);
 
                     // Submit the packet to the client handler bypassing the packet sent
-                    mc.addScheduledTask(() -> mc.getConnection().handleChunkData(packet));
+                    McIf.mc().addScheduledTask(() -> McIf.mc().getConnection().handleChunkData(packet));
                 }
             } catch (Exception ex) {
                 ex.printStackTrace();

--- a/src/main/java/com/wynntils/modules/visual/managers/CachedChunkManager.java
+++ b/src/main/java/com/wynntils/modules/visual/managers/CachedChunkManager.java
@@ -167,7 +167,7 @@ public class CachedChunkManager {
                     ChunkPos pos = new ChunkPos(player.x + x, player.z + z);
 
                     if (loadedChunks.contains(pos)) continue;
-                    if (McIf.mc().world.getChunk(pos.x, pos.z).isLoaded()) continue;
+                    if (McIf.world().getChunk(pos.x, pos.z).isLoaded()) continue;
 
                     toLoad.add(pos);
                 }

--- a/src/main/java/com/wynntils/modules/visual/overlays/OverlayEvents.java
+++ b/src/main/java/com/wynntils/modules/visual/overlays/OverlayEvents.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.visual.overlays;
 
+import com.wynntils.McIf;
 import com.wynntils.core.events.custom.GuiOverlapEvent;
 import com.wynntils.core.framework.interfaces.Listener;
 import com.wynntils.core.framework.rendering.instances.WindowedResolution;

--- a/src/main/java/com/wynntils/modules/visual/overlays/OverlayEvents.java
+++ b/src/main/java/com/wynntils/modules/visual/overlays/OverlayEvents.java
@@ -24,7 +24,7 @@ public class OverlayEvents implements Listener {
 
         WindowedResolution res = new WindowedResolution(480, 254);
         fakeCharacterSelector = new CharacterSelectorUI(null, e.getGui(), res.getScaleFactor());
-        fakeCharacterSelector.setWorldAndResolution(Minecraft.getMinecraft(), e.getGui().width, e.getGui().height);
+        fakeCharacterSelector.setWorldAndResolution(McIf.mc(), e.getGui().width, e.getGui().height);
     }
 
     @SubscribeEvent(priority = EventPriority.LOWEST)

--- a/src/main/java/com/wynntils/modules/visual/overlays/ui/CharacterSelectorUI.java
+++ b/src/main/java/com/wynntils/modules/visual/overlays/ui/CharacterSelectorUI.java
@@ -432,7 +432,7 @@ public class CharacterSelectorUI extends GuiScreen {
             enableBlend();
         }
 
-        GuiInventory.drawEntityOnScreen(middleX, 210, 60, 0, 0, Minecraft.getMinecraft().player);
+        GuiInventory.drawEntityOnScreen(middleX, 210, 60, 0, 0, McIf.mc().player);
     }
 
     private void drawCharacterBadge(int posX, int posY, ItemStack item, String name, String level, String deletion, float xp, boolean selected, int id) {

--- a/src/main/java/com/wynntils/modules/visual/overlays/ui/CharacterSelectorUI.java
+++ b/src/main/java/com/wynntils/modules/visual/overlays/ui/CharacterSelectorUI.java
@@ -63,7 +63,7 @@ public class CharacterSelectorUI extends GuiScreen {
 
     // scroll bar
     float scrollPosition = 0f;
-    long scrollDelay = Minecraft.getSystemTime();
+    long scrollDelay = McIf.getSystemTime();
 
     // scaled positions
     int mouseX, mouseY;
@@ -268,16 +268,16 @@ public class CharacterSelectorUI extends GuiScreen {
 
         float jump = availableCharacters.size() <= 7 ? 0 : 32 / (availableCharacters.size() - 7) * 32;
 
-        if (mDWheel <= -1 && (Minecraft.getSystemTime() - scrollDelay >= 15)) {
+        if (mDWheel <= -1 && (McIf.getSystemTime() - scrollDelay >= 15)) {
             if (scrollPosition >= 1f || availableCharacters.size() <= 7) return;
 
-            scrollDelay = Minecraft.getSystemTime();
+            scrollDelay = McIf.getSystemTime();
             if (scrollPosition + jump >= 1f) scrollPosition = 1f;
             else scrollPosition += jump;
-        } else if (mDWheel >= 1 && (Minecraft.getSystemTime() - scrollDelay >= 15)) {
+        } else if (mDWheel >= 1 && (McIf.getSystemTime() - scrollDelay >= 15)) {
             if (scrollPosition <= 0f || availableCharacters.size() <= 7) return;
 
-            scrollDelay = Minecraft.getSystemTime();
+            scrollDelay = McIf.getSystemTime();
             if (scrollPosition - jump <= 0f) scrollPosition = 0f;
             else scrollPosition -= jump;
         }

--- a/src/main/java/com/wynntils/modules/visual/overlays/ui/CharacterSelectorUI.java
+++ b/src/main/java/com/wynntils/modules/visual/overlays/ui/CharacterSelectorUI.java
@@ -100,7 +100,7 @@ public class CharacterSelectorUI extends GuiScreen {
         hoveredButton = -1;
         hoveredText = null;
 
-        McIf.mc().player.setInvisible(false); // removes invisibility from character selection
+        McIf.player().setInvisible(false); // removes invisibility from character selection
         updateItems(); // tries to get the inventory items
 
         float animationPercentage = Math.max((animationEnd - System.currentTimeMillis()) / 100f, 0f);
@@ -433,7 +433,7 @@ public class CharacterSelectorUI extends GuiScreen {
             enableBlend();
         }
 
-        GuiInventory.drawEntityOnScreen(middleX, 210, 60, 0, 0, McIf.mc().player);
+        GuiInventory.drawEntityOnScreen(middleX, 210, 60, 0, 0, McIf.player());
     }
 
     private void drawCharacterBadge(int posX, int posY, ItemStack item, String name, String level, String deletion, float xp, boolean selected, int id) {

--- a/src/main/java/com/wynntils/modules/visual/overlays/ui/CharacterSelectorUI.java
+++ b/src/main/java/com/wynntils/modules/visual/overlays/ui/CharacterSelectorUI.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.visual.overlays.ui;
 
+import com.wynntils.McIf;
 import com.wynntils.core.framework.enums.CharacterGameMode;
 import com.wynntils.core.framework.rendering.ScreenRenderer;
 import com.wynntils.core.framework.rendering.SmartFontRenderer;
@@ -99,7 +100,7 @@ public class CharacterSelectorUI extends GuiScreen {
         hoveredButton = -1;
         hoveredText = null;
 
-        mc.player.setInvisible(false); // removes invisibility from character selection
+        McIf.mc().player.setInvisible(false); // removes invisibility from character selection
         updateItems(); // tries to get the inventory items
 
         float animationPercentage = Math.max((animationEnd - System.currentTimeMillis()) / 100f, 0f);
@@ -191,7 +192,7 @@ public class CharacterSelectorUI extends GuiScreen {
         lastClick = System.currentTimeMillis();
         lastButton = hoveredButton;
 
-        mc.getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1.0F));
+        McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1.0F));
 
         // character picking
         if (hoveredButton <= 50) {
@@ -553,11 +554,11 @@ public class CharacterSelectorUI extends GuiScreen {
     }
 
     @Override
-    public void setWorldAndResolution(Minecraft mc, int width, int height) {
+    public void setWorldAndResolution(Minecraft minecraft, int width, int height) {
         scaledWidth = (int)(width / scale);
         scaledHeight = (int)(height / scale);
 
-        super.setWorldAndResolution(mc, width, height);
+        super.setWorldAndResolution(minecraft, width, height);
     }
 
 }

--- a/src/main/java/com/wynntils/webapi/WebManager.java
+++ b/src/main/java/com/wynntils/webapi/WebManager.java
@@ -6,7 +6,7 @@ package com.wynntils.webapi;
 
 import com.google.common.reflect.TypeToken;
 import com.google.gson.*;
-import com.wynntils.ModCore;
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.WynnGuildWarEvent;
 import com.wynntils.core.framework.FrameworkManager;
@@ -523,7 +523,7 @@ public class WebManager {
 
     public static void updatePlayerProfile(RequestHandler handler) {
         if (apiUrls == null) return;
-        String url = apiUrls.get("PlayerStatsv2") + ModCore.mc().getSession().getProfile().getId() + "/stats";
+        String url = apiUrls.get("PlayerStatsv2") + McIf.mc().getSession().getProfile().getId() + "/stats";
         handler.addRequest(new Request(url, "player_profile")
             .cacheTo(new File(API_CACHE_ROOT, "player_stats.json"))
             .addHeader("apikey", apiUrls.get("WynnApiKey"))

--- a/src/main/java/com/wynntils/webapi/account/WynntilsAccount.java
+++ b/src/main/java/com/wynntils/webapi/account/WynntilsAccount.java
@@ -6,7 +6,7 @@ package com.wynntils.webapi.account;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.gson.JsonObject;
-import com.wynntils.ModCore;
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.framework.enums.professions.GatheringMaterial;
 import com.wynntils.core.framework.enums.professions.ProfessionType;
@@ -44,7 +44,7 @@ public class WynntilsAccount {
     public String getToken() {
         return token;
     }
-    
+
     public boolean isConnected() {
         return ready;
     }
@@ -83,7 +83,7 @@ public class WynntilsAccount {
         // response
 
         JsonObject authParams = new JsonObject();
-        authParams.addProperty("username", ModCore.mc().getSession().getUsername());
+        authParams.addProperty("username", McIf.mc().getSession().getUsername());
         authParams.addProperty("key", secretKey[0]);
         authParams.addProperty("version", Reference.VERSION + "_" + Reference.BUILD_NUMBER);
 
@@ -169,8 +169,7 @@ public class WynntilsAccount {
 
             String s1 = (new BigInteger(CryptManager.getServerIdHash("", publicKey, secretkey))).toString(16);
 
-            Minecraft mc = ModCore.mc();
-            mc.getSessionService().joinServer(mc.getSession().getProfile(), mc.getSession().getToken(), s1.toLowerCase());
+            McIf.mc().getSessionService().joinServer(McIf.mc().getSession().getProfile(), McIf.mc().getSession().getToken(), s1.toLowerCase());
 
             byte[] secretKeyEncrypted = CryptManager.encryptData(publicKey, secretkey.getEncoded());
 

--- a/src/main/java/com/wynntils/webapi/account/WynntilsAccount.java
+++ b/src/main/java/com/wynntils/webapi/account/WynntilsAccount.java
@@ -16,11 +16,11 @@ import com.wynntils.webapi.WebManager;
 import com.wynntils.webapi.request.PostRequest;
 import com.wynntils.webapi.request.Request;
 import com.wynntils.webapi.request.RequestHandler;
-import net.minecraft.client.Minecraft;
 import net.minecraft.util.CryptManager;
+import org.apache.commons.codec.binary.Hex;
 
 import javax.crypto.SecretKey;
-import javax.xml.bind.DatatypeConverter;
+
 import java.io.File;
 import java.math.BigInteger;
 import java.security.PublicKey;
@@ -161,7 +161,7 @@ public class WynntilsAccount {
 
     private String parseAndJoinPublicKey(String key) {
         try {
-            byte[] publicKeyBy = DatatypeConverter.parseHexBinary(key);
+            byte[] publicKeyBy = Hex.decodeHex(key.toCharArray());
 
             SecretKey secretkey = CryptManager.createNewSharedKey();
 
@@ -173,7 +173,7 @@ public class WynntilsAccount {
 
             byte[] secretKeyEncrypted = CryptManager.encryptData(publicKey, secretkey.getEncoded());
 
-            return DatatypeConverter.printHexBinary(secretKeyEncrypted);
+            return Hex.encodeHexString(secretKeyEncrypted);
         } catch (Exception ex) {
             ex.printStackTrace();
             return "";

--- a/src/main/java/com/wynntils/webapi/profiles/item/ItemProfile.java
+++ b/src/main/java/com/wynntils/webapi/profiles/item/ItemProfile.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.webapi.profiles.item;
 
+import com.wynntils.McIf;
 import com.wynntils.core.framework.enums.ClassType;
 import com.wynntils.core.framework.enums.DamageType;
 import com.wynntils.core.utils.StringUtils;
@@ -268,7 +269,7 @@ public class ItemProfile {
 
             // item lore
             if (lore != null && !lore.isEmpty()) {
-                itemLore.addAll(Minecraft.getMinecraft().fontRenderer.listFormattedStringToWidth(DARK_GRAY + this.getLore(), 150));
+                itemLore.addAll(McIf.mc().fontRenderer.listFormattedStringToWidth(DARK_GRAY + this.getLore(), 150));
             }
         }
 


### PR DESCRIPTION
I've done some very basic cleaning up on how we access various internal Minecraft resources. This is driven by how these resources have changed in 1.16. Putting the access behind wrappers like this will facilitate a smoother transition to 1.16, but I also think they have a merit on their own (at least the mc() changes).

My proposal is to integrate this into mainline, but keep the 1.16-preparation branch open for more pre-1.16 adaptations. In the meantime, I'll integrate the changes from 1.16-preparations into the 1.16-proof-of-concept branch (soon to be added here).