### PR TITLE
Add prevent accidental emerald pouch clicks in loot chests

### DIFF
--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -54,6 +54,9 @@ public class UtilitiesConfig extends SettingsClass {
     @Setting(displayName = "Prevent Favorited Item Chest Closing", description = "Should the closing of loot chests be prevented when they contain favorited items?")
     public boolean preventFavoritedChestClose = true;
 
+    @Setting(displayName = "Prevent Clicking on Pouches in Loot Chests", description = "Should opening ingredient and emerald pouches be blocked in loot chests?")
+    public boolean preventOpeningPouchesChest = true;
+
     @Setting(displayName = "Prevent Clicking on Locked Items", description = "Should moving items to and from locked inventory slots be blocked?")
     public boolean preventSlotClicking = false;
 

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -667,7 +667,7 @@ public class ClientEvents implements Listener {
     @SubscribeEvent
     public void clickOnChest(GuiOverlapEvent.ChestOverlap.HandleMouseClick e) {
         // Prevent accidental ingredient/emerald pouch clicks in loot chests
-        if (e.getSlotIn() != null && e.getGui().getLowerInv().getDisplayName().getUnformattedText().contains("Loot Chest")) {
+        if (e.getSlotIn() != null && e.getGui().getLowerInv().getDisplayName().getUnformattedText().contains("Loot Chest") && UtilitiesConfig.INSTANCE.preventOpeningPouchesChest) {
             // Ingredient pouch
             if (e.getSlotId() - e.getGui().getLowerInv().getSizeInventory() == 4) {
                 e.setCanceled(true);

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -677,7 +677,7 @@ public class ClientEvents implements Listener {
             int mappedSlot = e.getSlotId();
             if (e.getSlotId() > 54) mappedSlot -= 54;
             if (e.getSlotId() > 31 && e.getSlotId() < 54) mappedSlot -= 18;
-            if (e.getGui().getUpperInv().getStackInSlot(mappedSlot).getDisplayName().startsWith("§aEmerald Pouch§2 [Tier ")) {
+            if (e.getGui().getUpperInv().getStackInSlot(mappedSlot).getDisplayName().startsWith("§aEmerald Pouch§2 [Tier ") && e.getSlotId() > 26) {
                 e.setCanceled(true);
                 return;
             }

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -666,9 +666,21 @@ public class ClientEvents implements Listener {
 
     @SubscribeEvent
     public void clickOnChest(GuiOverlapEvent.ChestOverlap.HandleMouseClick e) {
-        if (e.getSlotIn() != null && e.getSlotId() - e.getGui().getLowerInv().getSizeInventory() == 4) { // prevent accidental pouch clicking
-            e.setCanceled(true);
-            return;
+        // Prevent accidental ingredient/emerald pouch clicks in loot chests
+        if (e.getSlotIn() != null && e.getGui().getLowerInv().getDisplayName().getUnformattedText().contains("Loot Chest")) {
+            // Ingredient pouch
+            if (e.getSlotId() - e.getGui().getLowerInv().getSizeInventory() == 4) {
+                e.setCanceled(true);
+                return;
+            }
+            // Emerald pouch
+            int mappedSlot = e.getSlotId();
+            if (e.getSlotId() > 54) mappedSlot -= 54;
+            if (e.getSlotId() > 31 && e.getSlotId() < 54) mappedSlot -= 18;
+            if (e.getGui().getUpperInv().getStackInSlot(mappedSlot).getDisplayName().startsWith("§aEmerald Pouch§2 [Tier ")) {
+                e.setCanceled(true);
+                return;
+            }
         }
 
         if (UtilitiesConfig.INSTANCE.preventSlotClicking && e.getSlotIn() != null) {


### PR DESCRIPTION
Reformatted the section a bit, added a check to see if the inventory is actually "Loot Chest", moved the ingredient pouch check in there. Detects emerald pouch on name.