### PR TITLE
lootrun notes improvement / bugfix

### DIFF
--- a/src/main/java/com/wynntils/core/framework/rendering/colors/MinecraftChatColors.java
+++ b/src/main/java/com/wynntils/core/framework/rendering/colors/MinecraftChatColors.java
@@ -9,7 +9,6 @@ import net.minecraft.util.text.TextFormatting;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
-import java.util.regex.Pattern;
 
 public class MinecraftChatColors extends CustomColor.SetBase {
 
@@ -35,23 +34,18 @@ public class MinecraftChatColors extends CustomColor.SetBase {
     public static final MinecraftChatColors WHITE = new MinecraftChatColors(0xFFFFFF);
 
     private static final MinecraftChatColors[] colors = {
-        BLACK,     DARK_BLUE,    DARK_GREEN, DARK_AQUA,
-        DARK_RED,  DARK_PURPLE,  GOLD,       GRAY,
-        DARK_GRAY, BLUE,         GREEN,      AQUA,
-        RED,       LIGHT_PURPLE, YELLOW,     WHITE
+            BLACK,     DARK_BLUE,    DARK_GREEN, DARK_AQUA,
+            DARK_RED,  DARK_PURPLE,  GOLD,       GRAY,
+            DARK_GRAY, BLUE,         GREEN,      AQUA,
+            RED,       LIGHT_PURPLE, YELLOW,     WHITE
     };
 
     private static final String[] names = {
-        "BLACK",     "DARK_BLUE",    "DARK_GREEN", "DARK_AQUA",
-        "DARK_RED",  "DARK_PURPLE",  "GOLD",       "GRAY",
-        "DARK_GRAY", "BLUE",         "GREEN",      "AQUA",
-        "RED",       "LIGHT_PURPLE", "YELLOW",     "WHITE"
+            "BLACK",     "DARK_BLUE",    "DARK_GREEN", "DARK_AQUA",
+            "DARK_RED",  "DARK_PURPLE",  "GOLD",       "GRAY",
+            "DARK_GRAY", "BLUE",         "GREEN",      "AQUA",
+            "RED",       "LIGHT_PURPLE", "YELLOW",     "WHITE"
     };
-
-    /*
-    Pattern from org.bukkit.ChatColor
-     */
-    private static final Pattern STRIP_COLOR_PATTERN = Pattern.compile("(?i)" + '§' + "[0-9A-FK-OR]");
 
     private static final Map<String, MinecraftChatColors> aliases = new HashMap<>();
 
@@ -78,13 +72,6 @@ public class MinecraftChatColors extends CustomColor.SetBase {
 
     public static MinecraftChatColors fromTextFormatting(TextFormatting textFormatting) {
         return set.fromName(textFormatting.name());
-    }
-
-    /*
-    Function from org.bukkit.ChatColor
-     */
-    public static String stripColor(String input) {
-        return input == null ? null : STRIP_COLOR_PATTERN.matcher(input).replaceAll("");
     }
 
     /*

--- a/src/main/java/com/wynntils/core/framework/rendering/colors/MinecraftChatColors.java
+++ b/src/main/java/com/wynntils/core/framework/rendering/colors/MinecraftChatColors.java
@@ -9,6 +9,7 @@ import net.minecraft.util.text.TextFormatting;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 public class MinecraftChatColors extends CustomColor.SetBase {
 
@@ -47,6 +48,11 @@ public class MinecraftChatColors extends CustomColor.SetBase {
         "RED",       "LIGHT_PURPLE", "YELLOW",     "WHITE"
     };
 
+    /*
+    Pattern from org.bukkit.ChatColor
+     */
+    private static final Pattern STRIP_COLOR_PATTERN = Pattern.compile("(?i)" + '§' + "[0-9A-FK-OR]");
+
     private static final Map<String, MinecraftChatColors> aliases = new HashMap<>();
 
     static {
@@ -72,6 +78,27 @@ public class MinecraftChatColors extends CustomColor.SetBase {
 
     public static MinecraftChatColors fromTextFormatting(TextFormatting textFormatting) {
         return set.fromName(textFormatting.name());
+    }
+
+    /*
+    Function from org.bukkit.ChatColor
+     */
+    public static String stripColor(String input) {
+        return input == null ? null : STRIP_COLOR_PATTERN.matcher(input).replaceAll("");
+    }
+
+    /*
+    Function from org.bukkit.ChatColor
+     */
+    public static String translateAlternateColorCodes(char altColorChar, String textToTranslate) {
+        char[] b = textToTranslate.toCharArray();
+        for (int i = 0; i < b.length - 1; ++i) {
+            if (b[i] == altColorChar && "0123456789AaBbCcDdEeFfKkLlMmNnOoRr".indexOf(b[i + 1]) > -1) {
+                b[i] = 167;
+                b[i + 1] = Character.toLowerCase(b[i + 1]);
+            }
+        }
+        return new String(b);
     }
 
 }

--- a/src/main/java/com/wynntils/core/utils/StringUtils.java
+++ b/src/main/java/com/wynntils/core/utils/StringUtils.java
@@ -104,12 +104,18 @@ public class StringUtils {
         int length = 0;
 
         for (String string : stringArray) {
-            if (length + string.length() >= max) {
-                result.append('|');
-                length = 0;
+            String[] lines = string.split("\\|", -1);
+            for (int i = 0; i < lines.length; i ++) {
+                String line = lines[i];
+                if (i > 0 || length + line.length() >= max) {
+                    result.append('|');
+                    length = 0;
+                }
+                if (line.length() > 0) {
+                    result.append(line).append(' ');
+                    length += line.length() + 1;  // +1 for the space following
+                }
             }
-            result.append(string).append(' ');
-            length += string.length() + 1;  // +1 for the space following
         }
 
         return result.toString().split("\\|");
@@ -124,12 +130,18 @@ public class StringUtils {
         int length = 0;
 
         for (String string : stringArray) {
-            if (length + renderer.getStringWidth(string) >= maxPixels) {
-                result.append('|');
-                length = 0;
+            String[] lines = string.split("\\|", -1);
+            for (int i = 0; i < lines.length; i ++) {
+                String line = lines[i];
+                if (i > 0 || length + renderer.getStringWidth(line) >= maxPixels) {
+                    result.append('|');
+                    length = 0;
+                }
+                if (line.length() > 0) {
+                    result.append(line).append(' ');
+                    length += renderer.getStringWidth(line) + spaceSize;
+                }
             }
-            result.append(string).append(' ');
-            length += renderer.getStringWidth(string) + spaceSize;
         }
 
         return result.toString().split("\\|");

--- a/src/main/java/com/wynntils/core/utils/StringUtils.java
+++ b/src/main/java/com/wynntils/core/utils/StringUtils.java
@@ -104,11 +104,11 @@ public class StringUtils {
         int length = 0;
 
         for (String string : stringArray) {
-            String[] lines = string.split("\\|", -1);
+            String[] lines = string.split("\\\\n", -1);
             for (int i = 0; i < lines.length; i ++) {
                 String line = lines[i];
                 if (i > 0 || length + line.length() >= max) {
-                    result.append('|');
+                    result.append('\n');
                     length = 0;
                 }
                 if (line.length() > 0) {
@@ -118,7 +118,7 @@ public class StringUtils {
             }
         }
 
-        return result.toString().split("\\|");
+        return result.toString().split("\n");
     }
 
     public static String[] wrapTextBySize(String s, int maxPixels) {
@@ -130,11 +130,11 @@ public class StringUtils {
         int length = 0;
 
         for (String string : stringArray) {
-            String[] lines = string.split("\\|", -1);
+            String[] lines = string.split("\\\\n", -1);
             for (int i = 0; i < lines.length; i ++) {
                 String line = lines[i];
                 if (i > 0 || length + renderer.getStringWidth(line) >= maxPixels) {
-                    result.append('|');
+                    result.append('\n');
                     length = 0;
                 }
                 if (line.length() > 0) {
@@ -144,7 +144,7 @@ public class StringUtils {
             }
         }
 
-        return result.toString().split("\\|");
+        return result.toString().split("\n");
     }
 
     private static final Map<String, CustomColor> registeredColors = new HashMap<>();

--- a/src/main/java/com/wynntils/modules/map/instances/LootRunNote.java
+++ b/src/main/java/com/wynntils/modules/map/instances/LootRunNote.java
@@ -58,6 +58,7 @@ public class LootRunNote {
     }
 
     private static void drawNametag(String input, CustomColor color, float x, float y, float z, int verticalShift, float viewerYaw, float viewerPitch, boolean isThirdPersonFrontal) {
+        pushAttrib();
         pushMatrix();
         {
             ScreenRenderer.beginGL(0, 0); // we set to 0 because we don't want the ScreenRender to handle this thing
@@ -88,6 +89,7 @@ public class LootRunNote {
             ScreenRenderer.endGL();
         }
         popMatrix();
+        popAttrib();
     }
 
 }

--- a/src/main/java/com/wynntils/modules/map/instances/LootRunNote.java
+++ b/src/main/java/com/wynntils/modules/map/instances/LootRunNote.java
@@ -8,9 +8,9 @@ import com.wynntils.core.framework.rendering.colors.MinecraftChatColors;
 import com.wynntils.core.utils.StringUtils;
 import com.wynntils.core.utils.objects.Location;
 
-import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.renderer.entity.RenderManager;
+import net.minecraft.util.text.TextFormatting;
 
 import static net.minecraft.client.renderer.GlStateManager.*;
 
@@ -73,7 +73,7 @@ public class LootRunNote {
                 scale(-0.025F, -0.025F, 0.025F);
                 disableLighting();
 
-                int middlePos = (int) renderer.getStringWidth(MinecraftChatColors.stripColor(input)) / 2;
+                int middlePos = (int) renderer.getStringWidth(TextFormatting.getTextWithoutFormattingCodes(input)) / 2;
 
                 // draws the label
                 renderer.drawString(input, -middlePos, verticalShift, color, SmartFontRenderer.TextAlignment.LEFT_RIGHT, SmartFontRenderer.TextShadow.NONE);

--- a/src/main/java/com/wynntils/modules/map/instances/LootRunNote.java
+++ b/src/main/java/com/wynntils/modules/map/instances/LootRunNote.java
@@ -4,6 +4,7 @@ import com.wynntils.McIf;
 import com.wynntils.core.framework.rendering.ScreenRenderer;
 import com.wynntils.core.framework.rendering.SmartFontRenderer;
 import com.wynntils.core.framework.rendering.colors.CustomColor;
+import com.wynntils.core.framework.rendering.colors.MinecraftChatColors;
 import com.wynntils.core.utils.StringUtils;
 import com.wynntils.core.utils.objects.Location;
 
@@ -48,6 +49,7 @@ public class LootRunNote {
         if (McIf.player().getDistanceSq(location.x, location.y, location.z) > 4096f)
             return; // only draw nametag when close
 
+        String note = MinecraftChatColors.translateAlternateColorCodes('&', this.note);
         String[] lines = StringUtils.wrapTextBySize(note, 200);
         int offsetY = -(fr.FONT_HEIGHT * lines.length) / 2;
 
@@ -71,7 +73,7 @@ public class LootRunNote {
                 scale(-0.025F, -0.025F, 0.025F);
                 disableLighting();
 
-                int middlePos = (int) renderer.getStringWidth(input) / 2;
+                int middlePos = (int) renderer.getStringWidth(MinecraftChatColors.stripColor(input)) / 2;
 
                 // draws the label
                 renderer.drawString(input, -middlePos, verticalShift, color, SmartFontRenderer.TextAlignment.LEFT_RIGHT, SmartFontRenderer.TextShadow.NONE);


### PR DESCRIPTION
Right now if you use "|" in lootrun notes it will create a new line (as it is intended to do?) but it doesn't reset the width counter because the method doesn't take into consideration manual newlines. This means that if the line width is met soon after there will be a very short line.
My patch splits all the text segments already splitted by the " " character again but this time at the "|" character and if it finds more than one entry it will create a new line and reset the width counter.