### PR TITLE
feat: add support for MSA in the dev env

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,79 +25,17 @@ minecraft {
             property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
             property 'forge.logging.console.level', 'debug'
 
-
-        }
-
-        if (project.hasProperty("minecraftEmailUsername") || project.hasProperty("minecraftPassword")) {
-            eclipseUnsuppliedClient {
-                parent runs.client
-
-                args '--username=${string_prompt:Minecraft Email/Username}'
-                args '--password=${password_prompt:Minecraft Password}'
-            }
-
-            intellijUnsuppliedClient {
-                parent runs.client
-
-                // If someone knows a prompt variable that actually hides the password when entering it for intellij then put it after "--password="
-                args '--username=$Prompt$'
-                args '--password=$Prompt$'
-            }
-
-            if (project.hasProperty('minecraftEmailUsername') && project.hasProperty('minecraftPassword')) {
-                suppliedClient {
-                    parent runs.client
-
-                    args "--username=" + minecraftEmailUsername
-                    args "--password=" + minecraftPassword
-                }
-            } else {
-                eclipseSuppliedClient {
-                    parent runs.client
-
-                    if (project.hasProperty("minecraftEmailUsername")) {
-                        args "--username=" + minecraftEmailUsername
-                    } else {
-                        args '--username=${string_prompt:Minecraft Email/Username}'
-                    }
-
-                    if (project.hasProperty("minecraftPassword")) {
-                        args "--password=" + minecraftPassword
-                    } else {
-                        args '--password=${password_prompt:Minecraft Password}'
-                    }
-                }
-
-                intellijSuppliedClient {
-                    parent runs.client
-
-                    if (project.hasProperty("minecraftEmailUsername")) {
-                        args "--username=" + minecraftEmailUsername
-                    } else {
-                        args '--username=$Prompt$'
-                    }
-
-                    if (project.hasProperty("minecraftPassword")) {
-                        args "--password=" + minecraftPassword
-                    } else {
-                        args '--password=$Prompt$'
-                    }
-                }
-            }
-        } else {
-            eclipseClient {
-                parent runs.client
-
-                args '--username=${string_prompt:Minecraft Email/Username}'
-                args '--password=${password_prompt:Minecraft Password}'
-            }
-
-            intellijClient {
-                parent runs.client
-
-                // If someone knows a prompt variable that actually hides the password when entering it for intellij then put it after "--password="
-                args '--username=$Prompt$'
-                args '--password=$Prompt$'
+            // These arguments allow for optional authentication with Mojang servers.
+            // If you want to authenticate, put these properties in GRADLE_HOME/gradle.properties.
+            // By default, this is C:\Users\<your username>\.gradle\gradle.properties on Windows or ~/.gradle/gradle.properties on Linux/MacOS.
+            if (project.hasProperty('mc_uuid') && project.hasProperty('mc_username') && project.hasProperty('mc_accessToken')) {
+                // Your UUID, trimmed / without the dashes
+                args '--uuid', project.getProperty('mc_uuid')
+                // Your Minecraft in-game username, not email
+                args '--username', project.getProperty('mc_username')
+                // Your current access token. When it expires, you need to retrieve a new one and regenerate your run configurations.
+                // You may be able to find it in your .minecraft folder in launcher_accounts.json or launcher_profiles.json.
+                args '--accessToken', project.getProperty('mc_accessToken')
             }
         }
     }


### PR DESCRIPTION
This replaces the current way of authenticating to the developer environment with a different way.

- Is not IDE restrictive, users of any IDE can now contribute to this product, including VS Code, which is supported by forge in Forgegradle 5, but was not by this project
- Security, you are no longer saving your password and email in plain text, and just your access token.
- Microsoft accounts, Mojang accounts are being fazed out, and this enables people who have already migrated to contribute to the project