### PR TITLE
feat: Implement dialogue hotbar button override

### DIFF
--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -111,6 +111,8 @@ public class ClientEvents implements Listener {
 
     private static final Pattern CRAFTED_USES = Pattern.compile(".* \\[(\\d)/\\d\\]");
 
+    private Boolean isInInteractionDialogue = false;
+
     @SubscribeEvent
     public void onMoveEvent(InputEvent.MouseInputEvent e) {
         lastUserInput = System.currentTimeMillis();
@@ -124,6 +126,11 @@ public class ClientEvents implements Listener {
         if (currentTime <= lastAfkRequested + 500) return;
 
         lastUserInput = currentTime;
+
+        // Manually send a hotbar packet if we're in dialogue + the user presses the already selected hotbar slot
+        if (isInInteractionDialogue && Keyboard.getEventKeyState() && Keyboard.getEventKey() - 2 == McIf.player().inventory.currentItem) { // -2 because KEY_1 is 0x02, and hotbar is 0-8
+            McIf.mc().getConnection().sendPacket(new CPacketHeldItemChange(McIf.player().inventory.currentItem));
+        }
     }
 
     @SubscribeEvent
@@ -319,6 +326,8 @@ public class ClientEvents implements Listener {
         if (msg.startsWith("[Daily Rewards:")) {
             DailyReminderManager.openedDaily();
         }
+
+        isInInteractionDialogue = msg.contains("Select an option to continue");
     }
 
     @SubscribeEvent

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -323,11 +323,15 @@ public class ClientEvents implements Listener {
         if (e.isCanceled() || e.getType() == ChatType.GAME_INFO) return;
 
         String msg = McIf.getUnformattedText(e.getMessage());
+        String fMsg = McIf.getFormattedText(e.getMessage());
         if (msg.startsWith("[Daily Rewards:")) {
             DailyReminderManager.openedDaily();
         }
 
-        isInInteractionDialogue = msg.contains("Select an option to continue");
+        isInInteractionDialogue = fMsg.contains("§r§7Select §r§fan option §r§7to continue§r") ||
+                fMsg.contains("§r§4Select §r§can option §r§4to continue§r") ||
+                fMsg.contains("§r§fCLICK §r§7an option to continue§r") ||
+                fMsg.contains("§r§cCLICK §r§4an option to continue§r");
     }
 
     @SubscribeEvent


### PR DESCRIPTION
When in dialogue, send a CPacketHeldItemChange to trigger dialogue option if the user is already at the hotbar slot they pressed.
Works by checking if we're in dialogue which is set by a check in chat receive event, then checking keyboard button presses.