### PR TITLE
fix: Bulk buy check fixes

### DIFF
--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -1078,8 +1078,8 @@ public class ClientEvents implements Listener {
         String itemName = is.getDisplayName();
         return (itemName.endsWith(" Teleport Scroll") ||
                 itemName.contains("Potion of ") || // We're using .contains here because we check for skill point potions which are different colors/symbols
-                itemName.endsWith("Speed Surge") ||
-                itemName.endsWith("Bipedal Spring"))
+                itemName.endsWith("Speed Surge [1/1]") ||
+                itemName.endsWith("Bipedal Spring [1/1]"))
 
                 && ItemUtils.getStringLore(is).contains("§6Price:")
                 && !ItemUtils.getStringLore(is).contains(" x "); // Make sure we're not in trade market

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -1081,7 +1081,9 @@ public class ClientEvents implements Listener {
                 itemName.endsWith("Speed Surge") ||
                 itemName.endsWith("Bipedal Spring"))
 
-                && ItemUtils.getStringLore(is).contains("§6Price:");
+                && ItemUtils.getStringLore(is).contains("§6Price:")
+                && !ItemUtils.getStringLore(is).contains(" x "); // Make sure we're not in trade market
+        // Normal shops don't have a string with " x " whereas TM uses it for the amount of the item being sold
     }
 
     @SubscribeEvent


### PR DESCRIPTION
Checks if we're in TM by scanning item lore for " x ", which TM uses to denote amount of items being sold. This string (should) never appear in normal shops.