### PR TITLE
Tier overlay sync

### DIFF
--- a/src/main/java/com/wynntils/core/framework/enums/Powder.java
+++ b/src/main/java/com/wynntils/core/framework/enums/Powder.java
@@ -5,9 +5,9 @@
 package com.wynntils.core.framework.enums;
 
 import net.minecraft.util.text.TextFormatting;
-
 import java.util.LinkedList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 public enum Powder {
 
@@ -18,12 +18,16 @@ public enum Powder {
     AIR('❋', TextFormatting.WHITE);
 
     char symbol;
+    TextFormatting rawColor;
     String color;
 
     Powder(char symbol, TextFormatting color) {
         this.symbol = symbol;
+        this.rawColor = color;
         this.color = color.toString();
     }
+
+    public static Pattern powderRegexPattern = Pattern.compile("§[2ebcf8].? ?(Earth|Thunder|Water|Fire|Air|Blank) Powder ([IV]{1,3})");
 
     public char getSymbol() {
         return symbol;
@@ -31,6 +35,10 @@ public enum Powder {
 
     public String getColor() {
         return color;
+    }
+
+    public TextFormatting getRawColor() {
+        return rawColor;
     }
 
     public String getColoredSymbol() {

--- a/src/main/java/com/wynntils/core/framework/enums/Powder.java
+++ b/src/main/java/com/wynntils/core/framework/enums/Powder.java
@@ -27,7 +27,7 @@ public enum Powder {
         this.color = color.toString();
     }
 
-    public static Pattern powderRegexPattern = Pattern.compile("§[2ebcf8].? ?(Earth|Thunder|Water|Fire|Air|Blank) Powder ([IV]{1,3})");
+    public static Pattern POWDER_NAME_PATTERN = Pattern.compile("§[2ebcf8].? ?(Earth|Thunder|Water|Fire|Air|Blank) Powder ([IV]{1,3})");
 
     public char getSymbol() {
         return symbol;

--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -260,40 +260,44 @@ public class UtilitiesConfig extends SettingsClass {
         @Setting(displayName = "Emerald Pouch Specification", description = "Should the tier of emerald pouches be displayed?", order = 14)
         public boolean emeraldPouchSpecification = true;
 
-        @Setting(displayName = "Item Highlights in Containers", description = "Should items be highlighted according to rarity in remote containers?\n\n§8Remote containers are items such as chests and banks.", order = 15)
+        @Setting(displayName = "Tier Overlay Size", description = "How large should the tier overlays (emerald pouches, powders, amplifiers) be?", order = 15)
+        @Setting.Limitations.FloatLimit(min = 0.5f, max = 1, precision = 0.1f)
+        public float specificationTierSize = 1;
+
+        @Setting(displayName = "Item Highlights in Containers", description = "Should items be highlighted according to rarity in remote containers?\n\n§8Remote containers are items such as chests and banks.", order = 17)
         public boolean mainHighlightChest = true;
 
-        @Setting(displayName = "Item Highlights in Inventory", description = "Should items be highlighted according to rarity in your inventory?", order = 16)
+        @Setting(displayName = "Item Highlights in Inventory", description = "Should items be highlighted according to rarity in your inventory?", order = 18)
         public boolean mainHighlightInventory = true;
 
-        @Setting(displayName = "Accessories Highlight", description = "Should your worn accessories be highlighted according to rarity?", order = 17)
+        @Setting(displayName = "Accessories Highlight", description = "Should your worn accessories be highlighted according to rarity?", order = 19)
         public boolean accesoryHighlight = true;
 
-        @Setting(displayName = "Highlight Hotbar Items", description = "Should the items in your hotbar be highlighted according to rarity?", order = 18)
+        @Setting(displayName = "Highlight Hotbar Items", description = "Should the items in your hotbar be highlighted according to rarity?", order = 20)
         public boolean hotbarHighlight = true;
 
-        @Setting(displayName = "Highlight Armour Items", description = "Should your worn armour be highlighted according to rarity?", order = 19)
+        @Setting(displayName = "Highlight Armour Items", description = "Should your worn armour be highlighted according to rarity?", order = 21)
         public boolean armorHighlight = true;
 
-        @Setting(displayName = "Highlight Mythics", description = "Should mythic items be highlighted?", order = 20)
+        @Setting(displayName = "Highlight Mythics", description = "Should mythic items be highlighted?", order = 22)
         public boolean mythicHighlight = true;
 
-        @Setting(displayName = "Highlight Fabled", description = "Should fabled items be highlighted?", order = 21)
+        @Setting(displayName = "Highlight Fabled", description = "Should fabled items be highlighted?", order = 23)
         public boolean fabledHighlight = true;
 
-        @Setting(displayName = "Highlight Legendaries", description = "Should legendary items be highlighted?", order = 22)
+        @Setting(displayName = "Highlight Legendaries", description = "Should legendary items be highlighted?", order = 24)
         public boolean legendaryHighlight = true;
 
-        @Setting(displayName = "Highlight Rares", description = "Should rare items be highlighted?", order = 23)
+        @Setting(displayName = "Highlight Rares", description = "Should rare items be highlighted?", order = 25)
         public boolean rareHighlight = true;
 
-        @Setting(displayName = "Highlight Uniques", description = "Should unique items be highlighted?", order = 24)
+        @Setting(displayName = "Highlight Uniques", description = "Should unique items be highlighted?", order = 26)
         public boolean uniqueHighlight = true;
 
-        @Setting(displayName = "Highlight Set Items", description = "Should set items be highlighted?", order = 25)
+        @Setting(displayName = "Highlight Set Items", description = "Should set items be highlighted?", order = 27)
         public boolean setHighlight = true;
 
-        @Setting(displayName = "Highlight Normal Items", description = "Should normal items be highlighted?", order = 26)
+        @Setting(displayName = "Highlight Normal Items", description = "Should normal items be highlighted?", order = 28)
         public boolean normalHighlight = false;
 
         @Setting(displayName = "Highlight Black Market Cosmetics", description = "Should black market cosmetic items be highlighted?", order = 30)

--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -230,7 +230,7 @@ public class UtilitiesConfig extends SettingsClass {
         @Setting(displayName = "Show Average Unidentified Level", description = "Should the average level of an unidentified item be shown instead of the entire range?", order = 3)
         public boolean averageUnidentifiedLevel = true;
 
-        @Setting(displayName = "Show Levels Also Shows Item Tiers", description = "Should the tier of items (powders, amplifiers, pouches) be shown when pressing the show item level key?", order = 5)
+        @Setting(displayName = "Show Levels Key Also Shows Item Tiers", description = "Should the tier of items (powders, amplifiers, pouches) be shown when pressing the show item level key?", order = 5)
         public boolean levelKeyShowsItemTiers = false;
 
         @Setting(displayName = "Roman Numeral Item Tiers", description = "Should the tier of items (powders, amplifiers, pouches) be displayed using roman numerals?", order = 6)
@@ -251,7 +251,7 @@ public class UtilitiesConfig extends SettingsClass {
         @Setting(displayName = "Transportation Item Specification", description = "Should a letter indicating the destination of teleport scrolls and boat passes be displayed?", order = 11)
         public boolean transportationSpecification = true;
 
-        @Setting(displayName = "Amplifier Specification", description = "Should the tier of a Corkian Amplifier be displayed?", order = 12)
+        @Setting(displayName = "Corkian Amplifier Specification", description = "Should the tier of a Corkian Amplifier be displayed?", order = 12)
         public boolean amplifierSpecification = true;
 
         @Setting(displayName = "Powder Specification", description = "Should the tier of powders be displayed?", order = 13)

--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -230,10 +230,13 @@ public class UtilitiesConfig extends SettingsClass {
         @Setting(displayName = "Show Average Unidentified Level", description = "Should the average level of an unidentified item be shown instead of the entire range?", order = 3)
         public boolean averageUnidentifiedLevel = true;
 
-        @Setting(displayName = "Roman Numeral Powder Tier", description = "Should the tier of powders be displayed using roman numerals?", order = 4)
-        public boolean romanNumeralPowderTier = true;
+        @Setting(displayName = "Show Levels Also Shows Item Tiers", description = "Should the tier of items (powders, amplifiers, pouches) be shown when pressing the show item level key?", order = 5)
+        public boolean levelKeyShowsItemTiers = false;
 
-        @Setting(displayName = "Item Levels Outside GUIs", description = "Should the item level overlay key be enabled even when no GUI is open?", order = 5)
+        @Setting(displayName = "Roman Numeral Item Tiers", description = "Should the tier of items (powders, amplifiers, pouches) be displayed using roman numerals?", order = 6)
+        public boolean romanNumeralItemTier = true;
+
+        @Setting(displayName = "Item Levels Outside GUIs", description = "Should the item level overlay key be enabled even when no GUI is open?", order = 7)
         public boolean itemLevelOverlayOutsideGui = false;
 
         @Setting(displayName = "Dungeon Key Specification", description = "Should a letter indicating the destination of dungeon keys be displayed?", order = 8)

--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -254,6 +254,12 @@ public class UtilitiesConfig extends SettingsClass {
         @Setting(displayName = "Amplifier Specification", description = "Should the tier of a Corkian Amplifier be displayed?", order = 12)
         public boolean amplifierSpecification = true;
 
+        @Setting(displayName = "Powder Specification", description = "Should the tier of powders be displayed?", order = 13)
+        public boolean powderSpecification = true;
+
+        @Setting(displayName = "Emerald Pouch Specification", description = "Should the tier of emerald pouches be displayed?", order = 14)
+        public boolean emeraldPouchSpecification = true;
+
         @Setting(displayName = "Item Highlights in Containers", description = "Should items be highlighted according to rarity in remote containers?\n\n§8Remote containers are items such as chests and banks.", order = 15)
         public boolean mainHighlightChest = true;
 

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemLevelOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemLevelOverlay.java
@@ -23,8 +23,8 @@ import java.util.regex.Pattern;
 
 public class ItemLevelOverlay implements Listener {
 
-    private static final Pattern POWDER_NAME_PATTERN = Pattern.compile("(?:Earth|Thunder|Water|Fire|Air|Blank) Powder (VI|IV|V|I{1,3})");
-    private static final Pattern EMERALD_POUCH_PATTERN = Pattern.compile("§aEmerald Pouch§2 \\[Tier (IX|X|VI{1,3}|IV|V|I{1,3})]");
+    private static final Pattern POWDER_NAME_PATTERN = Pattern.compile("(?:Earth|Thunder|Water|Fire|Air|Blank) Powder ([IV]{1,3})");
+    private static final Pattern EMERALD_POUCH_PATTERN = Pattern.compile("§aEmerald Pouch§2 \\[Tier ([XIV]{1,4})]");
     private static final Pattern CORKIAN_AMPLIFIER_PATTERN = Pattern.compile("§bCorkian Amplifier (I{1,3})");
 
     private int romanToArabic(String romanNumeral) {
@@ -90,7 +90,7 @@ public class ItemLevelOverlay implements Listener {
 
         // emerald pouch tier
         if (item == Items.DIAMOND_AXE) {
-            Matcher emeraldPouchMatcher = EMERALD_POUCH_PATTERN.matcher(StringUtils.normalizeBadString(name));
+            Matcher emeraldPouchMatcher = EMERALD_POUCH_PATTERN.matcher(name);
             if (emeraldPouchMatcher.find()) {
                 if (!UtilitiesConfig.Items.INSTANCE.levelKeyShowsItemTiers) return;
                 if (UtilitiesConfig.Items.INSTANCE.romanNumeralItemTier) {
@@ -105,7 +105,7 @@ public class ItemLevelOverlay implements Listener {
 
         // cork amp tier
         if (item == Item.getItemFromBlock(Blocks.STONE_BUTTON)) {
-            Matcher amplifierMatcher = CORKIAN_AMPLIFIER_PATTERN.matcher(StringUtils.normalizeBadString(name));
+            Matcher amplifierMatcher = CORKIAN_AMPLIFIER_PATTERN.matcher(name);
             if (amplifierMatcher.find()) {
                 if (!UtilitiesConfig.Items.INSTANCE.levelKeyShowsItemTiers) return;
                 if (UtilitiesConfig.Items.INSTANCE.romanNumeralItemTier) {

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemLevelOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemLevelOverlay.java
@@ -7,6 +7,7 @@ package com.wynntils.modules.utilities.overlays.inventories;
 import com.wynntils.McIf;
 import com.wynntils.core.events.custom.RenderEvent;
 import com.wynntils.core.framework.interfaces.Listener;
+import com.wynntils.core.framework.enums.Powder;
 import com.wynntils.core.utils.ItemUtils;
 import com.wynntils.core.utils.StringUtils;
 import com.wynntils.core.utils.objects.IntRange;
@@ -23,7 +24,7 @@ import java.util.regex.Pattern;
 
 public class ItemLevelOverlay implements Listener {
 
-    private static final Pattern POWDER_NAME_PATTERN = Pattern.compile("(?:Earth|Thunder|Water|Fire|Air|Blank) Powder ([IV]{1,3})");
+    private static final Pattern POWDER_NAME_PATTERN = Powder.powderRegexPattern;
     private static final Pattern EMERALD_POUCH_PATTERN = Pattern.compile("§aEmerald Pouch§2 \\[Tier ([XIV]{1,4})]");
     private static final Pattern CORKIAN_AMPLIFIER_PATTERN = Pattern.compile("§bCorkian Amplifier (I{1,3})");
 

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemLevelOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemLevelOverlay.java
@@ -12,7 +12,7 @@ import com.wynntils.core.utils.StringUtils;
 import com.wynntils.core.utils.objects.IntRange;
 import com.wynntils.modules.utilities.configs.UtilitiesConfig;
 import com.wynntils.modules.utilities.managers.KeyManager;
-import net.minecraft.client.Minecraft;
+import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -24,6 +24,45 @@ import java.util.regex.Pattern;
 public class ItemLevelOverlay implements Listener {
 
     private static final Pattern POWDER_NAME_PATTERN = Pattern.compile("(?:Earth|Thunder|Water|Fire|Air|Blank) Powder (VI|IV|V|I{1,3})");
+    private static final Pattern EMERALD_POUCH_PATTERN = Pattern.compile("§aEmerald Pouch§2 \\[Tier (IX|X|VI{1,3}|IV|V|I{1,3})]");
+    private static final Pattern CORKIAN_AMPLIFIER_PATTERN = Pattern.compile("§bCorkian Amplifier (I{1,3})");
+
+    private int romanToArabic(String romanNumeral) {
+        int num = 0;
+        switch (romanNumeral) {
+            case "I":
+                num = 1;
+                break;
+            case "II":
+                num = 2;
+                break;
+            case "III":
+                num = 3;
+                break;
+            case "IV":
+                num = 4;
+                break;
+            case "V":
+                num = 5;
+                break;
+            case "VI":
+                num = 6;
+                break;
+            case "VII":
+                num = 7;
+                break;
+            case "VIII":
+                num = 8;
+                break;
+            case "IX":
+                num = 9;
+                break;
+            case "X":
+                num = 10;
+                break;
+        }
+        return num;
+    }
 
     @SubscribeEvent
     public void onItemOverlay(RenderEvent.DrawItemOverlay event) {
@@ -38,31 +77,42 @@ public class ItemLevelOverlay implements Listener {
         if (item == Items.DYE || item == Items.GUNPOWDER || item == Items.CLAY_BALL || item == Items.SUGAR) {
             Matcher powderMatcher = POWDER_NAME_PATTERN.matcher(StringUtils.normalizeBadString(name));
             if (powderMatcher.find()) {
-                if (UtilitiesConfig.Items.INSTANCE.romanNumeralPowderTier) {
+                if (!UtilitiesConfig.Items.INSTANCE.levelKeyShowsItemTiers) return;
+                if (UtilitiesConfig.Items.INSTANCE.romanNumeralItemTier) {
                     event.setOverlayText(powderMatcher.group(1));
                     return;
                 }
-                int tier = 0;
-                switch (powderMatcher.group(1)) {
-                    case "I":
-                        tier = 1;
-                        break;
-                    case "II":
-                        tier = 2;
-                        break;
-                    case "III":
-                        tier = 3;
-                        break;
-                    case "IV":
-                        tier = 4;
-                        break;
-                    case "V":
-                        tier = 5;
-                        break;
-                    case "VI":
-                        tier = 6;
-                        break;
+                int tier = romanToArabic(powderMatcher.group(1));
+                event.setOverlayText(Integer.toString(tier));
+                return;
+            }
+        }
+
+        // emerald pouch tier
+        if (item == Items.DIAMOND_AXE) {
+            Matcher emeraldPouchMatcher = EMERALD_POUCH_PATTERN.matcher(StringUtils.normalizeBadString(name));
+            if (emeraldPouchMatcher.find()) {
+                if (!UtilitiesConfig.Items.INSTANCE.levelKeyShowsItemTiers) return;
+                if (UtilitiesConfig.Items.INSTANCE.romanNumeralItemTier) {
+                    event.setOverlayText(emeraldPouchMatcher.group(1));
+                    return;
                 }
+                int tier = romanToArabic(emeraldPouchMatcher.group(1));
+                event.setOverlayText(Integer.toString(tier));
+                return;
+            }
+        }
+
+        // cork amp tier
+        if (item == Item.getItemFromBlock(Blocks.STONE_BUTTON)) {
+            Matcher amplifierMatcher = CORKIAN_AMPLIFIER_PATTERN.matcher(StringUtils.normalizeBadString(name));
+            if (amplifierMatcher.find()) {
+                if (!UtilitiesConfig.Items.INSTANCE.levelKeyShowsItemTiers) return;
+                if (UtilitiesConfig.Items.INSTANCE.romanNumeralItemTier) {
+                    event.setOverlayText(amplifierMatcher.group(1));
+                    return;
+                }
+                int tier = romanToArabic(amplifierMatcher.group(1));
                 event.setOverlayText(Integer.toString(tier));
                 return;
             }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemLevelOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemLevelOverlay.java
@@ -24,9 +24,8 @@ import java.util.regex.Pattern;
 
 public class ItemLevelOverlay implements Listener {
 
-    private static final Pattern POWDER_NAME_PATTERN = Powder.powderRegexPattern;
-    private static final Pattern EMERALD_POUCH_PATTERN = Pattern.compile("§aEmerald Pouch§2 \\[Tier ([XIV]{1,4})]");
-    private static final Pattern CORKIAN_AMPLIFIER_PATTERN = Pattern.compile("§bCorkian Amplifier (I{1,3})");
+    public static final Pattern EMERALD_POUCH_PATTERN = Pattern.compile("§aEmerald Pouch§2 \\[Tier ([XIV]{1,4})]");
+    public static final Pattern CORKIAN_AMPLIFIER_PATTERN = Pattern.compile("§bCorkian Amplifier (I{1,3})");
 
     private int romanToArabic(String romanNumeral) {
         int num = 0;
@@ -76,7 +75,7 @@ public class ItemLevelOverlay implements Listener {
 
         // powder tier
         if (item == Items.DYE || item == Items.GUNPOWDER || item == Items.CLAY_BALL || item == Items.SUGAR) {
-            Matcher powderMatcher = POWDER_NAME_PATTERN.matcher(StringUtils.normalizeBadString(name));
+            Matcher powderMatcher = Powder.POWDER_NAME_PATTERN.matcher(StringUtils.normalizeBadString(name));
             if (powderMatcher.find()) {
                 if (!UtilitiesConfig.Items.INSTANCE.levelKeyShowsItemTiers) return;
                 if (UtilitiesConfig.Items.INSTANCE.romanNumeralItemTier) {

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemSpecificationOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemSpecificationOverlay.java
@@ -8,10 +8,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.GuiOverlapEvent;
 import com.wynntils.core.framework.enums.SkillPoint;
+import com.wynntils.core.framework.enums.Powder;
 import com.wynntils.core.framework.interfaces.Listener;
 import com.wynntils.core.framework.rendering.ScreenRenderer;
 import com.wynntils.core.framework.rendering.SmartFontRenderer;
@@ -22,6 +22,7 @@ import com.wynntils.core.utils.ItemUtils;
 import com.wynntils.core.utils.StringUtils;
 import com.wynntils.modules.utilities.configs.UtilitiesConfig;
 import com.wynntils.webapi.profiles.item.enums.ItemType;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.RenderHelper;
@@ -154,27 +155,28 @@ public class ItemSpecificationOverlay implements Listener {
             }
 
             if (UtilitiesConfig.Items.INSTANCE.powderSpecification) {
-                Pattern powder = Pattern.compile("§[2ebcf8].? ?(Earth|Thunder|Water|Fire|Air|Blank) Powder ([IV]{1,3})");
+                Pattern powder = Powder.powderRegexPattern;
                 Matcher m = powder.matcher(StringUtils.normalizeBadString(name));
                 if (m.matches()) {
                     destinationName = m.group(2);
                     switch (m.group(1)) {
                         case "Earth":
-                            color = MinecraftChatColors.DARK_GREEN;
+                            color = MinecraftChatColors.fromTextFormatting(Powder.EARTH.getRawColor());
                             break;
                         case "Thunder":
-                            color = MinecraftChatColors.YELLOW;
+                            color = MinecraftChatColors.fromTextFormatting(Powder.THUNDER.getRawColor());
                             break;
                         case "Water":
-                            color = MinecraftChatColors.AQUA;
+                            color = MinecraftChatColors.fromTextFormatting(Powder.WATER.getRawColor());
                             break;
                         case "Fire":
-                            color = MinecraftChatColors.RED;
+                            color = MinecraftChatColors.fromTextFormatting(Powder.FIRE.getRawColor());
                             break;
                         case "Air":
-                            color = MinecraftChatColors.WHITE;
+                            color = MinecraftChatColors.fromTextFormatting(Powder.AIR.getRawColor());
                             break;
                         case "Blank":
+                            // Powder enum doesn't have blank
                             color = MinecraftChatColors.GRAY; // Dark gray is too hard to see, use normal instead
                             break;
                     }
@@ -184,7 +186,7 @@ public class ItemSpecificationOverlay implements Listener {
             }
 
             if (UtilitiesConfig.Items.INSTANCE.emeraldPouchSpecification) {
-                Pattern emeraldPouch = Pattern.compile("§aEmerald Pouch§2 \\[Tier (IX|X|VI{1,3}|IV|V|I{1,3})]");
+                Pattern emeraldPouch = Pattern.compile("§aEmerald Pouch§2 \\[Tier ([XIV]{1,4})]");
                 Matcher m = emeraldPouch.matcher(name);
                 if (m.matches()) {
                     destinationName = m.group(1);

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemSpecificationOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemSpecificationOverlay.java
@@ -22,8 +22,6 @@ import com.wynntils.core.utils.ItemUtils;
 import com.wynntils.core.utils.StringUtils;
 import com.wynntils.modules.utilities.configs.UtilitiesConfig;
 import com.wynntils.webapi.profiles.item.enums.ItemType;
-
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.RenderHelper;

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemSpecificationOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemSpecificationOverlay.java
@@ -22,7 +22,6 @@ import com.wynntils.core.utils.ItemUtils;
 import com.wynntils.core.utils.StringUtils;
 import com.wynntils.modules.utilities.configs.UtilitiesConfig;
 import com.wynntils.webapi.profiles.item.enums.ItemType;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.RenderHelper;
@@ -144,7 +143,7 @@ public class ItemSpecificationOverlay implements Listener {
             }
 
             if (UtilitiesConfig.Items.INSTANCE.amplifierSpecification) {
-                Pattern amp = Pattern.compile("^§bCorkian Amplifier (I{1,3})$");
+                Pattern amp = ItemLevelOverlay.CORKIAN_AMPLIFIER_PATTERN;
                 Matcher m = amp.matcher(name);
                 if (m.matches()) {
                     destinationName = m.group(1);
@@ -155,7 +154,7 @@ public class ItemSpecificationOverlay implements Listener {
             }
 
             if (UtilitiesConfig.Items.INSTANCE.powderSpecification) {
-                Pattern powder = Powder.powderRegexPattern;
+                Pattern powder = Powder.POWDER_NAME_PATTERN;
                 Matcher m = powder.matcher(StringUtils.normalizeBadString(name));
                 if (m.matches()) {
                     destinationName = m.group(2);
@@ -186,7 +185,7 @@ public class ItemSpecificationOverlay implements Listener {
             }
 
             if (UtilitiesConfig.Items.INSTANCE.emeraldPouchSpecification) {
-                Pattern emeraldPouch = Pattern.compile("§aEmerald Pouch§2 \\[Tier ([XIV]{1,4})]");
+                Pattern emeraldPouch = ItemLevelOverlay.EMERALD_POUCH_PATTERN;
                 Matcher m = emeraldPouch.matcher(name);
                 if (m.matches()) {
                     destinationName = m.group(1);

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemSpecificationOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemSpecificationOverlay.java
@@ -23,6 +23,7 @@ import com.wynntils.core.utils.StringUtils;
 import com.wynntils.modules.utilities.configs.UtilitiesConfig;
 import com.wynntils.webapi.profiles.item.enums.ItemType;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.RenderHelper;
@@ -150,7 +151,48 @@ public class ItemSpecificationOverlay implements Listener {
                     destinationName = m.group(1);
                     color = MinecraftChatColors.AQUA;
                     xOffset = -1;
-                    scale = 0.8f;
+                    scale = 1.0f;
+                }
+            }
+
+            if (UtilitiesConfig.Items.INSTANCE.powderSpecification) {
+                Pattern powder = Pattern.compile("§[2ebcf8].? ?(Earth|Thunder|Water|Fire|Air|Blank) Powder ([IV]{1,3})");
+                Matcher m = powder.matcher(StringUtils.normalizeBadString(name));
+                if (m.matches()) {
+                    destinationName = m.group(2);
+                    switch (m.group(1)) {
+                        case "Earth":
+                            color = MinecraftChatColors.DARK_GREEN;
+                            break;
+                        case "Thunder":
+                            color = MinecraftChatColors.YELLOW;
+                            break;
+                        case "Water":
+                            color = MinecraftChatColors.AQUA;
+                            break;
+                        case "Fire":
+                            color = MinecraftChatColors.RED;
+                            break;
+                        case "Air":
+                            color = MinecraftChatColors.WHITE;
+                            break;
+                        case "Blank":
+                            color = MinecraftChatColors.GRAY; // Dark gray is too hard to see, use normal instead
+                            break;
+                    }
+                    xOffset = -1;
+                    scale = 1.0f;
+                }
+            }
+
+            if (UtilitiesConfig.Items.INSTANCE.emeraldPouchSpecification) {
+                Pattern emeraldPouch = Pattern.compile("§aEmerald Pouch§2 \\[Tier (IX|X|VI{1,3}|IV|V|I{1,3})]");
+                Matcher m = emeraldPouch.matcher(name);
+                if (m.matches()) {
+                    destinationName = m.group(1);
+                    color = MinecraftChatColors.GREEN;
+                    xOffset = -1;
+                    scale = 1.0f;
                 }
             }
 

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemSpecificationOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemSpecificationOverlay.java
@@ -151,7 +151,7 @@ public class ItemSpecificationOverlay implements Listener {
                     destinationName = m.group(1);
                     color = MinecraftChatColors.AQUA;
                     xOffset = -1;
-                    scale = 1.0f;
+                    scale = UtilitiesConfig.Items.INSTANCE.specificationTierSize;
                 }
             }
 
@@ -181,7 +181,7 @@ public class ItemSpecificationOverlay implements Listener {
                             break;
                     }
                     xOffset = -1;
-                    scale = 1.0f;
+                    scale = UtilitiesConfig.Items.INSTANCE.specificationTierSize;
                 }
             }
 
@@ -192,7 +192,7 @@ public class ItemSpecificationOverlay implements Listener {
                     destinationName = m.group(1);
                     color = MinecraftChatColors.GREEN;
                     xOffset = -1;
-                    scale = 1.0f;
+                    scale = UtilitiesConfig.Items.INSTANCE.specificationTierSize;
                 }
             }
 


### PR DESCRIPTION
### Tier Overlay Sync

- Previously, Corkian Amplifiers and elemental powders did not have the option to show their tiers when the "Show Item Levels" hotkey was pressed. Added.
- Added emerald pouch specification overlay as well as "Show Item Levels" hotkey
- Cleaned up roman numeral converting in ItemLevelOverlay.java
- Added a slider to allow users to adjust size of tier specifications. Currently used for powders, emerald pouches, and amplifiers.
- Combined all "Show Item Levels" tier overlays into one setting.