### PR TITLE
Support Stream Mode 

### DIFF
--- a/src/main/java/com/wynntils/Reference.java
+++ b/src/main/java/com/wynntils/Reference.java
@@ -32,7 +32,7 @@ public class Reference {
     private static String userWorld = null;
 
     public static synchronized void setUserWorld(String uw) {
-        if (uw.equals("-")) {
+        if ("-".equals(uw)) {
             inStream = true;
             return;
         }

--- a/src/main/java/com/wynntils/Reference.java
+++ b/src/main/java/com/wynntils/Reference.java
@@ -32,6 +32,13 @@ public class Reference {
     private static String userWorld = null;
 
     public static synchronized void setUserWorld(String uw) {
+        if (uw.equals("-")) {
+            inStream = true;
+            return;
+        }
+
+        inStream = false;
+
         ServerData currentServer = McIf.mc().getCurrentServerData();
         String lowerIP = currentServer == null || currentServer.serverIP == null ? null : currentServer.serverIP.toLowerCase(Locale.ROOT);
         onServer = !McIf.mc().isSingleplayer() && lowerIP != null && !currentServer.isOnLAN() && lowerIP.contains("wynncraft");
@@ -58,6 +65,8 @@ public class Reference {
     public static boolean onWars = false;
     public static boolean onBeta = false;
     public static boolean onLobby = false;
+
+    public static boolean inStream = false;
 
     public static boolean developmentEnvironment = false;
 

--- a/src/main/java/com/wynntils/core/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/core/events/ClientEvents.java
@@ -185,7 +185,9 @@ public class ClientEvents {
                     String name = McIf.getUnformattedText(nameComponent);
                     String world = name.substring(name.indexOf("[") + 1, name.indexOf("]"));
 
-                    if (world.equalsIgnoreCase(lastWorld)) continue;
+                    if (world.equalsIgnoreCase(lastWorld)) {
+                        continue;
+                    }
 
                     Reference.setUserWorld(world);
                     FrameworkManager.getEventBus().post(new WynnWorldEvent.Join(world));

--- a/src/main/java/com/wynntils/core/utils/reflections/ReflectionFields.java
+++ b/src/main/java/com/wynntils/core/utils/reflections/ReflectionFields.java
@@ -28,7 +28,7 @@ public enum ReflectionFields {
     Entity_CUSTOM_NAME(Entity.class, "CUSTOM_NAME", "field_184242_az"),
     Entity_CUSTOM_NAME_VISIBLE(Entity.class, "CUSTOM_NAME_VISIBLE", "field_184233_aA"),
     EntityItemFrame_ITEM(EntityItemFrame.class, "ITEM", "field_184525_c"),
-    Event_phase(Event.class, "phase"),
+    Event_phase(Event.class, "phase", null),
     GuiScreen_buttonList(GuiScreen.class, "buttonList", "field_146292_n"),
     GuiScreenHorseInventory_horseEntity(GuiScreenHorseInventory.class, "horseEntity", "field_147034_x"),
     GuiScreenHorseInventory_horseInventory(GuiScreenHorseInventory.class, "horseInventory", "field_147029_w"),
@@ -51,8 +51,8 @@ public enum ReflectionFields {
 
     final Field field;
 
-    ReflectionFields(Class<?> holdingClass, String... values) {
-        this.field = ReflectionHelper.findField(holdingClass, values);
+    ReflectionFields(Class<?> holdingClass, String deobf, String obf) {
+        this.field = ReflectionHelper.findField(holdingClass, deobf, obf);
     }
 
     public <T> T getValue(Object parent) {

--- a/src/main/java/com/wynntils/modules/utilities/instances/InfoFormatter.java
+++ b/src/main/java/com/wynntils/modules/utilities/instances/InfoFormatter.java
@@ -89,7 +89,7 @@ public class InfoFormatter {
 
         // The world/server number
         registerFormatter((input) ->
-                Reference.getUserWorld(),
+                Reference.inStream ? "-" : Reference.getUserWorld(),
                 "world");
 
         // The ping time to the server

--- a/src/main/java/com/wynntils/modules/utilities/instances/InfoFormatter.java
+++ b/src/main/java/com/wynntils/modules/utilities/instances/InfoFormatter.java
@@ -89,7 +89,7 @@ public class InfoFormatter {
 
         // The world/server number
         registerFormatter((input) ->
-                Reference.inStream ? "-" : Reference.getUserWorld(),
+                Reference.inStream ? "WC -" : Reference.getUserWorld(),
                 "world");
 
         // The ping time to the server

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/PlayerInfoOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/PlayerInfoOverlay.java
@@ -68,7 +68,7 @@ public class PlayerInfoOverlay extends Overlay {
 
                 {  // titles
                     drawString("Friends", -124, 7, CommonColors.BLACK, SmartFontRenderer.TextAlignment.MIDDLE, SmartFontRenderer.TextShadow.NONE);
-                    drawString(Reference.inStream ? "Stream Mode" : Reference.getUserWorld(), -39, 7, Reference.inStream ? CommonColors.RED : CommonColors.BLACK, SmartFontRenderer.TextAlignment.MIDDLE, SmartFontRenderer.TextShadow.NONE);
+                    drawString(Reference.inStream ? "Streaming" : Reference.getUserWorld(), -39, 7, Reference.inStream ? CommonColors.RED : CommonColors.BLACK, SmartFontRenderer.TextAlignment.MIDDLE, SmartFontRenderer.TextShadow.NONE);
                     drawString("Party", 47, 7, CommonColors.BLACK, SmartFontRenderer.TextAlignment.MIDDLE, SmartFontRenderer.TextShadow.NONE);
                     drawString("Guild", 133, 7, CommonColors.BLACK, SmartFontRenderer.TextAlignment.MIDDLE, SmartFontRenderer.TextShadow.NONE);
                 }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/PlayerInfoOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/PlayerInfoOverlay.java
@@ -68,7 +68,7 @@ public class PlayerInfoOverlay extends Overlay {
 
                 {  // titles
                     drawString("Friends", -124, 7, CommonColors.BLACK, SmartFontRenderer.TextAlignment.MIDDLE, SmartFontRenderer.TextShadow.NONE);
-                    drawString(Reference.getUserWorld(), -39, 7, CommonColors.BLACK, SmartFontRenderer.TextAlignment.MIDDLE, SmartFontRenderer.TextShadow.NONE);
+                    drawString(Reference.inStream ? "Stream Mode" : Reference.getUserWorld(), -39, 7, Reference.inStream ? CommonColors.RED : CommonColors.BLACK, SmartFontRenderer.TextAlignment.MIDDLE, SmartFontRenderer.TextShadow.NONE);
                     drawString("Party", 47, 7, CommonColors.BLACK, SmartFontRenderer.TextAlignment.MIDDLE, SmartFontRenderer.TextShadow.NONE);
                     drawString("Guild", 133, 7, CommonColors.BLACK, SmartFontRenderer.TextAlignment.MIDDLE, SmartFontRenderer.TextShadow.NONE);
                 }


### PR DESCRIPTION
`Reference.getUserWorld()` now internally returns the actual world instead of `-`, which should stop crashing with /stream. Note that /stream is disabled on join so this should not be an issue. Made the world anonymous when /stream is enabled as well.

Removed deprecated method and replaced it with a better one

Not tested but decently sure it works