### PR TITLE
Guild QOL Feature: Shift + Right click on territory to open /guild territory for the hovered territory in GuildWorldMap

### DIFF
--- a/src/main/java/com/wynntils/modules/map/overlays/objects/MapTerritory.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/objects/MapTerritory.java
@@ -125,7 +125,7 @@ public class MapTerritory {
         float ppX = getCenterX();
         float ppY = getCenterY();
 
-        boolean hovering = (mouseX > initX && mouseX < endX && mouseY > initY && mouseY < endY);
+        boolean hovering = IsBeingHovered(mouseX, mouseY);
 
         if (showHeadquarters) {
             if (!resources.isHeadquarters()) return;
@@ -146,10 +146,13 @@ public class MapTerritory {
     }
 
     public void postDraw(int mouseX, int mouseY, float partialTicks, int width, int height) {
-        boolean hovering = (mouseX > initX && mouseX < endX && mouseY > initY && mouseY < endY);
+        boolean hovering = IsBeingHovered(mouseX, mouseY);
         if (!hovering) return;
 
         infoBox.render((int)(width * 0.95), (int)(height * 0.1));
     }
 
+    public boolean IsBeingHovered(int mouseX, int mouseY) {
+        return (mouseX > initX && mouseX < endX && mouseY > initY && mouseY < endY);
+    }
 }

--- a/src/main/java/com/wynntils/modules/map/overlays/objects/MapTerritory.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/objects/MapTerritory.java
@@ -125,7 +125,7 @@ public class MapTerritory {
         float ppX = getCenterX();
         float ppY = getCenterY();
 
-        boolean hovering = IsBeingHovered(mouseX, mouseY);
+        boolean hovering = isBeingHovered(mouseX, mouseY);
 
         if (showHeadquarters) {
             if (!resources.isHeadquarters()) return;
@@ -146,13 +146,13 @@ public class MapTerritory {
     }
 
     public void postDraw(int mouseX, int mouseY, float partialTicks, int width, int height) {
-        boolean hovering = IsBeingHovered(mouseX, mouseY);
+        boolean hovering = isBeingHovered(mouseX, mouseY);
         if (!hovering) return;
 
         infoBox.render((int)(width * 0.95), (int)(height * 0.1));
     }
 
-    public boolean IsBeingHovered(int mouseX, int mouseY) {
+    public boolean isBeingHovered(int mouseX, int mouseY) {
         return (mouseX > initX && mouseX < endX && mouseY > initY && mouseY < endY);
     }
 }

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/GuildWorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/GuildWorldMapUI.java
@@ -203,10 +203,8 @@ public class GuildWorldMapUI extends WorldMapUI {
 
     @Override
     public void handleMouseInput() throws IOException {
-        clicking[1] = Mouse.isButtonDown(1);
-
         //Check for shift + left click
-        if (!territoryManageShortcut || !clicking[1] || !Keyboard.isKeyDown(Keyboard.KEY_LSHIFT)) {
+        if (!territoryManageShortcut || !Mouse.isButtonDown(1) || !Keyboard.isKeyDown(Keyboard.KEY_LSHIFT)) {
             super.handleMouseInput();
             return;
         }
@@ -217,7 +215,7 @@ public class GuildWorldMapUI extends WorldMapUI {
 
             //Close map and open territory management menu
             Utils.displayGuiScreen(null);
-            McIf.player().sendChatMessage("/guild territory "+territory.getTerritory().getName());
+            McIf.player().sendChatMessage("/guild territory " + territory.getTerritory().getName());
             return;
         }
 

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/GuildWorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/GuildWorldMapUI.java
@@ -192,4 +192,26 @@ public class GuildWorldMapUI extends WorldMapUI {
         super.keyTyped(typedChar, keyCode);
     }
 
+    @Override
+    public void handleMouseInput() throws IOException {
+        clicking[1] = Mouse.isButtonDown(1);
+
+        //Check for shift + left click
+        if (!clicking[1] || !Keyboard.isKeyDown(Keyboard.KEY_LSHIFT)) {
+            super.handleMouseInput();
+            return;
+        }
+
+        for (MapTerritory territory : territories.values()) {
+            boolean hovering = territory.IsBeingHovered(lastMouseX, lastMouseY);
+            if (!hovering) continue;
+
+            //Close map and open territory management menu
+            McIf.mc().displayGuiScreen(null);
+            McIf.player().sendChatMessage("/guild territory "+territory.getTerritory().getName());
+            return;
+        }
+
+        super.handleMouseInput();
+    }
 }

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/GuildWorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/GuildWorldMapUI.java
@@ -7,6 +7,7 @@ package com.wynntils.modules.map.overlays.ui;
 import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.framework.rendering.ScreenRenderer;
+import com.wynntils.core.utils.Utils;
 import com.wynntils.modules.map.MapModule;
 import com.wynntils.modules.map.instances.GuildResourceContainer;
 import com.wynntils.modules.map.instances.MapProfile;
@@ -211,11 +212,11 @@ public class GuildWorldMapUI extends WorldMapUI {
         }
 
         for (MapTerritory territory : territories.values()) {
-            boolean hovering = territory.IsBeingHovered(lastMouseX, lastMouseY);
+            boolean hovering = territory.isBeingHovered(lastMouseX, lastMouseY);
             if (!hovering) continue;
 
             //Close map and open territory management menu
-            McIf.mc().displayGuiScreen(null);
+            Utils.displayGuiScreen(null);
             McIf.player().sendChatMessage("/guild territory "+territory.getTerritory().getName());
             return;
         }

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/GuildWorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/GuildWorldMapUI.java
@@ -37,6 +37,7 @@ public class GuildWorldMapUI extends WorldMapUI {
     private boolean showOwners = false;
     private boolean resourceColors = false;
     private boolean showTradeRoutes = true;
+    private boolean territoryManageShortcut = true;
 
     public GuildWorldMapUI() {
         super((float) McIf.player().posX, (float) McIf.player().posZ);
@@ -72,6 +73,13 @@ public class GuildWorldMapUI extends WorldMapUI {
                 GRAY + "Click here to enable/disable",
                 GRAY + "territory trade routes."
         ), (v) -> showTradeRoutes, (i, btn) -> showTradeRoutes = !showTradeRoutes);
+
+        addButton(MapButtonType.PLUS, 3, Arrays.asList(
+                RED + "[>] Shift + Right Click on a territory",
+                RED + "to open management menu.",
+                GRAY + "Click here to enable/disable",
+                GRAY + "territory management shortcut."
+        ), (v) -> territoryManageShortcut, (i, btn) -> territoryManageShortcut = !territoryManageShortcut);
     }
 
     @Override
@@ -197,7 +205,7 @@ public class GuildWorldMapUI extends WorldMapUI {
         clicking[1] = Mouse.isButtonDown(1);
 
         //Check for shift + left click
-        if (!clicking[1] || !Keyboard.isKeyDown(Keyboard.KEY_LSHIFT)) {
+        if (!territoryManageShortcut || !clicking[1] || !Keyboard.isKeyDown(Keyboard.KEY_LSHIFT)) {
             super.handleMouseInput();
             return;
         }


### PR DESCRIPTION
Added a feature to the GuildWorldMap so that the player can Shift + Right-Click on a hovered territory to run `/guild territory <hovered territory name>`.

The feature can be disabled with a map button.