### PR TITLE
Emerald Pouch Hotkey Enhancements

### DIFF
--- a/src/main/java/com/wynntils/modules/utilities/managers/EmeraldPouchManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/EmeraldPouchManager.java
@@ -32,6 +32,10 @@ public class EmeraldPouchManager {
     public static int getPouchUsage(ItemStack i) {
         Matcher usageMatcher = POUCH_USAGE_PATTERN.matcher(ItemUtils.getStringLore(i));
         if (!usageMatcher.find()) {
+            if (ItemUtils.getStringLore(i).contains("§7Empty")) { // We might just have an valid, empty pouch
+                return 0;
+            }
+
             return -1;
         }
         return Integer.parseInt(usageMatcher.group(1).replaceAll("\\s", ""));

--- a/src/main/java/com/wynntils/modules/utilities/managers/PouchHotkeyManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/PouchHotkeyManager.java
@@ -35,15 +35,13 @@ public class PouchHotkeyManager {
         HashMap<Integer, Integer> emeraldPouches = new HashMap<Integer, Integer>() { // <inventory slot, usage>
         };
 
-        Integer slot = 4958;
-
         for (int i = 0; i < inventory.size(); i++) {
             ItemStack stack = inventory.get(i);
             if (!stack.isEmpty() && stack.hasDisplayName() && EmeraldPouchManager.isEmeraldPouch(stack)) {
                 emeraldPouches.put(i, EmeraldPouchManager.getPouchUsage(stack));
-                slot = i;
             }
         }
+
         pouchSwitch:
         switch (emeraldPouches.size()) {
             default:

--- a/src/main/java/com/wynntils/modules/utilities/managers/PouchHotkeyManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/PouchHotkeyManager.java
@@ -11,6 +11,7 @@ import net.minecraft.util.NonNullList;
 import net.minecraft.util.text.TextFormatting;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 public class PouchHotkeyManager {
@@ -31,21 +32,56 @@ public class PouchHotkeyManager {
 
         EntityPlayerSP player = McIf.player();
         NonNullList<ItemStack> inventory = player.inventory.mainInventory;
-        List<Integer> emeraldPouchSlots = new ArrayList<Integer>() {};
+        HashMap<Integer, Integer> emeraldPouches = new HashMap<Integer, Integer>() { // <inventory slot, usage>
+        };
+
+        Integer slot = 4958;
 
         for (int i = 0; i < inventory.size(); i++) {
             ItemStack stack = inventory.get(i);
-            if (!stack.isEmpty() && stack.hasDisplayName() && stack.getDisplayName().contains("§aEmerald Pouch§2 [Tier")) { // Match as much as possible of the emerald pouch name to prevent false positives
-                emeraldPouchSlots.add(i);
+            if (!stack.isEmpty() && stack.hasDisplayName() && EmeraldPouchManager.isEmeraldPouch(stack)) {
+                emeraldPouches.put(i, EmeraldPouchManager.getPouchUsage(stack));
+                slot = i;
             }
         }
-        switch (emeraldPouchSlots.size()) {
+        pouchSwitch:
+        switch (emeraldPouches.size()) {
             default:
-                GameUpdateOverlay.queueMessage(TextFormatting.DARK_RED + "You have more than one emerald pouch in your inventory.");
+                boolean alreadyHasNonEmpty = false;
+                for (Integer amount : emeraldPouches.values()) { // We're just checking balances here, we have no way of knowing which pouch has which balance
+                    if (amount > 0 && !alreadyHasNonEmpty) { // We've discovered one pouch with a non-zero balance, remember this
+                        alreadyHasNonEmpty = true;
+                    } else if (amount > 0) { // Another pouch has a non-zero balance; notify user
+                        GameUpdateOverlay.queueMessage(TextFormatting.DARK_RED + "You have more than one non-empty emerald pouch in your inventory.");
+                        break pouchSwitch;
+                    }
+                }
+
+                // At this point, we have either multiple pouches with zero emeralds, or multiple pouches but only one with a non-zero balance
+                // Check to make sure we don't have a bunch of zero balances - if we do, notify user
+                System.out.println(emeraldPouches.values().stream().mapToInt(Integer::intValue).sum());
+                if (emeraldPouches.values().stream().mapToInt(Integer::intValue).sum() < 1) {
+                    GameUpdateOverlay.queueMessage(TextFormatting.DARK_RED + "You have more than one empty and no filled emerald pouches in your inventory.");
+                    break;
+                }
+
+                // Now, we know we have 1 used pouch and 1+ empty pouches - just open the used one
+                List<Integer> pouchSlotList = new ArrayList<>();
+                emeraldPouches.entrySet().stream() // Sort our HashMap to determine which is the used one
+                        .sorted((k1, k2) -> -k1.getValue().compareTo(k2.getValue()))
+                        .forEach(k -> pouchSlotList.add(k.getKey()));
+
+                player.connection.sendPacket(new CPacketClickWindow(
+                        player.inventoryContainer.windowId,
+                        pouchSlotList.get(0), 1, ClickType.PICKUP, player.inventory.getStackInSlot(pouchSlotList.get(0)),
+                        player.inventoryContainer.getNextTransactionID(player.inventory)));
+                break;
+
             case 0:
                 GameUpdateOverlay.queueMessage(TextFormatting.DARK_RED + "You do not have an emerald pouch in your inventory.");
+                break;
             case 1:
-                int slotNumber = emeraldPouchSlots.get(0);
+                int slotNumber = emeraldPouches.entrySet().iterator().next().getKey(); // We can just get the first value in the HashMap since we only have one value
                 if (slotNumber < 9) {
                     // sendPacket uses raw slot numbers, we need to remap the hotbar
                     slotNumber += 36;
@@ -54,6 +90,7 @@ public class PouchHotkeyManager {
                         player.inventoryContainer.windowId,
                         slotNumber, 1, ClickType.PICKUP, player.inventory.getStackInSlot(slotNumber),
                         player.inventoryContainer.getNextTransactionID(player.inventory)));
+                break;
         }
     }
 

--- a/src/main/java/com/wynntils/modules/utilities/managers/PouchHotkeyManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/PouchHotkeyManager.java
@@ -52,7 +52,7 @@ public class PouchHotkeyManager {
                     if (amount > 0 && !alreadyHasNonEmpty) { // We've discovered one pouch with a non-zero balance, remember this
                         alreadyHasNonEmpty = true;
                     } else if (amount > 0) { // Another pouch has a non-zero balance; notify user
-                        GameUpdateOverlay.queueMessage(TextFormatting.DARK_RED + "You have more than one non-empty emerald pouch in your inventory.");
+                        GameUpdateOverlay.queueMessage(TextFormatting.DARK_RED + "You have more than one filled emerald pouch in your inventory.");
                         break pouchSwitch;
                     }
                 }

--- a/src/main/java/com/wynntils/modules/utilities/managers/PouchHotkeyManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/PouchHotkeyManager.java
@@ -57,7 +57,7 @@ public class PouchHotkeyManager {
 
                 // At this point, we have either multiple pouches with zero emeralds, or multiple pouches but only one with a non-zero balance
                 // Check to make sure we don't have a bunch of zero balances - if we do, notify user
-                if (emeraldPouches.values().stream().mapToInt(Integer::intValue).sum() < 1) {
+                if (!alreadyHasNonEmpty) {
                     GameUpdateOverlay.queueMessage(TextFormatting.DARK_RED + "You have more than one empty and no filled emerald pouches in your inventory.");
                     break;
                 }


### PR DESCRIPTION
### Emerald Pouch Manager
- EmeraldPouchManager#getPouchUsage now correctly returns 0 for empty pouches - it used to return -1

### Emerald Pouch Hotkeys
- Previously, the hotkey wouldn't work when multiple pouches were in the user's inventory
- This has been changed to allow hotkeys to work with multiple pouches in inventory, with a few conditions:
    - Player must not have multiple filled pouches in inventory
    - Player must not only have multiple empty pouches in inventory
    - Key will work when player has 1 filled pouch and any number of empty pouches in inventory