### PR TITLE
Made the map zoom use acceleration for smoothness

### DIFF
--- a/src/main/java/com/wynntils/McIf.java
+++ b/src/main/java/com/wynntils/McIf.java
@@ -8,7 +8,6 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.client.multiplayer.WorldClient;
 import net.minecraft.util.text.ITextComponent;
-import org.lwjgl.Sys;
 
 /**
  * The Wynntils Minecraft Interface (MC IF).
@@ -17,6 +16,7 @@ import org.lwjgl.Sys;
  * depend on directly, for instance due to version disparity.
  */
 public class McIf {
+
     public static String getUnformattedText(ITextComponent msg) {
         return msg.getUnformattedText();
     }
@@ -37,8 +37,8 @@ public class McIf {
         return mc().player;
     }
 
-    public static long getSystemTime()
-    {
+    public static long getSystemTime() {
         return Minecraft.getSystemTime();
     }
+
 }

--- a/src/main/java/com/wynntils/core/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/core/events/ClientEvents.java
@@ -11,14 +11,15 @@ import com.wynntils.core.events.custom.*;
 import com.wynntils.core.framework.FrameworkManager;
 import com.wynntils.core.framework.enums.ClassType;
 import com.wynntils.core.framework.enums.professions.ProfessionType;
+import com.wynntils.core.framework.instances.GuiTickableScreen;
 import com.wynntils.core.framework.instances.PlayerInfo;
 import com.wynntils.core.framework.instances.data.CharacterData;
 import com.wynntils.core.framework.rendering.ScreenRenderer;
 import com.wynntils.core.utils.reflections.ReflectionFields;
 import com.wynntils.core.utils.reflections.ReflectionMethods;
 import com.wynntils.modules.core.managers.GuildAndFriendManager;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiDisconnected;
+import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.multiplayer.GuiConnecting;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.play.server.SPacketPlayerListItem;
@@ -228,6 +229,13 @@ public class ClientEvents {
         FrameworkManager.triggerHudTick(e);
         FrameworkManager.triggerKeyPress();
         FrameworkManager.triggerNaturalSpawn();
+
+        if (McIf.mc().currentScreen == null) return;
+
+        // Tick gui screens that requires ticks
+        GuiScreen screen = McIf.mc().currentScreen;
+        if (!(screen instanceof GuiTickableScreen)) return;
+        ((GuiTickableScreen) screen).onTick();
     }
 
     @SubscribeEvent

--- a/src/main/java/com/wynntils/core/framework/instances/GuiMovementScreen.java
+++ b/src/main/java/com/wynntils/core/framework/instances/GuiMovementScreen.java
@@ -1,19 +1,19 @@
 /*
- *  * Copyright © Wynntils - 2018 - 2021.
+ *  * Copyright © Wynntils - 2021.
  */
 
 package com.wynntils.core.framework.instances;
 
 import com.wynntils.McIf;
 import com.wynntils.core.framework.enums.wynntils.WynntilsConflictContext;
-import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.settings.KeyBinding;
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.input.Mouse;
 
 import java.io.IOException;
 
-public class GuiMovementScreen extends GuiScreen {
+public abstract class GuiMovementScreen extends GuiTickableScreen {
+
     protected boolean allowMovement = true;
 
     @Override
@@ -42,6 +42,11 @@ public class GuiMovementScreen extends GuiScreen {
                 this.handleKeyboardInput();
             }
         }
+    }
+
+    @Override
+    public void onTick() {
+
     }
 
 }

--- a/src/main/java/com/wynntils/core/framework/instances/GuiTickableScreen.java
+++ b/src/main/java/com/wynntils/core/framework/instances/GuiTickableScreen.java
@@ -1,0 +1,13 @@
+/*
+ *  * Copyright © Wynntils - 2021.
+ */
+
+package com.wynntils.core.framework.instances;
+
+import net.minecraft.client.gui.GuiScreen;
+
+public abstract class GuiTickableScreen extends GuiScreen {
+
+    public abstract void onTick();
+
+}

--- a/src/main/java/com/wynntils/modules/map/overlays/objects/MapTerritory.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/objects/MapTerritory.java
@@ -46,7 +46,7 @@ public class MapTerritory {
         return this;
     }
 
