### PR TITLE
Hoverable item tooltips in chat

### DIFF
--- a/src/main/java/com/wynntils/core/framework/enums/Powder.java
+++ b/src/main/java/com/wynntils/core/framework/enums/Powder.java
@@ -29,6 +29,14 @@ public enum Powder {
         return symbol;
     }
 
+    public String getColor() {
+        return color;
+    }
+
+    public String getColoredSymbol() {
+        return color + symbol;
+    }
+
     public String getLetterRepresentation() {
         return this.name().substring(0, 1).toLowerCase();
     }

--- a/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
+++ b/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
@@ -331,26 +331,32 @@ public class ChatManager {
                     continue;
                 }
 
-                String text = McIf.getUnformattedText(comp);
-                Style style = comp.getStyle();
+                do {
 
-                ITextComponent item = ChatItemManager.decodeItem(m.group());
-                if (item == null) { // couldn't decode, skip
-                    ITextComponent newComponent = new TextComponentString(comp.getUnformattedComponentText());
-                    newComponent.setStyle(comp.getStyle().createShallowCopy());
-                    temp.appendSibling(newComponent);
-                    continue;
-                }
+                    String text = McIf.getUnformattedText(comp);
+                    Style style = comp.getStyle();
 
-                ITextComponent preText = new TextComponentString(text.substring(0, m.start()));
-                preText.setStyle(style.createShallowCopy());
-                temp.appendSibling(preText);
+                    ITextComponent item = ChatItemManager.decodeItem(m.group());
+                    if (item == null) { // couldn't decode, skip
+                        comp = new TextComponentString(comp.getUnformattedComponentText());
+                        comp.setStyle(style.createShallowCopy());
+                        continue;
+                    }
 
-                temp.appendSibling(item);
+                    ITextComponent preText = new TextComponentString(text.substring(0, m.start()));
+                    preText.setStyle(style.createShallowCopy());
+                    temp.appendSibling(preText);
 
-                ITextComponent postText = new TextComponentString(text.substring(m.end()));
-                postText.setStyle(style.createShallowCopy());
-                temp.appendSibling(postText);
+                    temp.appendSibling(item);
+
+                    comp = new TextComponentString(text.substring(m.end()));
+                    comp.setStyle(style.createShallowCopy());
+
+                    m = ChatItemManager.ENCODED_PATTERN.matcher(comp.getUnformattedText()); // recreate matcher for new substring
+
+                } while (m.find()); // search for multiple items in the same message
+
+                temp.appendSibling(comp); // leftover text after item(s)
             }
             in = temp;
         }

