### PR TITLE
Block spell hotkeys if not holding weapon

### DIFF
--- a/src/main/java/com/wynntils/modules/utilities/managers/KeyManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/KeyManager.java
@@ -53,12 +53,12 @@ public class KeyManager {
             McIf.mc().gameSettings.gammaSetting = lastGamma;
         });
 
-        checkForUpdatesKey = CoreModule.getModule().registerKeyBinding("Check for Updates", Keyboard.KEY_L, "Wynntils", true, WebManager::checkForUpdates);
+        checkForUpdatesKey = CoreModule.getModule().registerKeyBinding("Check for Updates", Keyboard.KEY_NONE, "Wynntils", true, WebManager::checkForUpdates);
 
         CoreModule.getModule().registerKeyBinding("Open Settings", Keyboard.KEY_P, "Wynntils", KeyConflictContext.IN_GAME, true, () -> McIf.mc().displayGuiScreen(SettingsUI.getInstance(McIf.mc().currentScreen)));
 
         lockInventoryKey = UtilitiesModule.getModule().registerKeyBinding("Lock Slot", Keyboard.KEY_H, "Wynntils", KeyConflictContext.GUI, true, () -> {});
-        favoriteTradeKey = UtilitiesModule.getModule().registerKeyBinding("Favorite Trade", Keyboard.KEY_F, "Wynntils", KeyConflictContext.GUI, true, () -> {});
+        favoriteTradeKey = UtilitiesModule.getModule().registerKeyBinding("Favorite Trade", Keyboard.KEY_NONE, "Wynntils", KeyConflictContext.GUI, true, () -> {});
 
         UtilitiesModule.getModule().registerKeyBinding("Toggle AFK Protection", Keyboard.KEY_N, "Wynntils", KeyConflictContext.IN_GAME, true, ClientEvents::toggleAfkProtection);
 

--- a/src/main/java/com/wynntils/modules/utilities/managers/QuickCastManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/QuickCastManager.java
@@ -11,8 +11,10 @@ import com.wynntils.core.framework.instances.PlayerInfo;
 import com.wynntils.core.framework.instances.data.ActionBarData;
 import com.wynntils.core.framework.instances.data.CharacterData;
 import com.wynntils.core.framework.instances.data.SpellData;
+import com.wynntils.core.utils.ItemUtils;
 import com.wynntils.modules.core.managers.PacketQueue;
 import net.minecraft.client.Minecraft;
+import net.minecraft.item.ItemStack;
 import net.minecraft.network.Packet;
 import net.minecraft.network.play.client.CPacketAnimation;
 import net.minecraft.network.play.client.CPacketPlayerDigging;
@@ -49,6 +51,7 @@ public class QuickCastManager {
     }
 
     public static void castFirstSpell() {
+        if (!ItemUtils.getStringLore(McIf.player().getHeldItemMainhand()).contains("§7 Class Req:")) return;
         if (PlayerInfo.get(CharacterData.class).getCurrentClass() == ClassType.ARCHER) {
             queueSpell(1, SPELL_LEFT, SPELL_RIGHT, SPELL_LEFT);
             return;
@@ -58,6 +61,7 @@ public class QuickCastManager {
     }
 
     public static void castSecondSpell() {
+        if (!ItemUtils.getStringLore(McIf.player().getHeldItemMainhand()).contains("§7 Class Req:")) return;
         if (PlayerInfo.get(CharacterData.class).getCurrentClass() == ClassType.ARCHER) {
             queueSpell(2, SPELL_LEFT, SPELL_LEFT, SPELL_LEFT);
             return;
@@ -67,6 +71,7 @@ public class QuickCastManager {
     }
 
     public static void castThirdSpell() {
+        if (!ItemUtils.getStringLore(McIf.player().getHeldItemMainhand()).contains("§7 Class Req:")) return;
         if (PlayerInfo.get(CharacterData.class).getCurrentClass() == ClassType.ARCHER) {
             queueSpell(3, SPELL_LEFT, SPELL_RIGHT, SPELL_RIGHT);
             return;
@@ -76,6 +81,7 @@ public class QuickCastManager {
     }
 
     public static void castFourthSpell() {
+        if (!ItemUtils.getStringLore(McIf.player().getHeldItemMainhand()).contains("§7 Class Req:")) return;
         if (PlayerInfo.get(CharacterData.class).getCurrentClass() == ClassType.ARCHER) {
             queueSpell(4, SPELL_LEFT, SPELL_LEFT, SPELL_RIGHT);
             return;


### PR DESCRIPTION
Works by checking if "§7 Class Req:" is in the held item lore.
Also I removed default binds for favourite trade and ingred pouch on this pr, imo it's a small enough change to be lumped in here.