-    public void updateAxis(MapProfile mp, int width, int height, float maxX, float minX, float maxZ, float minZ, int zoom) {
+    public void updateAxis(MapProfile mp, int width, int height, float maxX, float minX, float maxZ, float minZ, float zoom) {
         alpha = 1 - ((zoom - 10) / 40.0f);
 
         float initX = ((mp.getTextureXPosition(territory.getStartX()) - minX) / (maxX - minX));

--- a/src/main/java/com/wynntils/modules/map/overlays/objects/WorldMapIcon.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/objects/WorldMapIcon.java
@@ -36,13 +36,13 @@ public class WorldMapIcon {
         }
     }
 
-    public void updateAxis(MapProfile mp, int width, int height, float maxX, float minX, float maxZ, float minZ, int zoom) {
+    public void updateAxis(MapProfile mp, int width, int height, float maxX, float minX, float maxZ, float minZ, float zoom) {
         if (!info.isEnabled(false)) {
             shouldRender = false;
             return;
         }
 
-        updateAlphaForZoom(zoom);
+        updateAlphaForZoom((int) zoom);
         if (alpha <= 0) {
             shouldRender = false;
             return;

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/WorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/WorldMapUI.java
@@ -21,11 +21,9 @@ import com.wynntils.modules.map.instances.MapProfile;
 import com.wynntils.modules.map.managers.LootRunManager;
 import com.wynntils.modules.map.overlays.enums.MapButtonType;
 import com.wynntils.modules.map.overlays.objects.*;
-import com.wynntils.modules.questbook.managers.QuestManager;
 import com.wynntils.modules.utilities.managers.KeyManager;
 import com.wynntils.webapi.WebManager;
 import com.wynntils.webapi.profiles.TerritoryProfile;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.audio.PositionedSoundRecord;
 import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.Tessellator;
@@ -52,13 +50,19 @@ public class WorldMapUI extends GuiMovementScreen {
     private static final int MAX_ZOOM = 300;  // Note that this is the most zoomed out
     private static final int MIN_ZOOM = -10;  // And this is the most zoomed in
     private static final float ZOOM_SCALE_FACTOR = 1.1f;
+    private static final float ZOOM_RESISTENCE = 4f; // The zoom resistence in ticks (any change takes 4 ticks)
 
     protected ScreenRenderer renderer = new ScreenRenderer();
 
     // Position Related
     protected float centerPositionX = Float.NaN;
     protected float centerPositionZ = Float.NaN;
-    protected int zoom = 0;  // Zoom goes from 300 (whole world) to -10 (max details)
+
+    // Zoom
+    protected float zoom = 0;  // Zoom goes from 300 (whole world) to -10 (max details)
+    protected float zoomInitial = 0;
+    protected float zoomTarget = 0;
+    protected float zoomPosition = 0;
 
     // Properties
     float minX = 0; float maxX = 0;
@@ -119,7 +123,7 @@ public class WorldMapUI extends GuiMovementScreen {
         List<MapIcon> apiMapIcons = MapIcon.getApiMarkers(MapConfig.INSTANCE.iconTexture);
         // Handles map labels from map.wynncraft.com
         List<MapIcon> mapLabels = MapIcon.getLabels();
-        // HeyZeer0: Handles all waypoints
+        // Handles all waypoints
         List<MapIcon> wpMapIcons = MapIcon.getWaypoints();
         List<MapIcon> pathWpMapIcons = MapIcon.getPathWaypoints();
         // Handles guild / party / friends
@@ -146,6 +150,7 @@ public class WorldMapUI extends GuiMovementScreen {
                 } else {
                     icon = new WorldMapIcon(i);
                 }
+
                 icons.add(icon);
             }
         }
@@ -221,10 +226,9 @@ public class WorldMapUI extends GuiMovementScreen {
         return getScaleFactor(zoom);
     }
 
-    protected float getScaleFactor(int zoom) {
+    protected float getScaleFactor(float zoom) {
         // How many blocks in one pixel
-        // TODO this needs to scale in even numbers to avoid distortion!
-        return 1f / (1f + zoom / 50f);
+        return 50f / (zoom + 50f);
     }
 
     protected void updatePosition(int mouseX, int mouseY, boolean canMove) {
@@ -242,6 +246,7 @@ public class WorldMapUI extends GuiMovementScreen {
         if (!Reference.onWorld || !MapModule.getModule().getMainMap().isReadyToUse()) return;
 
         handleOpenAnimation();
+        handleZoomAcceleration(partialTicks);
 
         // texture
         renderer.drawRectF(Textures.Map.full_map, 10, 10, width - 10, height - 10, 1, 1, 511, 255);
@@ -377,7 +382,18 @@ public class WorldMapUI extends GuiMovementScreen {
         float invertedProgress = (animationEnd - System.currentTimeMillis()) / (float) MapConfig.WorldMap.INSTANCE.animationLength;
         double radians = (Math.PI / 2f) * invertedProgress;
 
-        zoom = (int)(25 * Math.sin(radians));
+        zoom = (float) (25 * Math.sin(radians));
+        updateCenterPosition(centerPositionX, centerPositionZ);
+    }
+
+    protected void handleZoomAcceleration(float partialTicks) {
+        if (zoomTarget == 0f) return;
+
+        // We are using the mc partial ticks because somehow the GUI one ticks slower (no clue why)
+        float percentage = Math.min(1f, (zoomPosition + McIf.mc().getRenderPartialTicks()) / ZOOM_RESISTENCE);
+        float toIncrease = (zoomTarget - zoomInitial) * percentage;
+
+        zoom = zoomInitial + toIncrease;
         updateCenterPosition(centerPositionX, centerPositionZ);
     }
 
@@ -408,10 +424,18 @@ public class WorldMapUI extends GuiMovementScreen {
         popMatrix();
     }
 
-    private void zoomBy(int by) {
+    private void zoomBy(float by) {
         double zoomScale = Math.pow(ZOOM_SCALE_FACTOR, -by);
-        zoom = MathHelper.clamp((int) Math.round(zoomScale * (zoom + 50) - 50), MIN_ZOOM, MAX_ZOOM);
+        zoom = (float) MathHelper.clamp(zoomScale * (zoom + 50) - 50, MIN_ZOOM, MAX_ZOOM);
         updateCenterPosition(centerPositionX, centerPositionZ);
+    }
+
+    private void accelerateZoomBy(float by) {
+        double zoomScale = Math.pow(ZOOM_SCALE_FACTOR, -by);
+        zoomTarget = (float) MathHelper.clamp(zoomScale * (zoom + 50) - 50, MIN_ZOOM, MAX_ZOOM);
+
+        zoomPosition = 0;
+        zoomInitial = zoom;
     }
 
     @Override
@@ -420,6 +444,18 @@ public class WorldMapUI extends GuiMovementScreen {
 
         updateCenterPosition(centerPositionX, centerPositionZ);
         Keyboard.enableRepeatEvents(true);
+    }
+
+    @Override
+    public void onTick() {
+        if (zoomTarget == 0) return;
+
+        // Increase the zoom position animation
+        zoomPosition++;
+
+        // Remove the step if the animation ended
+        if (zoomPosition <= ZOOM_RESISTENCE) return;
+        zoomTarget = 0;
     }
 
     @Override
@@ -435,10 +471,14 @@ public class WorldMapUI extends GuiMovementScreen {
         // allow scroll only after animation ended
         if (System.currentTimeMillis() > animationEnd) {
             int mDWheel = Mouse.getEventDWheel() * CoreDBConfig.INSTANCE.scrollDirection.getScrollDirection();
+
+            // Zoom faster if we are really far
+            float zoomAmount = 2f + (4f * (zoom / MAX_ZOOM));
+
             if (mDWheel > 0) {
-                zoomBy(+1);
+                accelerateZoomBy(zoomAmount);
             } else if (mDWheel < 0) {
-                zoomBy(-1);
+                accelerateZoomBy(-zoomAmount);
             }
         }
 
@@ -448,12 +488,12 @@ public class WorldMapUI extends GuiMovementScreen {
     @Override
     protected void keyTyped(char typedChar, int keyCode) throws IOException {
         if (keyCode == KeyManager.getZoomInKey().getKeyBinding().getKeyCode()) {
-            zoomBy(+2);
+            accelerateZoomBy(4f);
             return;
         }
 
         if (keyCode == KeyManager.getZoomOutKey().getKeyBinding().getKeyCode()) {
-            zoomBy(-2);
+            accelerateZoomBy(-4f);
             return;
         }
 


### PR DESCRIPTION
The initial idea was to actually use acceleration but that made the zoom frame reliant which is a problem for bad computers (would cause a bad overall experience).

My second attempt was using frames but somehow there's a very harsh limit on partial ticks over GUIs (which made the animation clutter a lot) so the leftover solution was to use time which, finally, looks really great!

Quick Preview:
https://cdn.hey0.dev/ss/2021/07/18142529.mp4

This also changes our zoom format to use floats for higher precision zooms.
I have made the zoom be quicker/smaller depending on the scale, so if you are really far the zoom amplifies more and if you are really close it amplifies less. On my overall testing that looks enough but we might want to invert it if you are zooming in/out for a more satisfying look.

We are also using sin "rounding" for the extra movement parabola 😎 