--- a/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
+++ b/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
@@ -270,7 +270,6 @@ public class ChatManager {
 
         // clickable coordinates
         if (ChatConfig.INSTANCE.clickableCoordinates && coordinateReg.matcher(McIf.getUnformattedText(in)).find()) {
-
             ITextComponent temp = new TextComponentString("");
             for (ITextComponent texts : in) {
                 Matcher m = coordinateReg.matcher(texts.getUnformattedComponentText());
@@ -319,10 +318,8 @@ public class ChatManager {
 
         // chat item tooltips
         if (ChatItemManager.ENCODED_PATTERN.matcher(McIf.getUnformattedText(in)).find()) {
-
             ITextComponent temp = new TextComponentString("");
             for (ITextComponent comp : in) {
-
                 Matcher m = ChatItemManager.ENCODED_PATTERN.matcher(comp.getUnformattedComponentText());
                 if (!m.find()) {
                     ITextComponent newComponent = new TextComponentString(comp.getUnformattedComponentText());
@@ -332,7 +329,6 @@ public class ChatManager {
                 }
 
                 do {
-
                     String text = McIf.getUnformattedText(comp);
                     Style style = comp.getStyle();
 
@@ -353,9 +349,7 @@ public class ChatManager {
                     comp.setStyle(style.createShallowCopy());
 
                     m = ChatItemManager.ENCODED_PATTERN.matcher(comp.getUnformattedText()); // recreate matcher for new substring
-
                 } while (m.find()); // search for multiple items in the same message
-
                 temp.appendSibling(comp); // leftover text after item(s)
             }
             in = temp;

--- a/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
+++ b/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
@@ -16,6 +16,7 @@ import com.wynntils.modules.questbook.enums.AnalysePosition;
 import com.wynntils.modules.questbook.instances.DiscoveryInfo;
 import com.wynntils.modules.questbook.managers.QuestManager;
 import com.wynntils.modules.utilities.configs.TranslationConfig;
+import com.wynntils.modules.utilities.managers.ChatItemManager;
 import com.wynntils.webapi.services.TranslationManager;
 import net.minecraft.client.audio.PositionedSoundRecord;
 import net.minecraft.init.Items;
@@ -312,6 +313,44 @@ public class ChatManager {
                 crdMsg.add(postText);
 
                 temp.getSiblings().addAll(crdMsg);
+            }
+            in = temp;
+        }
+
+        // chat item tooltips
+        if (ChatItemManager.ENCODED_PATTERN.matcher(McIf.getUnformattedText(in)).find()) {
+
+            ITextComponent temp = new TextComponentString("");
+            for (ITextComponent comp : in) {
+
+                Matcher m = ChatItemManager.ENCODED_PATTERN.matcher(comp.getUnformattedComponentText());
+                if (!m.find()) {
+                    ITextComponent newComponent = new TextComponentString(comp.getUnformattedComponentText());
+                    newComponent.setStyle(comp.getStyle().createShallowCopy());
+                    temp.appendSibling(newComponent);
+                    continue;
+                }
+
+                String text = McIf.getUnformattedText(comp);
+                Style style = comp.getStyle();
+
+                ITextComponent item = ChatItemManager.decodeItem(m.group());
+                if (item == null) { // couldn't decode, skip
+                    ITextComponent newComponent = new TextComponentString(comp.getUnformattedComponentText());
+                    newComponent.setStyle(comp.getStyle().createShallowCopy());
+                    temp.appendSibling(newComponent);
+                    continue;
+                }
+
+                ITextComponent preText = new TextComponentString(text.substring(0, m.start()));
+                preText.setStyle(style.createShallowCopy());
+                temp.appendSibling(preText);
+
+                temp.appendSibling(item);
+
+                ITextComponent postText = new TextComponentString(text.substring(m.end()));
+                postText.setStyle(style.createShallowCopy());
+                temp.appendSibling(postText);
             }
             in = temp;
         }

--- a/src/main/java/com/wynntils/modules/questbook/managers/ScoreboardManager.java
+++ b/src/main/java/com/wynntils/modules/questbook/managers/ScoreboardManager.java
@@ -1,3 +1,7 @@
+/*
+ *  * Copyright © Wynntils - 2018 - 2021.
+ */
+
 package com.wynntils.modules.questbook.managers;
 
 import java.util.ArrayList;

--- a/src/main/java/com/wynntils/modules/utilities/managers/ChatItemManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/ChatItemManager.java
@@ -159,10 +159,10 @@ public class ChatItemManager {
         Matcher m = ENCODED_PATTERN.matcher(encoded);
         if (!m.matches()) return null;
 
-        String name = ENCODE_NAME ? decodeString(m.group(1)) : m.group(1);
-        int ids[] = decodeNumbers(m.group(2));
-        int powders[] = m.group(3) != null ? decodeNumbers(m.group(3)) : new int[0];
-        int rerolls = decodeNumbers(m.group(4))[0];
+        String name = ENCODE_NAME ? decodeString(m.group("Name")) : m.group("Name");
+        int ids[] = decodeNumbers(m.group("Ids"));
+        int powders[] = m.group("Powders") != null ? decodeNumbers(m.group("Powders")) : new int[0];
+        int rerolls = decodeNumbers(m.group("Rerolls"))[0];
 
         ItemProfile item = WebManager.getItems().get(name);
         if (item == null) return null;

--- a/src/main/java/com/wynntils/modules/utilities/managers/ChatItemManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/ChatItemManager.java
@@ -1,9 +1,12 @@
+/*
+ *  * Copyright © Wynntils - 2018 - 2021.
+ */
+
 package com.wynntils.modules.utilities.managers;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/com/wynntils/modules/utilities/managers/ChatItemManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/ChatItemManager.java
@@ -176,7 +176,7 @@ public class ChatItemManager {
         List<String> itemLore = new ArrayList<>();
 
         // identifier
-        itemLore.add(DARK_GRAY.toString() + Arrays.stream(ids).sum());
+        itemLore.add(DARK_GRAY.toString() + ITALIC + "From chat");
 
         // attack speed
         if (item.getAttackSpeed() != null) {

--- a/src/main/java/com/wynntils/modules/utilities/managers/ChatItemManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/ChatItemManager.java
@@ -1,0 +1,340 @@
+package com.wynntils.modules.utilities.managers;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import com.wynntils.McIf;
+import com.wynntils.core.framework.enums.ClassType;
+import com.wynntils.core.framework.enums.Powder;
+import com.wynntils.core.framework.enums.SpellType;
+import com.wynntils.core.framework.instances.PlayerInfo;
+import com.wynntils.core.framework.instances.data.CharacterData;
+import com.wynntils.core.utils.ItemUtils;
+import com.wynntils.core.utils.StringUtils;
+import com.wynntils.modules.utilities.overlays.inventories.ItemIdentificationOverlay;
+import com.wynntils.webapi.WebManager;
+import com.wynntils.webapi.profiles.item.IdentificationOrderer;
+import com.wynntils.webapi.profiles.item.ItemProfile;
+import com.wynntils.webapi.profiles.item.objects.IdentificationContainer;
+import com.wynntils.webapi.profiles.item.objects.ItemRequirementsContainer;
+import com.wynntils.webapi.profiles.item.objects.MajorIdentification;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagByte;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagInt;
+import net.minecraft.util.text.TextFormatting;
+
+import static net.minecraft.util.text.TextFormatting.*;
+
+public class ChatItemManager {
+
+    // private-use unicode chars
+    private static final String START = new String(Character.toChars(0xF5000));
+    private static final String END = new String(Character.toChars(0xF5001));
+    private static final String SEPARATOR = new String(Character.toChars(0xF5002));
+    private static final String RANGE = "[" + new String(Character.toChars(0xF5003)) + "-" + new String(Character.toChars(0xF5067)) + "]";
+    private static final int OFFSET = 0xF5003;
+
+    public static final Pattern ENCODED_PATTERN = Pattern.compile(START + "(" + RANGE + "+)" + SEPARATOR + "(" + RANGE + "*)(?:" + SEPARATOR + "(" + RANGE + "+))?" + SEPARATOR + "(" + RANGE + ")" + END);
+
+    public static String encodeItem(ItemStack stack) {
+        String itemName = TextFormatting.getTextWithoutFormattingCodes(stack.getDisplayName());
+        if (!stack.getTagCompound().hasKey("wynntils") && WebManager.getItems().get(itemName) == null) return null; // not a gear item, cannot be encoded
+
+        // get identification data
+        NBTTagCompound itemData = ItemIdentificationOverlay.generateData(stack);
+        ItemProfile item = WebManager.getItems().get(itemData.getString("originName"));
+
+        // sort list to ensure encoding/decoding is always 1:1
+        List<String> sortedIds = new ArrayList<>(item.getStatuses().keySet());
+        sortedIds.sort(Comparator.comparingInt(IdentificationOrderer.INSTANCE::getOrder));
+
+        // item is missing id data when it shouldn't, abort
+        if (!itemData.hasKey("ids") && !sortedIds.isEmpty()) return null;
+
+        // name
+        StringBuilder encoded = new StringBuilder(START + encodeString(item.getDisplayName()) + SEPARATOR);
+
+        // ids
+        for (String id : sortedIds) {
+            IdentificationContainer status = item.getStatuses().get(id);
+            if (status.isFixed()) continue; // don't care about these
+
+            if (!itemData.getCompoundTag("ids").hasKey(id)) return null; // some kind of mismatch
+            int idValue = itemData.getCompoundTag("ids").getInteger(id);
+
+            int translatedValue = 0;
+            if (Math.abs(status.getBaseValue()) > 100) { // calculate percent
+                translatedValue = (int) Math.round((idValue * 100.0 / status.getBaseValue()) - 30);
+            } else { // raw value
+                translatedValue = idValue - status.getMin();
+            }
+            encoded.append(encodeNumber(translatedValue));
+
+            // stars
+            int stars = itemData.getCompoundTag("ids").hasKey(id + "*") ? itemData.getCompoundTag("ids").getInteger(id + "*") : 0;
+            encoded.append(encodeNumber(stars));
+        }
+
+        // powders
+        if (itemData.hasKey("powderSlots")) {
+            List<Powder> powders = Powder.findPowders(itemData.getString("powderSlots"));
+            if (!powders.isEmpty()) {
+                encoded.append(SEPARATOR);
+                powders.forEach(p -> encoded.append(encodeString(p.getLetterRepresentation())));
+            }
+        }
+
+        // rerolls
+        int rerolls = itemData.hasKey("rerollAmount") ? itemData.getInteger("rerollAmount") : 0;
+        encoded.append(SEPARATOR);
+        encoded.append(encodeNumber(rerolls));
+
+        encoded.append(END);
+        return encoded.toString();
+    }
+
+    public static ItemStack decodeItem(String encoded) {
+        Matcher m = ENCODED_PATTERN.matcher(encoded);
+        if (!m.matches()) return null;
+
+        String name = decodeString(m.group(1));
+        int ids[] = decodeNumbers(m.group(2));
+        String powders = m.group(3) != null ? decodeString(m.group(3)) : "";
+        int rerolls = decodeNumbers(m.group(4))[0];
+
+        ItemProfile item = WebManager.getItems().get(name);
+        if (item == null) return null;
+
+        ItemStack stack = item.getItemInfo().asItemStack();
+        stack.setStackDisplayName(item.getTier().getTextColor() + item.getDisplayName());
+        stack.setTagInfo("Unbreakable", new NBTTagByte((byte) 1));
+        stack.setTagInfo("HideFlags", new NBTTagInt(6));
+
+        List<String> itemLore = new ArrayList<>();
+
+        // identifier
+        itemLore.add(DARK_GRAY.toString() + Arrays.stream(ids).sum());
+
+        // attack speed
+        if (item.getAttackSpeed() != null) {
+            itemLore.add(item.getAttackSpeed().asLore());
+            itemLore.add(" ");
+        }
+
+        // damages
+        Map<String, String> damageTypes = item.getDamageTypes();
+        if (damageTypes.size() > 0) {
+            if (damageTypes.containsKey("neutral"))
+                itemLore.add(GOLD + "✣ Neutral Damage: " + damageTypes.get("neutral"));
+            if (damageTypes.containsKey("fire"))
+                itemLore.add(RED + "✹ Fire" + GRAY + " Damage: " + damageTypes.get("fire"));
+            if (damageTypes.containsKey("water"))
+                itemLore.add(AQUA + "❉ Water" + GRAY + " Damage: " + damageTypes.get("water"));
+            if (damageTypes.containsKey("air"))
+                itemLore.add(WHITE + "❋ Air" + GRAY + " Damage: " + damageTypes.get("air"));
+            if (damageTypes.containsKey("thunder"))
+                itemLore.add(YELLOW + "✦ Thunder" + GRAY + " Damage: " + damageTypes.get("thunder"));
+            if (damageTypes.containsKey("earth"))
+                itemLore.add(DARK_GREEN + "✤ Earth" + GRAY + " Damage: " + damageTypes.get("earth"));
+
+            itemLore.add(" ");
+        }
+
+        // defenses
+        Map<String, Integer> defenseTypes = item.getDefenseTypes();
+        if (defenseTypes.size() > 0) {
+            if (defenseTypes.containsKey("health"))
+                itemLore.add(DARK_RED + "❤ Health: " + (defenseTypes.get("health") > 0 ? "+" : "") + defenseTypes.get("health"));
+            if (defenseTypes.containsKey("fire"))
+                itemLore.add(RED + "✹ Fire" + GRAY + " Defence: " + (defenseTypes.get("fire") > 0 ? "+" : "") + defenseTypes.get("fire"));
+            if (defenseTypes.containsKey("water"))
+                itemLore.add(AQUA + "❉ Water" + GRAY + " Defence: " + (defenseTypes.get("water") > 0 ? "+" : "") + defenseTypes.get("water"));
+            if (defenseTypes.containsKey("air"))
+                itemLore.add(WHITE + "❋ Air" + GRAY + " Defence: " + (defenseTypes.get("air") > 0 ? "+" : "") + defenseTypes.get("air"));
+            if (defenseTypes.containsKey("thunder"))
+                itemLore.add(YELLOW + "✦ Thunder" + GRAY + " Defence: " + (defenseTypes.get("thunder") > 0 ? "+" : "") + defenseTypes.get("thunder"));
+            if (defenseTypes.containsKey("earth"))
+                itemLore.add(DARK_GREEN + "✤ Earth" + GRAY + " Defence: " + (defenseTypes.get("earth") > 0 ? "+" : "") + defenseTypes.get("earth"));
+
+            itemLore.add(" ");
+        }
+
+        // requirements
+        ItemRequirementsContainer requirements = item.getRequirements();
+        if (requirements.hasRequirements(item.getItemInfo().getType())) {
+            if (requirements.requiresQuest())
+                itemLore.add(GREEN + "✔ " + GRAY + "Quest Req: " + requirements.getQuest());
+            if (requirements.requiresClass(item.getItemInfo().getType()))
+                itemLore.add(GREEN + "✔ " + GRAY + "Class Req: " + requirements.getRealClass(item.getItemInfo().getType()).getDisplayName());
+            if (requirements.getLevel() != 0)
+                itemLore.add(GREEN + "✔ " + GRAY + "Combat Lv. Min: " + requirements.getLevel());
+            if (requirements.getStrength() != 0)
+                itemLore.add(GREEN + "✔ " + GRAY + "Strength Min: " + requirements.getStrength());
+            if (requirements.getAgility() != 0)
+                itemLore.add(GREEN + "✔ " + GRAY + "Agility Min: " + requirements.getAgility());
+            if (requirements.getDefense() != 0)
+                itemLore.add(GREEN + "✔ " + GRAY + "Defense Min: " + requirements.getDefense());
+            if (requirements.getIntelligence() != 0)
+                itemLore.add(GREEN + "✔ " + GRAY + "Intelligence Min: " + requirements.getIntelligence());
+            if (requirements.getDexterity() != 0)
+                itemLore.add(GREEN + "✔ " + GRAY + "Dexterity Min: " + requirements.getDexterity());
+
+            itemLore.add(" ");
+        }
+
+        // ids
+        List<String> sortedIds = new ArrayList<>(item.getStatuses().keySet());
+        sortedIds.sort(Comparator.comparingInt(IdentificationOrderer.INSTANCE::getOrder));
+
+        int counter = 0; // for id value array
+        for (String id : sortedIds) {
+            IdentificationContainer status = item.getStatuses().get(id);
+
+            String stars = "";
+            int value;
+            if (status.isFixed()) {
+                value = status.getBaseValue();
+            } else {
+                if (counter > ids.length) return null; // some kind of mismatch, abort
+
+                // id value
+                if (Math.abs(status.getBaseValue()) > 100) {
+                    value = new BigDecimal(ids[counter] + 30).movePointLeft(2).multiply(new BigDecimal(status.getBaseValue())).setScale(0, RoundingMode.HALF_UP).intValue();
+                } else {
+                    value = ids[counter] + status.getMin();
+                }
+
+                // stars
+                stars = DARK_GREEN + "***".substring(0, ids[counter+1]);
+
+                counter+=2;
+            }
+
+            // name
+            String longName = IdentificationContainer.getAsLongName(id);
+            SpellType spell = SpellType.fromName(longName);
+            if (spell != null) {
+                ClassType requiredClass = item.getClassNeeded();
+                if (requiredClass != null) {
+                    longName = spell.forOtherClass(requiredClass).getName() + " Spell Cost";
+                } else {
+                    longName = spell.forOtherClass(PlayerInfo.get(CharacterData.class).getCurrentClass()).getGenericAndSpecificName() + " Cost";
+                }
+            }
+
+            // value string
+            String lore;
+            if (IdentificationOrderer.INSTANCE.isInverted(id))
+                lore = (value < 0 ? GREEN.toString() : value > 0 ? RED + "+" : GRAY.toString())
+                        + value + status.getType().getInGame(id);
+            else
+                lore = (value < 0 ? RED.toString() : value > 0 ? GREEN + "+" : GRAY.toString())
+                        + value + status.getType().getInGame(id);
+
+            lore += stars + " " + GRAY + longName;
+            itemLore.add(lore);
+        }
+        if (!sortedIds.isEmpty()) itemLore.add(" ");
+
+        // major ids
+        if (item.getMajorIds() != null && item.getMajorIds().size() > 0) {
+            for (MajorIdentification majorId : item.getMajorIds()) {
+                Stream.of(StringUtils.wrapTextBySize(majorId.asLore(), 150)).forEach(c -> itemLore.add(DARK_AQUA + c));
+            }
+            itemLore.add(" ");
+        }
+
+        //powders
+        if (item.getPowderAmount() > 0) {
+            int powderCount = 0;
+            String powderList = "";
+
+            if (!powders.isEmpty()) {
+                for (char c : powders.toCharArray()) {
+                    powderCount++;
+                    switch (c) {
+                        case 'e':
+                            powderList += DARK_GREEN + "✤ ";
+                            break;
+                        case 't':
+                            powderList += YELLOW + "✦ ";
+                            break;
+                        case 'w':
+                            powderList += AQUA + "❉ ";
+                            break;
+                        case 'f':
+                            powderList += RED + "✹ ";
+                            break;
+                        case 'a':
+                            powderList += WHITE + "❋ ";
+                            break;
+                    }
+                }
+            }
+
+            String powderString = TextFormatting.GRAY + "[" + powderCount + "/" + item.getPowderAmount() + "] Powder Slots ";
+            if (powderCount > 0) powderString += "[" + powderList.trim() + TextFormatting.GRAY + "]";
+
+            itemLore.add(powderString);
+        }
+
+        // tier & rerolls
+        String tierString = item.getTier().asLore();
+        if (rerolls > 1)
+            tierString += " [" + rerolls + "]";
+        itemLore.add(tierString);
+
+        // untradable
+        if (item.getRestriction() != null) itemLore.add(RED + StringUtils.capitalizeFirst(item.getRestriction()) + " Item");
+
+        // item lore
+        if (item.getLore() != null && !item.getLore().isEmpty()) {
+            itemLore.addAll(McIf.mc().fontRenderer.listFormattedStringToWidth(DARK_GRAY + item.getLore(), 150));
+        }
+
+        ItemUtils.replaceLore(stack, itemLore);
+        return stack;
+
+    }
+
+    private static String encodeString(String text) {
+        String encoded = "";
+        for (char c : text.toCharArray()) {
+            int value = c - 32; // offset by 32 to ignore ascii control characters
+            encoded += new String(Character.toChars(value + OFFSET)); // get encoded representation
+        }
+        return encoded;
+    }
+
+    private static String encodeNumber(int value) {
+        return new String(Character.toChars(value + OFFSET));
+    }
+
+    private static String decodeString(String text) {
+        String decoded = "";
+        for (int i = 0; i < text.length(); i+=2) {
+            int value = text.codePointAt(i) - OFFSET + 32;
+            decoded += (char) value;
+        }
+        return decoded;
+    }
+
+    private static int[] decodeNumbers(String text) {
+        int decoded[] = new int[text.length()/2];
+        for (int i = 0; i < text.length(); i+=2) {
+            decoded[i/2] = text.codePointAt(i) - OFFSET;
+        }
+        return decoded;
+    }
+
+}

--- a/src/main/java/com/wynntils/modules/utilities/managers/ItemScreenshotManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/ItemScreenshotManager.java
@@ -7,6 +7,7 @@ package com.wynntils.modules.utilities.managers;
 import java.awt.Image;
 import java.awt.Toolkit;
 import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.StringSelection;
 import java.awt.datatransfer.Transferable;
 import java.awt.datatransfer.UnsupportedFlavorException;
 import java.awt.image.BufferedImage;
@@ -22,7 +23,9 @@ import org.lwjgl.opengl.GL11;
 
 import com.wynntils.McIf;
 import com.wynntils.Reference;
+import com.wynntils.core.utils.helpers.TextAction;
 
+import net.minecraft.client.audio.PositionedSoundRecord;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.inventory.GuiContainer;
@@ -34,10 +37,13 @@ import net.minecraft.client.renderer.texture.TextureUtil;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.client.shader.Framebuffer;
 import net.minecraft.client.util.ITooltipFlag;
+import net.minecraft.init.SoundEvents;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraft.util.text.TextFormatting;
+import net.minecraft.util.text.event.HoverEvent;
 
 public class ItemScreenshotManager {
 
@@ -105,6 +111,18 @@ public class ItemScreenshotManager {
         Toolkit.getDefaultToolkit().getSystemClipboard().setContents(ci, null);
 
         McIf.player().sendMessage(new TextComponentString(TextFormatting.GREEN + "Copied " + stack.getDisplayName() + TextFormatting.GREEN + " to the clipboard!"));
+
+        String encoded = ChatItemManager.encodeItem(stack);
+        if (encoded != null) { // item was valid, show copy message
+            ITextComponent msg = new TextComponentString(TextFormatting.DARK_GREEN + "" + TextFormatting.UNDERLINE + "Click here to copy the item for chat!");
+            msg.getStyle().setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new TextComponentString(TextFormatting.DARK_AQUA + "Paste this text in chat to display your item to other Wynntils users.")));
+            msg = TextAction.withDynamicEvent(msg, () -> {
+                Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new StringSelection(encoded), null);
+                McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.BLOCK_NOTE_PLING, 1f)); // confirmation pling
+                });
+
+            McIf.player().sendMessage(msg);
+        }
     }
 
     private static void removeItemLore(List<String> tooltip) {

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemIdentificationOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemIdentificationOverlay.java
@@ -27,7 +27,6 @@ import com.wynntils.webapi.profiles.item.enums.ItemTier;
 import com.wynntils.webapi.profiles.item.objects.IdentificationContainer;
 import com.wynntils.webapi.profiles.item.objects.MajorIdentification;
 
-import net.minecraft.client.Minecraft;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;
@@ -73,7 +72,16 @@ public class ItemIdentificationOverlay implements Listener {
         replaceLore(e.getGui().getSlotUnderMouse().getStack());
     }
 
-    public static void replaceLore(ItemStack stack)  {
+    public static void replaceLore(ItemStack stack) {
+        IdentificationType idType;
+        if (Keyboard.isKeyDown(Keyboard.KEY_LSHIFT)) idType = IdentificationType.MIN_MAX;
+        else if (Keyboard.isKeyDown(Keyboard.KEY_LCONTROL)) idType = IdentificationType.UPGRADE_CHANCES;
+        else idType = IdentificationType.PERCENTAGES;
+
+        replaceLore(stack, idType);
+    }
+
+    public static void replaceLore(ItemStack stack, IdentificationType forcedIdType)  {
         if (!UtilitiesConfig.Identifications.INSTANCE.enabled || !stack.hasDisplayName() || !stack.hasTagCompound()) return;
         NBTTagCompound nbt = stack.getTagCompound();
         if (nbt.hasKey("wynntilsIgnore")) return;
@@ -94,7 +102,7 @@ public class ItemIdentificationOverlay implements Listener {
             return;
         }
 
-        NBTTagCompound wynntils = generateData(stack);
+        NBTTagCompound wynntils = generateData(stack, forcedIdType);
         ItemProfile item = WebManager.getItems().get(wynntils.getString("originName"));
 
         // Block if the item is not the real item
@@ -391,12 +399,7 @@ public class ItemIdentificationOverlay implements Listener {
         ItemUtils.getLoreTag(stack).appendTag(new NBTTagString(GREEN + "- " + GRAY + "Possibilities: " + itemNamesAndCosts));
     }
 
-    public static NBTTagCompound generateData(ItemStack stack) {
-        IdentificationType idType;
-        if (Keyboard.isKeyDown(Keyboard.KEY_LSHIFT)) idType = IdentificationType.MIN_MAX;
-        else if (Keyboard.isKeyDown(Keyboard.KEY_LCONTROL)) idType = IdentificationType.UPGRADE_CHANCES;
-        else idType = IdentificationType.PERCENTAGES;
-
+    public static NBTTagCompound generateData(ItemStack stack, IdentificationType idType) {
         if (stack.hasTagCompound() && stack.getTagCompound().hasKey("wynntils")) {
             NBTTagCompound compound = stack.getTagCompound().getCompoundTag("wynntils");
 

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemIdentificationOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemIdentificationOverlay.java
@@ -391,7 +391,7 @@ public class ItemIdentificationOverlay implements Listener {
         ItemUtils.getLoreTag(stack).appendTag(new NBTTagString(GREEN + "- " + GRAY + "Possibilities: " + itemNamesAndCosts));
     }
 
-    private static NBTTagCompound generateData(ItemStack stack) {
+    public static NBTTagCompound generateData(ItemStack stack) {
         IdentificationType idType;
         if (Keyboard.isKeyDown(Keyboard.KEY_LSHIFT)) idType = IdentificationType.MIN_MAX;
         else if (Keyboard.isKeyDown(Keyboard.KEY_LCONTROL)) idType = IdentificationType.UPGRADE_CHANCES;


### PR DESCRIPTION
Adds an option to copy an item as a string to be put in a chat message after pressing the item screenshot button. This string will automatically be converted into the color-coded and underlined item name, which can be moused over to view the item's exact stats, powders, and rerolls. Multiple items can be put in one message and still be properly viewed. When the string is pasted into the chat box, it will be replaced with a simple shorthand (`<ItemName>`) until the message is actually sent, to avoid any confusion due to the invisible characters used. Only regular gear items are supported: no crafted items or any non-gear item like powders, ingredients, etc.

The chat tooltips also contain an extra line specifying that it is this type of tooltip - a dark gray "_From chat_" below the item's name. My motivation for adding this was to combat fake items being spread. If this is not deemed a significant enough issue, I can easily remove it.

The "encoded" item strings are created using Unicode characters in the private use block; the exact implementation can be found in a comment at the top of ChatItemManager. To other players without Wynntils (or with older versions of Wynntils) in 1.12, these characters will not be rendered, and all they will see is the item's name. However, in newer versions of Minecraft, they will be seen as rectangles. In order to avoid spamming the chats of players on these versions, I attempted to make the encoding as efficient and short as possible, while retaining all the necessary information. Below are some examples of encoded strings, with the outliers Singularity (15 powder slots) and Melange (15 identifications) demonstrating some of the longest possible encodings.
```
󵿰Fate's Shear󵿲󵄽󵅹󵂰󵀀󵀵󵀭󵀼󵀜󵿲󵁵󵀀󵿱
󵿰Singularity󵿲󵃴󵀤󵃀󵀜󵄹󵁠󵿲󵏾󵈆󵈆󵁖󵀂󵿱
󵿰Melange󵿲󵀌󵀈󵀈󵀌󵀐󵀞󵀌󵀄󵀀󵀙󵀈󵀕󵀐󵀌󵀄󵀀󵿱
󵿰Suppression󵿲󵀍󵃬󵀊󵀈󵀀󵿱
󵿰Unravel󵿲󵁐󵆓󵀊󵀸󵀽󵀀󵿱
```
I did write code to encode the item's name as well, but I decided it would be best to at least leave some part of it intelligible, so even if someone can't view the tooltip, they at least know what is going on. However, if desired, I could enable the encoding of names as well.

![image](https://user-images.githubusercontent.com/3767283/126058832-c2ae0799-2ce8-435a-b0a4-d9ab6d95ced3.png)
![image](https://user-images.githubusercontent.com/3767283/126058870-4e7c0800-037f-4b47-aa2d-f5141fef9db2.png)
![image](https://user-images.githubusercontent.com/3767283/126058911-65065d1a-c721-47d7-a7d9-05960e87ffee.png)
