### PR TITLE
feat: Add potion message redirect

### DIFF
--- a/src/main/java/com/wynntils/modules/utilities/configs/OverlayConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/OverlayConfig.java
@@ -361,6 +361,9 @@ public class OverlayConfig extends SettingsClass {
             @Setting(displayName = "Redirect Emerald Pouch Messages", description = "Should messages about emeralds being added to your pouch be redirected to the game update ticker?")
             public boolean redirectEmeraldPouch = true;
 
+            @Setting(displayName = "Redirect Potion Stack Messages", description = "Should messages about potions being added to your potion stack be redirected to the game update ticker?")
+            public boolean redirectPotionStack = true;
+
             @Setting(displayName = "Redirect Gathering Tool Messages", description = "Should messages about your gathering tool durability be redirected to the game update ticker?")
             public boolean redirectGatheringDura = true;
 

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -354,6 +354,10 @@ public class ClientEvents implements Listener {
         }
 
         Matcher potionMatcher = Pattern.compile("§a\\+(\\d+)§7 potion §acharges?").matcher(message);
+        if (OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectPotionStack && potionMatcher.matches()) {
+            e.setCanceled(true);
+            GameUpdateOverlay.queueMessage(message);
+        }
     }
 
     @SubscribeEvent

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -330,7 +330,8 @@ public class ClientEvents implements Listener {
         if (packet.getType() != SPacketTitle.Type.SUBTITLE) return;
         String message = McIf.getUnformattedText(packet.getMessage());
 
-        if (OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectIngredientPouch && message.matches("^§a\\+\\d+ §7.+§a to pouch$")) {
+        Matcher ingredientMatcher = Pattern.compile("^§a\\+\\d+ §7.+§a to pouch$").matcher(message);
+        if (OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectIngredientPouch && ingredientMatcher.matches()) {
             e.setCanceled(true);
             GameUpdateOverlay.queueMessage(message);
         }

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -336,6 +336,7 @@ public class ClientEvents implements Listener {
         if (OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectIngredientPouch && ingredientMatcher.matches()) {
             e.setCanceled(true);
             GameUpdateOverlay.queueMessage(message);
+            return;
         }
 
         Matcher emeraldMatcher = Pattern.compile("§a\\+(\\d+)§7 Emeralds? §ato pouch").matcher(message);

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -330,30 +330,26 @@ public class ClientEvents implements Listener {
         if (packet.getType() != SPacketTitle.Type.SUBTITLE) return;
         String message = McIf.getUnformattedText(packet.getMessage());
 
-        if (message.matches("^§a\\+\\d+ §7.+§a to pouch$")) {
-            if (OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectIngredientPouch) {
-                e.setCanceled(true);
-                GameUpdateOverlay.queueMessage(message);
-            }
+        if (OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectIngredientPouch && message.matches("^§a\\+\\d+ §7.+§a to pouch$")) {
+            e.setCanceled(true);
+            GameUpdateOverlay.queueMessage(message);
         }
 
         Matcher emeraldMatcher = Pattern.compile("§a\\+(\\d+)§7 Emeralds? §ato pouch").matcher(message);
-        if (emeraldMatcher.matches()) {
-            if (OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectEmeraldPouch) {
-                e.setCanceled(true);
-                if (new Timestamp(System.currentTimeMillis() - 3000).before(emeraldPouchLastPickup)) {
-                    // If the last emerald pickup event was less than 3 seconds ago, assume Wynn has relayed us an "updated" emerald title
-                    // Edit the first message it gave us with the new amount
-                    // editMessage doesn't return the new MessageContainer, so we can just keep re-using the first one
-                    int currentEmeralds = Integer.parseInt(emeraldMatcher.group(1));
-                    GameUpdateOverlay.editMessage(emeraldPouchMessage, "§a+" + currentEmeralds + "§7 Emeralds §ato pouch");
-                    emeraldPouchLastPickup = new Timestamp(System.currentTimeMillis());
-                    return;
-                }
-                // First time we've picked up emeralds in 3 seconds, set new MessageContainer and start the timer
-                emeraldPouchMessage = GameUpdateOverlay.queueMessage(message);
+        if (OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectEmeraldPouch && emeraldMatcher.matches()) {
+            e.setCanceled(true);
+            if (new Timestamp(System.currentTimeMillis() - 3000).before(emeraldPouchLastPickup)) {
+                // If the last emerald pickup event was less than 3 seconds ago, assume Wynn has relayed us an "updated" emerald title
+                // Edit the first message it gave us with the new amount
+                // editMessage doesn't return the new MessageContainer, so we can just keep re-using the first one
+                int currentEmeralds = Integer.parseInt(emeraldMatcher.group(1));
+                GameUpdateOverlay.editMessage(emeraldPouchMessage, "§a+" + currentEmeralds + "§7 Emeralds §ato pouch");
                 emeraldPouchLastPickup = new Timestamp(System.currentTimeMillis());
+                return;
             }
+            // First time we've picked up emeralds in 3 seconds, set new MessageContainer and start the timer
+            emeraldPouchMessage = GameUpdateOverlay.queueMessage(message);
+            emeraldPouchLastPickup = new Timestamp(System.currentTimeMillis());
         }
 
         Matcher potionMatcher = Pattern.compile("§a\\+(\\d+)§7 potion §acharges?").matcher(message);

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -323,7 +323,9 @@ public class ClientEvents implements Listener {
 
     @SubscribeEvent
     public void onTitle(PacketEvent<SPacketTitle> e) {
-        if (!OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectIngredientPouch && !OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectEmeraldPouch)
+        if (!OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectIngredientPouch
+                && !OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectEmeraldPouch
+                && !OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectPotionStack)
             return;
 
         SPacketTitle packet = e.getPacket();

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -328,32 +328,35 @@ public class ClientEvents implements Listener {
 
         SPacketTitle packet = e.getPacket();
         if (packet.getType() != SPacketTitle.Type.SUBTITLE) return;
+        String message = McIf.getUnformattedText(packet.getMessage());
 
-        if (McIf.getUnformattedText(packet.getMessage()).matches("^§a\\+\\d+ §7.+§a to pouch$")) {
+        if (message.matches("^§a\\+\\d+ §7.+§a to pouch$")) {
             if (OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectIngredientPouch) {
                 e.setCanceled(true);
-                GameUpdateOverlay.queueMessage(McIf.getFormattedText(packet.getMessage()));
+                GameUpdateOverlay.queueMessage(message);
             }
         }
 
-        Matcher m = Pattern.compile("§a\\+(\\d+)§7 Emeralds? §ato pouch").matcher(McIf.getUnformattedText(packet.getMessage()));
-        if (m.matches()) {
+        Matcher emeraldMatcher = Pattern.compile("§a\\+(\\d+)§7 Emeralds? §ato pouch").matcher(message);
+        if (emeraldMatcher.matches()) {
             if (OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectEmeraldPouch) {
                 e.setCanceled(true);
                 if (new Timestamp(System.currentTimeMillis() - 3000).before(emeraldPouchLastPickup)) {
                     // If the last emerald pickup event was less than 3 seconds ago, assume Wynn has relayed us an "updated" emerald title
                     // Edit the first message it gave us with the new amount
                     // editMessage doesn't return the new MessageContainer, so we can just keep re-using the first one
-                    int currentEmeralds = Integer.parseInt(m.group(1));
+                    int currentEmeralds = Integer.parseInt(emeraldMatcher.group(1));
                     GameUpdateOverlay.editMessage(emeraldPouchMessage, "§a+" + currentEmeralds + "§7 Emeralds §ato pouch");
                     emeraldPouchLastPickup = new Timestamp(System.currentTimeMillis());
                     return;
                 }
                 // First time we've picked up emeralds in 3 seconds, set new MessageContainer and start the timer
-                emeraldPouchMessage = GameUpdateOverlay.queueMessage(McIf.getFormattedText(packet.getMessage()));
+                emeraldPouchMessage = GameUpdateOverlay.queueMessage(message);
                 emeraldPouchLastPickup = new Timestamp(System.currentTimeMillis());
             }
         }
+
+        Matcher potionMatcher = Pattern.compile("§a\\+(\\d+)§7 potion §acharges?").matcher(message);
     }
 
     @SubscribeEvent


### PR DESCRIPTION
Adds config and redirect functionality for `+3 potion charges` and similar messages. Also made the ingredient redirect consistent with emerald/potion redirects.