### PR TITLE
Updated Fabled and Set Identification Cost

### DIFF
--- a/src/main/java/com/wynntils/webapi/profiles/item/enums/ItemTier.java
+++ b/src/main/java/com/wynntils/webapi/profiles/item/enums/ItemTier.java
@@ -16,7 +16,7 @@ public enum ItemTier {
     NORMAL    (0, TextFormatting.WHITE,        MinecraftChatColors.WHITE,        new CustomColor(1f, 1f, 1f),      () -> UtilitiesConfig.Items.INSTANCE.normalHighlightColor,     0,  1.0f),
     UNIQUE    (1, TextFormatting.YELLOW,       MinecraftChatColors.YELLOW,       new CustomColor(1f, 1f, 0f),      () -> UtilitiesConfig.Items.INSTANCE.uniqueHighlightColor,     3,  0.5f),
     RARE      (2, TextFormatting.LIGHT_PURPLE, MinecraftChatColors.LIGHT_PURPLE, new CustomColor(1f, 0f, 1f),      () -> UtilitiesConfig.Items.INSTANCE.rareHighlightColor,       8,  1.2f),
-    SET       (3, TextFormatting.GREEN,        MinecraftChatColors.GREEN,        new CustomColor(0f, 1f, 0f),      () -> UtilitiesConfig.Items.INSTANCE.setHighlightColor,        8,  1.5f),
+    SET       (3, TextFormatting.GREEN,        MinecraftChatColors.GREEN,        new CustomColor(0f, 1f, 0f),      () -> UtilitiesConfig.Items.INSTANCE.setHighlightColor,        8,  1.2f),
     LEGENDARY (4, TextFormatting.AQUA,         MinecraftChatColors.AQUA,         new CustomColor(0f, 1f, 1f),      () -> UtilitiesConfig.Items.INSTANCE.legendaryHighlightColor, 12,  4.5f),
     FABLED    (5, TextFormatting.RED,          MinecraftChatColors.RED,          new CustomColor(1, 1/3f, 1/3f),   () -> UtilitiesConfig.Items.INSTANCE.fabledHighlightColor,    16,  8.0f),
     MYTHIC    (6, TextFormatting.DARK_PURPLE,  MinecraftChatColors.DARK_PURPLE,  new CustomColor(0.3f, 0, 0.3f),   () -> UtilitiesConfig.Items.INSTANCE.mythicHighlightColor,    90, 18.0f),

--- a/src/main/java/com/wynntils/webapi/profiles/item/enums/ItemTier.java
+++ b/src/main/java/com/wynntils/webapi/profiles/item/enums/ItemTier.java
@@ -18,7 +18,7 @@ public enum ItemTier {
     RARE      (2, TextFormatting.LIGHT_PURPLE, MinecraftChatColors.LIGHT_PURPLE, new CustomColor(1f, 0f, 1f),      () -> UtilitiesConfig.Items.INSTANCE.rareHighlightColor,       8,  1.2f),
     SET       (3, TextFormatting.GREEN,        MinecraftChatColors.GREEN,        new CustomColor(0f, 1f, 0f),      () -> UtilitiesConfig.Items.INSTANCE.setHighlightColor,        8,  1.5f),
     LEGENDARY (4, TextFormatting.AQUA,         MinecraftChatColors.AQUA,         new CustomColor(0f, 1f, 1f),      () -> UtilitiesConfig.Items.INSTANCE.legendaryHighlightColor, 12,  4.5f),
-    FABLED    (5, TextFormatting.RED,          MinecraftChatColors.RED,          new CustomColor(1, 1/3f, 1/3f),   () -> UtilitiesConfig.Items.INSTANCE.fabledHighlightColor,    26, 12.0f),
+    FABLED    (5, TextFormatting.RED,          MinecraftChatColors.RED,          new CustomColor(1, 1/3f, 1/3f),   () -> UtilitiesConfig.Items.INSTANCE.fabledHighlightColor,    16,  8.0f),
     MYTHIC    (6, TextFormatting.DARK_PURPLE,  MinecraftChatColors.DARK_PURPLE,  new CustomColor(0.3f, 0, 0.3f),   () -> UtilitiesConfig.Items.INSTANCE.mythicHighlightColor,    90, 18.0f),
     CRAFTED   (7, TextFormatting.DARK_AQUA,    MinecraftChatColors.DARK_AQUA,    new CustomColor(0, .545f, .545f), () -> UtilitiesConfig.Items.INSTANCE.craftedHighlightColor,    0,  1.0f);
 


### PR DESCRIPTION
Fabled id cost formula changed from 26+12*(level) to 16+8*(level) in the last patch.