### PR TITLE
Item favoriting

### DIFF
--- a/src/main/java/com/wynntils/core/utils/StringUtils.java
+++ b/src/main/java/com/wynntils/core/utils/StringUtils.java
@@ -384,37 +384,41 @@ public class StringUtils {
         return Character.toString((char) ((gavellian) - 9327));
     }
 
-    public static int convertEmeraldPrice(String input) {
+    public static long convertEmeraldPrice(String input) {
         input = input.toLowerCase();
-        int emeralds = 0;
+        long emeralds = 0;
 
-        // stx
-        Matcher m = STX_PATTERN.matcher(input);
-        while (m.find()) {
-            emeralds += Float.parseFloat(m.group(1)) * 64 * 64 * 64;
-        }
+        try {
+            // stx
+            Matcher m = STX_PATTERN.matcher(input);
+            while (m.find()) {
+                emeralds += Long.parseLong(m.group(1)) * 64 * 64 * 64;
+            }
 
-        // le
-        m = LE_PATTERN.matcher(input);
-        while (m.find()) {
-            emeralds += Float.parseFloat(m.group(1)) * 64 * 64;
-        }
+            // le
+            m = LE_PATTERN.matcher(input);
+            while (m.find()) {
+                emeralds += Long.parseLong(m.group(1)) * 64 * 64;
+            }
 
-        // eb
-        m = EB_PATTERN.matcher(input);
-        while (m.find()) {
-            emeralds += Float.parseFloat(m.group(1)) * 64;
-        }
+            // eb
+            m = EB_PATTERN.matcher(input);
+            while (m.find()) {
+                emeralds += Long.parseLong(m.group(1)) * 64;
+            }
 
-        // standard numbers/emeralds
-        m = E_PATTERN.matcher(input);
-        while (m.find()) {
-            emeralds += Integer.parseInt(m.group(1));
-        }
+            // standard numbers/emeralds
+            m = E_PATTERN.matcher(input);
+            while (m.find()) {
+                emeralds += Long.parseLong(m.group(1));
+            }
 
-        // account for tax if flagged
-        if (input.contains("-t")) {
-            emeralds = Math.round(emeralds / 1.05F);
+            // account for tax if flagged
+            if (input.contains("-t")) {
+                emeralds = Math.round(emeralds / 1.05F);
+            }
+        } catch (NumberFormatException e) {
+            return 0; // number exceeds long limit (somehow)
         }
 
         return emeralds;

--- a/src/main/java/com/wynntils/core/utils/helpers/ItemFilter.java
+++ b/src/main/java/com/wynntils/core/utils/helpers/ItemFilter.java
@@ -505,6 +505,12 @@ public interface ItemFilter extends Predicate<ItemProfile>, Comparator<ItemProfi
         @Type.Alias("Powders")
         public static final StatType TYPE_POWDER_SLOTS = new StatType("PowderSlots", "Powder Slot Count", ItemProfile::getPowderAmount);
 
+        // user-favorited
+        @Type.Alias({"Favourited", "fav"})
+        public static final StatType TYPE_FAVORITED = new StatType("Favorited", "Favorited", i -> {
+            return i.isFavorited() ? 1 : 0;
+        });
+
         public static class StatType extends Type<ByStat> {
 
             static StatType getIdStat(String name, String desc, String key) {

--- a/src/main/java/com/wynntils/modules/utilities/UtilitiesModule.java
+++ b/src/main/java/com/wynntils/modules/utilities/UtilitiesModule.java
@@ -51,6 +51,7 @@ public class UtilitiesModule extends Module {
         registerEvents(new ItemSpecificationOverlay());
         registerEvents(new BankOverlay());
         registerEvents(new ServerSelectorOverlay());
+        registerEvents(new FavoriteItemsOverlay());
 
         // Real overlays
         registerOverlay(new WarTimerOverlay(), Priority.LOWEST);

--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -17,7 +17,9 @@ import com.wynntils.webapi.profiles.item.enums.ItemTier;
 
 import java.math.RoundingMode;
 import java.text.DecimalFormat;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -48,6 +50,9 @@ public class UtilitiesConfig extends SettingsClass {
 
     @Setting(displayName = "Prevent Mythic Chest Closing", description = "Should the closing of loot chests be prevented when they contain mythics?")
     public boolean preventMythicChestClose = true;
+
+    @Setting(displayName = "Prevent Favorited Item Chest Closing", description = "Should the closing of loot chests be prevented when they contain favorited items?")
+    public boolean preventFavoritedChestClose = true;
 
     @Setting(displayName = "Prevent Clicking on Locked Items", description = "Should moving items to and from locked inventory slots be blocked?")
     public boolean preventSlotClicking = false;
@@ -99,6 +104,9 @@ public class UtilitiesConfig extends SettingsClass {
 
     @Setting
     public Map<String, SkillPointAllocation> skillPointLoadouts = new HashMap<>();
+
+    @Setting
+    public List<String> favoriteItems = new ArrayList<>();
 
     public enum FovScalingFunction {
         Vanilla,

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -279,7 +279,7 @@ public class ClientEvents implements Listener {
         if (!priceInput) return;
 
         priceInput = false;
-        int price = StringUtils.convertEmeraldPrice(e.getMessage());
+        long price = StringUtils.convertEmeraldPrice(e.getMessage());
         if (price != 0) // price of 0 means either garbage input or actual 0, can be ignored either way
             e.setMessage("" + price);
     }
@@ -666,6 +666,11 @@ public class ClientEvents implements Listener {
 
     @SubscribeEvent
     public void clickOnChest(GuiOverlapEvent.ChestOverlap.HandleMouseClick e) {
+        if (e.getSlotIn() != null && e.getSlotId() - e.getGui().getLowerInv().getSizeInventory() == 4) { // prevent accidental pouch clicking
+            e.setCanceled(true);
+            return;
+        }
+
         if (UtilitiesConfig.INSTANCE.preventSlotClicking && e.getSlotIn() != null) {
             if (e.getSlotId() - e.getGui().getLowerInv().getSizeInventory() >= 0 && e.getSlotId() - e.getGui().getLowerInv().getSizeInventory() < 27) {
                 e.setCanceled(checkDropState(e.getSlotId() - e.getGui().getLowerInv().getSizeInventory() + 9, McIf.mc().gameSettings.keyBindDrop.getKeyCode()));

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -104,7 +104,7 @@ public class ClientEvents implements Listener {
     }
 
     @SubscribeEvent
-    public void onKeyboardEven(InputEvent.KeyInputEvent e) {
+    public void onKeyboardEvent(InputEvent.KeyInputEvent e) {
         long currentTime = System.currentTimeMillis();
         // Events triggered just after the user pressed the Toggle AFK Protection key
         // should be ignored
@@ -488,7 +488,7 @@ public class ClientEvents implements Listener {
     public void keyPressOnChest(GuiOverlapEvent.ChestOverlap.KeyTyped e) {
         if (!Reference.onWorld) return;
 
-        if (UtilitiesConfig.INSTANCE.preventMythicChestClose) {
+        if (UtilitiesConfig.INSTANCE.preventMythicChestClose || UtilitiesConfig.INSTANCE.preventFavoritedChestClose) {
             if (e.getKeyCode() == 1 || e.getKeyCode() == McIf.mc().gameSettings.keyBindInventory.getKeyCode()) {
                 IInventory inv = e.getGui().getLowerInv();
                 if (McIf.getUnformattedText(inv.getDisplayName()).contains("Loot Chest") ||
@@ -496,13 +496,20 @@ public class ClientEvents implements Listener {
                         McIf.getUnformattedText(inv.getDisplayName()).contains("Objective Rewards")) {
                     for (int i = 0; i < inv.getSizeInventory(); i++) {
                         ItemStack stack = inv.getStackInSlot(i);
-                        if (!stack.hasDisplayName() ||
-                            !stack.getDisplayName().startsWith(TextFormatting.DARK_PURPLE.toString()) ||
-                            !ItemUtils.getStringLore(stack).toLowerCase().contains("mythic")) continue;
 
-                        TextComponentString text = new TextComponentString("You cannot close this loot chest while there is a mythic in it!");
+                        TextComponentString text;
+                        if (UtilitiesConfig.INSTANCE.preventMythicChestClose && stack.hasDisplayName() &&
+                                stack.getDisplayName().startsWith(TextFormatting.DARK_PURPLE.toString()) &&
+                                ItemUtils.getStringLore(stack).toLowerCase().contains("mythic")) {
+                            text = new TextComponentString("You cannot close this loot chest while there is a mythic in it!");
+                        } else if (UtilitiesConfig.INSTANCE.preventFavoritedChestClose && stack.hasTagCompound() &&
+                                stack.getTagCompound().getBoolean("wynntilsFavorite")) {
+                            text = new TextComponentString("You cannot close this loot chest while there is a favorited item in it!");
+                        } else {
+                            continue;
+                        }
+
                         text.getStyle().setColor(TextFormatting.RED);
-
                         McIf.player().sendMessage(text);
                         McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.BLOCK_NOTE_BASS, 1f));
                         e.setCanceled(true);

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/EmeraldCountOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/EmeraldCountOverlay.java
@@ -38,15 +38,17 @@ public class EmeraldCountOverlay implements Listener {
 
     private static final CustomColor textColor = new CustomColor(77f / 255f, 77f / 255f, 77f / 255f, 1);
 
+    private final ScreenRenderer renderer = new ScreenRenderer();
+
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onPlayerInventory(GuiOverlapEvent.InventoryOverlap.DrawGuiContainerForegroundLayer e) {
         if (!Reference.onWorld || !UtilitiesConfig.Items.INSTANCE.emeraldCountInventory) return;
 
         if (UtilitiesConfig.Items.INSTANCE.emeraldCountText) {
-            drawTextMoneyAmount(170, 7, PlayerInfo.get(InventoryData.class).getMoney(), new ScreenRenderer(), textColor);
+            drawTextMoneyAmount(170, 7, PlayerInfo.get(InventoryData.class).getMoney(), renderer, textColor);
             return;
         }
-        drawIconsMoneyAmount(178, 0, PlayerInfo.get(InventoryData.class).getMoney(), new ScreenRenderer());
+        drawIconsMoneyAmount(178, 0, PlayerInfo.get(InventoryData.class).getMoney(), renderer);
     }
 
     @SubscribeEvent
@@ -58,7 +60,6 @@ public class EmeraldCountOverlay implements Listener {
 
         IInventory upperInv = e.getGui().getUpperInv();
 
-        ScreenRenderer renderer = new ScreenRenderer();
         if (UtilitiesConfig.Items.INSTANCE.emeraldCountText) {
             if (UtilitiesConfig.Items.INSTANCE.emeraldCountInventory)
                 drawTextMoneyAmount(170, -10, ItemUtils.countMoney(lowerInv), renderer, CommonColors.WHITE);
@@ -78,9 +79,8 @@ public class EmeraldCountOverlay implements Listener {
 
         IInventory lowerInv = e.getGui().getLowerInv();
 
-        ScreenRenderer renderer = new ScreenRenderer();
         if (UtilitiesConfig.Items.INSTANCE.emeraldCountText) {
-            drawTextMoneyAmount(170, 7, ItemUtils.countMoney(lowerInv), new ScreenRenderer(), textColor);
+            drawTextMoneyAmount(170, 7, ItemUtils.countMoney(lowerInv), renderer, textColor);
             return;
         }
 

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/FavoriteItemsOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/FavoriteItemsOverlay.java
@@ -26,6 +26,8 @@ import static net.minecraft.util.text.TextFormatting.*;
 
 public class FavoriteItemsOverlay implements Listener {
 
+    private static final ScreenRenderer renderer = new ScreenRenderer();
+
     private static void renderFavorites(GuiContainer gui) {
         if (!Reference.onWorld) return;
 
@@ -36,14 +38,12 @@ public class FavoriteItemsOverlay implements Listener {
             if (!nbt.getBoolean("wynntilsFavorite")) continue;
 
             // draw star
-            ScreenRenderer.beginGL(0, 0);
+            ScreenRenderer.beginGL(gui.getGuiLeft() + s.xPos + 10, gui.getGuiTop() + s.yPos - 5);
             GlStateManager.translate(0, 0, 300);
 
-            ScreenRenderer r = new ScreenRenderer();
             RenderHelper.disableStandardItemLighting();
-            float scaleFactor = 0.5f;
-            ScreenRenderer.scale(scaleFactor);
-            r.drawRect(Textures.Map.map_icons, (int)((gui.getGuiLeft() + s.xPos + 10) / scaleFactor), (int)((gui.getGuiTop() + s.yPos - 5) / scaleFactor), 208, 36, 18, 18);
+            ScreenRenderer.scale(0.5f);
+            renderer.drawRect(Textures.Map.map_icons, 0, 0, 208, 36, 18, 18);
             ScreenRenderer.endGL();
         }
     }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/FavoriteItemsOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/FavoriteItemsOverlay.java
@@ -1,0 +1,103 @@
+/*
+ *  * Copyright © Wynntils - 2018 - 2021.
+ */
+
+package com.wynntils.modules.utilities.overlays.inventories;
+
+import com.wynntils.Reference;
+import com.wynntils.core.events.custom.GuiOverlapEvent;
+import com.wynntils.core.framework.interfaces.Listener;
+import com.wynntils.core.framework.rendering.ScreenRenderer;
+import com.wynntils.core.framework.rendering.textures.Textures;
+import com.wynntils.core.utils.StringUtils;
+import com.wynntils.webapi.WebManager;
+import com.wynntils.webapi.profiles.item.ItemProfile;
+
+import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.renderer.RenderHelper;
+import net.minecraft.inventory.Slot;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.fml.common.eventhandler.EventPriority;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+import static net.minecraft.util.text.TextFormatting.*;
+
+public class FavoriteItemsOverlay implements Listener {
+
+    private static void renderFavorites(GuiContainer gui) {
+        if (!Reference.onWorld) return;
+
+        for (Slot s : gui.inventorySlots.inventorySlots) {
+            ItemStack stack = s.getStack();
+            if (stack.isEmpty() || !stack.hasDisplayName() || !stack.hasTagCompound()) continue;
+            NBTTagCompound nbt = stack.getTagCompound();
+            if (!nbt.getBoolean("wynntilsFavorite")) continue;
+
+            // draw star
+            ScreenRenderer.beginGL(0, 0);
+            GlStateManager.translate(0, 0, 300);
+
+            ScreenRenderer r = new ScreenRenderer();
+            RenderHelper.disableStandardItemLighting();
+            float scaleFactor = 0.5f;
+            ScreenRenderer.scale(scaleFactor);
+            r.drawRect(Textures.Map.map_icons, (int)((gui.getGuiLeft() + s.xPos + 10) / scaleFactor), (int)((gui.getGuiTop() + s.yPos - 5) / scaleFactor), 208, 36, 18, 18);
+            ScreenRenderer.endGL();
+        }
+    }
+
+    private static void checkFavorites(GuiContainer gui) {
+        if (!Reference.onWorld) return;
+
+        for (Slot s : gui.inventorySlots.inventorySlots) {
+            ItemStack stack = s.getStack();
+            if (stack.isEmpty() || !stack.hasDisplayName() || !stack.hasTagCompound()) continue;
+
+            NBTTagCompound nbt = stack.getTagCompound();
+            if (nbt.hasKey("wynntilsFavorite")) continue; // already been checked
+
+            String itemName = StringUtils.normalizeBadString(getTextWithoutFormattingCodes(stack.getDisplayName()));
+            if (!itemName.contains("Unidentified")) {
+                nbt.setBoolean("wynntilsFavorite", false);
+                continue; // don't care about identified items
+            }
+
+            String items = ItemIdentificationOverlay.getItemsFromBox(stack);
+            if (items == null) continue;
+
+            for (String possibleItem : items.split(", ")) {
+                ItemProfile itemProfile = WebManager.getItems().get(possibleItem);
+                if (itemProfile == null) continue;
+
+                if (itemProfile.isFavorited()) {
+                    nbt.setBoolean("wynntilsFavorite", true);
+                    break;
+                }
+            }
+
+            if (!nbt.hasKey("wynntilsFavorite")) // wasn't favorited
+                nbt.setBoolean("wynntilsFavorite", false);
+        }
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOW)
+    public void onChestGui(GuiOverlapEvent.ChestOverlap.HoveredToolTip.Pre e) {
+        checkFavorites(e.getGui());
+        renderFavorites(e.getGui());
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOW)
+    public void onInventoryGui(GuiOverlapEvent.InventoryOverlap.HoveredToolTip.Pre e) {
+        checkFavorites(e.getGui());
+        renderFavorites(e.getGui());
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOW)
+    public void onHorseGui(GuiOverlapEvent.HorseOverlap.HoveredToolTip.Pre e) {
+        checkFavorites(e.getGui());
+        renderFavorites(e.getGui());
+    }
+
+}

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/FavoriteTradesOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/FavoriteTradesOverlay.java
@@ -13,7 +13,6 @@ import com.wynntils.core.framework.rendering.textures.Textures;
 import com.wynntils.core.utils.ItemUtils;
 import com.wynntils.core.utils.reference.EmeraldSymbols;
 import com.wynntils.modules.utilities.managers.KeyManager;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.inventory.Slot;
@@ -28,6 +27,8 @@ import java.util.List;
 public class FavoriteTradesOverlay implements Listener {
 
     private final List<String> favorites_trade_items_lore = new ArrayList<>();
+
+    private final ScreenRenderer renderer = new ScreenRenderer();
 
     @SubscribeEvent
     public void onKeyPress(GuiOverlapEvent.ChestOverlap.KeyTyped e) {
@@ -76,10 +77,9 @@ public class FavoriteTradesOverlay implements Listener {
         // HeyZeer0: this will make the lock appear over the item
         GlStateManager.translate(0, 0, 260);
 
-        ScreenRenderer r = new ScreenRenderer();
         RenderHelper.disableStandardItemLighting();
         ScreenRenderer.scale(0.5f);
-        r.drawRect(Textures.UIs.hud_overlays, (int)((guiLeft + s.xPos) / 0.5) + 20, (int)((guiTop + s.yPos) / 0.5) - 3, 51, 0, 17, 16);
+        renderer.drawRect(Textures.UIs.hud_overlays, (int)((guiLeft + s.xPos) / 0.5) + 20, (int)((guiTop + s.yPos) / 0.5) - 3, 51, 0, 17, 16);
         ScreenRenderer.endGL();
     }
 

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemLockOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemLockOverlay.java
@@ -20,6 +20,8 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
 public class ItemLockOverlay implements Listener {
 
+    private static final ScreenRenderer renderer = new ScreenRenderer();
+
     @SubscribeEvent(priority = EventPriority.LOW)
     public void onInventoryGui(GuiOverlapEvent.InventoryOverlap.HoveredToolTip.Pre e) {
         if (!Reference.onWorld) return;
@@ -62,10 +64,9 @@ public class ItemLockOverlay implements Listener {
         // HeyZeer0: this will make the lock appear over the item
         GlStateManager.translate(0, 0, 260);
 
-        ScreenRenderer r = new ScreenRenderer();
         RenderHelper.disableStandardItemLighting();
         ScreenRenderer.scale(0.5f);
-        r.drawRect(Textures.UIs.hud_overlays, (int)((guiLeft + s.xPos) / 0.5) + 25, (int)((guiTop + s.yPos) / 0.5) - 8, 0, 0, 16, 16);
+        renderer.drawRect(Textures.UIs.hud_overlays, (int)((guiLeft + s.xPos) / 0.5) + 25, (int)((guiTop + s.yPos) / 0.5) - 8, 0, 0, 16, 16);
         ScreenRenderer.endGL();
     }
 

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemSpecificationOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemSpecificationOverlay.java
@@ -33,6 +33,8 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
 public class ItemSpecificationOverlay implements Listener {
 
+    private final ScreenRenderer renderer = new ScreenRenderer();
+
     private void renderOverlay(GuiContainer gui) {
         if (!Reference.onWorld) return;
 
@@ -66,11 +68,10 @@ public class ItemSpecificationOverlay implements Listener {
                         ScreenRenderer.beginGL(0, 0);
                         GlStateManager.translate(0, 0, 270);
 
-                        ScreenRenderer r = new ScreenRenderer();
                         RenderHelper.disableStandardItemLighting();
                         float scaleFactor = 0.75f;
                         ScreenRenderer.scale(scaleFactor);
-                        r.drawRect(Textures.UIs.hud_overlays, (int)((gui.getGuiLeft() + s.xPos) / scaleFactor) + 3, (int)((gui.getGuiTop() + s.yPos) / scaleFactor) + 3 , type.getTextureX(), type.getTextureY(), 16, 16);
+                        renderer.drawRect(Textures.UIs.hud_overlays, (int)((gui.getGuiLeft() + s.xPos) / scaleFactor) + 3, (int)((gui.getGuiTop() + s.yPos) / scaleFactor) + 3 , type.getTextureX(), type.getTextureY(), 16, 16);
                         ScreenRenderer.endGL();
                     } else {
                         // This is an un-id:ed but named item
@@ -156,13 +157,12 @@ public class ItemSpecificationOverlay implements Listener {
             if (destinationName != null) {
                 ScreenRenderer.beginGL((int) (gui.getGuiLeft()/scale), (int) (gui.getGuiTop()/scale));
                 GlStateManager.translate(0, 0, 260);
-                ScreenRenderer r = new ScreenRenderer();
                 GlStateManager.scale(scale, scale, 1);
                 RenderHelper.disableStandardItemLighting();
                 // Make a modifiable copy
                 color = new CustomColor(color);
                 color.setA(0.8f);
-                r.drawString(destinationName, (s.xPos + xOffset)/scale, (s.yPos + 1)/scale, color, SmartFontRenderer.TextAlignment.LEFT_RIGHT, SmartFontRenderer.TextShadow.OUTLINE);
+                renderer.drawString(destinationName, (s.xPos + xOffset)/scale, (s.yPos + 1)/scale, color, SmartFontRenderer.TextAlignment.LEFT_RIGHT, SmartFontRenderer.TextShadow.OUTLINE);
                 ScreenRenderer.endGL();
             }
         }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemSpecificationOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemSpecificationOverlay.java
@@ -74,7 +74,7 @@ public class ItemSpecificationOverlay implements Listener {
                         ScreenRenderer.endGL();
                     } else {
                         // This is an un-id:ed but named item
-                        destinationName = "?";
+                        destinationName = "";
                         color = MinecraftChatColors.GRAY;
                     }
                 }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/RarityColorOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/RarityColorOverlay.java
@@ -49,6 +49,8 @@ public class RarityColorOverlay implements Listener {
     private static final Pattern DURABILITY_PATTERN = Pattern.compile("\\[([0-9]+)/([0-9]+) Durability\\]");
     private static String professionFilter = "-";
 
+    private static final ScreenRenderer renderer = new ScreenRenderer();
+
     @SubscribeEvent
     public void onChestInventory(GuiOverlapEvent.ChestOverlap.DrawGuiContainerBackgroundLayer e) {
         drawChest(e.getGui(), e.getGui().getLowerInv(), e.getGui().getUpperInv(), true, true);
@@ -263,7 +265,6 @@ public class RarityColorOverlay implements Listener {
     private static void drawHighlightColor(GuiContainer guiContainer, Slot s, CustomColor colour) {
         if (colour == null) return;
 
-        ScreenRenderer renderer = new ScreenRenderer();
         ScreenRenderer.beginGL(guiContainer.getGuiLeft() + s.xPos, guiContainer.getGuiTop() + s.yPos);
         {
             color(colour.r, colour.g, colour.b, UtilitiesConfig.Items.INSTANCE.inventoryAlpha / 100);

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/SkillPointOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/SkillPointOverlay.java
@@ -62,6 +62,8 @@ public class SkillPointOverlay implements Listener {
     private static final int SAVE_SLOT = 1;
     private static final int LOAD_SLOT = 3;
 
+    private final ScreenRenderer renderer = new ScreenRenderer();
+
     private GuiTextFieldWynn nameField;
 
     private int skillPointsRemaining;
@@ -177,9 +179,8 @@ public class SkillPointOverlay implements Listener {
             ScreenRenderer.beginGL(e.getGui().getGuiLeft() , e.getGui().getGuiTop());
             {
                 GlStateManager.translate(0, 0, 251);
-                ScreenRenderer r = new ScreenRenderer();
                 RenderHelper.disableStandardItemLighting();
-                r.drawString(skillPoint.getColoredSymbol(), s.xPos + 2, s.yPos, CommonColors.WHITE, SmartFontRenderer.TextAlignment.LEFT_RIGHT, SmartFontRenderer.TextShadow.NONE);
+                renderer.drawString(skillPoint.getColoredSymbol(), s.xPos + 2, s.yPos, CommonColors.WHITE, SmartFontRenderer.TextAlignment.LEFT_RIGHT, SmartFontRenderer.TextShadow.NONE);
             }
             ScreenRenderer.endGL();
         }

--- a/src/main/java/com/wynntils/webapi/profiles/item/ItemProfile.java
+++ b/src/main/java/com/wynntils/webapi/profiles/item/ItemProfile.java
@@ -187,6 +187,10 @@ public class ItemProfile {
         return wynnBuilderID;
     }
 
+    public boolean isFavorited() {
+        return UtilitiesConfig.INSTANCE.favoriteItems.contains(displayName);
+    }
+
     public ItemStack getGuideStack() {
         return guideStack != null ? guideStack : generateStack();
     }


### PR DESCRIPTION
Adds a system for 'favoriting' items so that they can more easily be noticed in loot chests. Users can favorite and unfavorite items through the item guide by shift left clicking, which is noted in each item's tooltip similar to the Wynndata feature. Any boxes that might contain a favorited item have a star icon to signify the fact, and the name of the item(s) in question will be underlined in the possibilities line of the tooltip, if item possibilities are enabled. Wynntils will also prevent the closing of chests with such boxes, in the same way it does with mythic boxes (this feature can be toggled off). Currently, only regular gear items are supported (basically, anything that shows up in the item guide) - I do want to expand the feature to ingredients eventually.

This PR also fixes a crash that occurs when extremely large numbers are entered as prices in the trade market, and disables clicking the ingredient pouch while in a chest, since it does nothing but force close the chest.

![image](https://user-images.githubusercontent.com/3767283/131205683-05a060ba-23db-4ae4-8004-f1d1500034fe.png)
![image](https://user-images.githubusercontent.com/3767283/131205689-e895a6bd-ac7d-4c62-80f4-05e943ffb2b9.png)
![image](https://user-images.githubusercontent.com/3767283/131205692-1696062c-cd8c-4073-8ce6-acf3b554d4c6.png)
