### PR TITLE
Map QOL changes: If player is in war, use a generic X Z coordinate pair to open the map. Added a changeable default zoom level to maps.

### DIFF
--- a/src/main/java/com/wynntils/modules/map/MapModule.java
+++ b/src/main/java/com/wynntils/modules/map/MapModule.java
@@ -23,6 +23,7 @@ import com.wynntils.modules.map.overlays.OverlayEvents;
 import com.wynntils.modules.map.overlays.ui.GuildWorldMapUI;
 import com.wynntils.modules.map.overlays.ui.MainWorldMapUI;
 import com.wynntils.modules.map.overlays.ui.WaypointCreationMenu;
+import com.wynntils.modules.map.overlays.ui.WorldMapUI;
 import com.wynntils.webapi.WebManager;
 import com.wynntils.webapi.WebReader;
 import net.minecraft.scoreboard.Score;
@@ -77,13 +78,7 @@ public class MapModule extends Module {
                 if (WebManager.getApiUrls() == null) {
                     WebManager.tryReloadApiUrls(true);
                 } else {
-                    //Check if in war using scoreboard
-                    boolean inWar = isPlayerInWar();
-
-                    if (inWar)
-                        Utils.displayGuiScreen(new MainWorldMapUI(MapConfig.WorldMap.INSTANCE.mapDefaultX, MapConfig.WorldMap.INSTANCE.mapDefaultZ));
-                    else
-                        Utils.displayGuiScreen(new MainWorldMapUI());
+                    openMap(false);
                 }
             }
         });
@@ -93,16 +88,32 @@ public class MapModule extends Module {
                 if (WebManager.getApiUrls() == null) {
                     WebManager.tryReloadApiUrls(true);
                 } else {
-                    //Check if in war using scoreboard
-                    boolean inWar = isPlayerInWar();
-
-                    if (inWar)
-                        Utils.displayGuiScreen(new GuildWorldMapUI(MapConfig.WorldMap.INSTANCE.mapDefaultX, MapConfig.WorldMap.INSTANCE.mapDefaultZ));
-                    else
-                        Utils.displayGuiScreen(new GuildWorldMapUI());
+                    openMap(true);
                 }
             }
         });
+    }
+
+    private void openMap(boolean guildMap) {
+        //Check if in war using scoreboard
+        boolean inWar = isPlayerInWar();
+
+        WorldMapUI map;
+
+        if (inWar) {
+            if (guildMap)
+                map = new GuildWorldMapUI(MapConfig.WorldMap.INSTANCE.mapDefaultX, MapConfig.WorldMap.INSTANCE.mapDefaultZ);
+            else
+                map = new MainWorldMapUI(MapConfig.WorldMap.INSTANCE.mapDefaultX, MapConfig.WorldMap.INSTANCE.mapDefaultZ);
+        }
+        else {
+            if (guildMap)
+                map = new GuildWorldMapUI();
+            else
+                map = new MainWorldMapUI();
+        }
+
+        Utils.displayGuiScreen(map);
     }
 
     private boolean isPlayerInWar() {

--- a/src/main/java/com/wynntils/modules/map/MapModule.java
+++ b/src/main/java/com/wynntils/modules/map/MapModule.java
@@ -25,8 +25,12 @@ import com.wynntils.modules.map.overlays.ui.MainWorldMapUI;
 import com.wynntils.modules.map.overlays.ui.WaypointCreationMenu;
 import com.wynntils.webapi.WebManager;
 import com.wynntils.webapi.WebReader;
+import net.minecraft.scoreboard.Score;
+import net.minecraft.scoreboard.ScoreObjective;
 import net.minecraftforge.client.settings.KeyConflictContext;
 import org.lwjgl.input.Keyboard;
+
+import java.util.Collection;
 
 @ModuleInfo(name = "map", displayName = "Map")
 public class MapModule extends Module {
@@ -73,7 +77,13 @@ public class MapModule extends Module {
                 if (WebManager.getApiUrls() == null) {
                     WebManager.tryReloadApiUrls(true);
                 } else {
-                    Utils.displayGuiScreen(new MainWorldMapUI());
+                    //Check if in war using scoreboard
+                    boolean inWar = isPlayerInWar();
+
+                    if (inWar)
+                        Utils.displayGuiScreen(new MainWorldMapUI(MapConfig.WorldMap.INSTANCE.mapDefaultX, MapConfig.WorldMap.INSTANCE.mapDefaultZ));
+                    else
+                        Utils.displayGuiScreen(new MainWorldMapUI());
                 }
             }
         });
@@ -83,10 +93,33 @@ public class MapModule extends Module {
                 if (WebManager.getApiUrls() == null) {
                     WebManager.tryReloadApiUrls(true);
                 } else {
-                    Utils.displayGuiScreen(new GuildWorldMapUI());
+                    //Check if in war using scoreboard
+                    boolean inWar = isPlayerInWar();
+
+                    if (inWar)
+                        Utils.displayGuiScreen(new GuildWorldMapUI(MapConfig.WorldMap.INSTANCE.mapDefaultX, MapConfig.WorldMap.INSTANCE.mapDefaultZ));
+                    else
+                        Utils.displayGuiScreen(new GuildWorldMapUI());
                 }
             }
         });
+    }
+
+    private boolean isPlayerInWar() {
+        boolean inWar = false;
+
+        ScoreObjective objective = McIf.world().getScoreboard().getObjectiveInDisplaySlot(1);
+        if (objective != null) {
+            Collection<Score> objectiveList = objective.getScoreboard().getSortedScores(objective);
+            for (Score score : objectiveList) {
+                if (score.getPlayerName().equals("§4§lWar:"))
+                {
+                    inWar = true;
+                    break;
+                }
+            }
+        }
+        return inWar;
     }
 
     public static MapModule getModule() {

--- a/src/main/java/com/wynntils/modules/map/configs/MapConfig.java
+++ b/src/main/java/com/wynntils/modules/map/configs/MapConfig.java
@@ -119,12 +119,31 @@ public class MapConfig extends SettingsClass {
         public int defaultMapZoom = 0;
 
         @Setting(displayName = "Map Center X if in war", description = "Map center X coordinate will be this value when player is in war.")
-        @Setting.Limitations.IntLimit(min = -10000, max = +10000)
+        public String mapDefaultXString = "-200";
+
+        @Setting
         public int mapDefaultX = -200;
 
         @Setting(displayName = "Map Center Z if in war", description = "Map center Z coordinate will be this value when player is in war.")
-        @Setting.Limitations.IntLimit(min = -10000, max = +10000)
+        public String mapDefaultZString = "-3300";
+
+        @Setting
         public int mapDefaultZ = -3300;
+
+        @Override
+        public void onSettingChanged(String name) {
+            super.onSettingChanged(name);
+
+            if (name.equals("mapDefaultXString")) {
+                try {
+                    mapDefaultX = Integer.parseInt(mapDefaultXString);
+                } catch (NumberFormatException ignored) { }
+            } else if (name.equals("mapDefaultZString")) {
+                try {
+                    mapDefaultZ = Integer.parseInt(mapDefaultZString);
+                } catch (NumberFormatException ignored) { }
+            }
+        }
     }
 
     @SettingsInfo(name = "map_textures", displayPath = "Map/Textures")

--- a/src/main/java/com/wynntils/modules/map/configs/MapConfig.java
+++ b/src/main/java/com/wynntils/modules/map/configs/MapConfig.java
@@ -67,15 +67,15 @@ public class MapConfig extends SettingsClass {
     @Setting(displayName = "Map Blur", description = "Should the map be rendered using linear textures to avoid aliasing issues?", order = 12)
     public boolean renderUsingLinear = true;
 
-    @Setting(displayName = "Minimap Icons Size", description = "How big should minimap icons be?", order = 13)
+    @Setting(displayName = "Minimap Icons Size", description = "How big should minimap icons be?", order = 16)
     @Setting.Limitations.FloatLimit(min = 0.5f, max = 2f)
     public float minimapIconSizeMultiplier = 1f;
 
-    @Setting(displayName = "Minimap Zoom", description = "How zoomed out should the minimap be?", order = 14)
+    @Setting(displayName = "Minimap Zoom", description = "How zoomed out should the minimap be?", order = 17)
     @Setting.Limitations.IntLimit(min = MiniMapOverlay.MIN_ZOOM, max = MiniMapOverlay.MAX_ZOOM, precision = 1)
     public int mapZoom = 30;
 
-    @Setting(displayName = "Hide in Non-Mapped Areas", description = "Should the minimap be hidden if the player is outside the map?", order = 15)
+    @Setting(displayName = "Hide in Non-Mapped Areas", description = "Should the minimap be hidden if the player is outside the map?", order = 18)
     public boolean hideMinimapOutOfBounds = true;
 
     @Setting
@@ -113,6 +113,18 @@ public class MapConfig extends SettingsClass {
         @Setting(displayName = "Opening Animation Length", description = "How long should be the opening animation")
         @Setting.Limitations.IntLimit(min = 50, max = 1000)
         public int animationLength = 250;
+
+        @Setting(displayName = "Default Map Zoom", description = "Default zoom value when a map is opened.")
+        @Setting.Limitations.IntLimit(min = -10, max = 300)
+        public int defaultMapZoom = 0;
+
+        @Setting(displayName = "Map Center X if in war", description = "Map center X coordinate will be this value when player is in war.")
+        @Setting.Limitations.IntLimit(min = -10000, max = +10000)
+        public int mapDefaultX = -200;
+
+        @Setting(displayName = "Map Center Z if in war", description = "Map center Z coordinate will be this value when player is in war.")
+        @Setting.Limitations.IntLimit(min = -10000, max = +10000)
+        public int mapDefaultZ = -3300;
     }
 
     @SettingsInfo(name = "map_textures", displayPath = "Map/Textures")

--- a/src/main/java/com/wynntils/modules/map/configs/MapConfig.java
+++ b/src/main/java/com/wynntils/modules/map/configs/MapConfig.java
@@ -67,15 +67,15 @@ public class MapConfig extends SettingsClass {
     @Setting(displayName = "Map Blur", description = "Should the map be rendered using linear textures to avoid aliasing issues?", order = 12)
     public boolean renderUsingLinear = true;
 
-    @Setting(displayName = "Minimap Icons Size", description = "How big should minimap icons be?", order = 16)
+    @Setting(displayName = "Minimap Icons Size", description = "How big should minimap icons be?", order = 13)
     @Setting.Limitations.FloatLimit(min = 0.5f, max = 2f)
     public float minimapIconSizeMultiplier = 1f;
 
-    @Setting(displayName = "Minimap Zoom", description = "How zoomed out should the minimap be?", order = 17)
+    @Setting(displayName = "Minimap Zoom", description = "How zoomed out should the minimap be?", order = 14)
     @Setting.Limitations.IntLimit(min = MiniMapOverlay.MIN_ZOOM, max = MiniMapOverlay.MAX_ZOOM, precision = 1)
     public int mapZoom = 30;
 
-    @Setting(displayName = "Hide in Non-Mapped Areas", description = "Should the minimap be hidden if the player is outside the map?", order = 18)
+    @Setting(displayName = "Hide in Non-Mapped Areas", description = "Should the minimap be hidden if the player is outside the map?", order = 15)
     public boolean hideMinimapOutOfBounds = true;
 
     @Setting

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/GuildWorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/GuildWorldMapUI.java
@@ -42,6 +42,11 @@ public class GuildWorldMapUI extends WorldMapUI {
         super((float) McIf.player().posX, (float) McIf.player().posZ);
     }
 
+    public GuildWorldMapUI(float startX, float startZ) {
+        super(startX, startZ);
+
+    }
+
     @Override
     public void initGui() {
         super.initGui();

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/WorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/WorldMapUI.java
@@ -44,6 +44,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import static com.wynntils.modules.map.configs.MapConfig.INSTANCE;
 import static net.minecraft.client.renderer.GlStateManager.*;
 
 public class WorldMapUI extends GuiMovementScreen {
@@ -129,7 +130,7 @@ public class WorldMapUI extends GuiMovementScreen {
 
     protected void createIcons() {
         // HeyZeer0: Handles MiniMap markers provided by Wynn API
-        List<MapIcon> apiMapIcons = MapIcon.getApiMarkers(MapConfig.INSTANCE.iconTexture);
+        List<MapIcon> apiMapIcons = MapIcon.getApiMarkers(INSTANCE.iconTexture);
         // Handles map labels from map.wynncraft.com
         List<MapIcon> mapLabels = MapIcon.getLabels();
         // Handles all waypoints
@@ -394,7 +395,7 @@ public class WorldMapUI extends GuiMovementScreen {
         float invertedProgress = (animationEnd - System.currentTimeMillis()) / (float) MapConfig.WorldMap.INSTANCE.animationLength;
         double radians = (Math.PI / 2f) * invertedProgress;
 
-        zoom = (float) (25 * Math.sin(radians));
+        zoom = (float) (25 * Math.sin(radians)) + (float) MapConfig.WorldMap.INSTANCE.defaultMapZoom;
         updateCenterPosition(centerPositionX, centerPositionZ);
     }
 

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/WorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/WorldMapUI.java
@@ -97,6 +97,10 @@ public class WorldMapUI extends GuiMovementScreen {
             territories.put(territory.getFriendlyName(), new MapTerritory(territory).setRenderer(renderer));
         }
 
+        //Only set if there is no animation, otherwise it is handled by handleOpenAnimation()
+        if (!MapConfig.WorldMap.INSTANCE.openAnimation)
+            zoom = MapConfig.WorldMap.INSTANCE.defaultMapZoom;
+
         // Also creates icons
         createIcons();
         this.centerPositionX = startX; this.centerPositionZ = startZ;


### PR DESCRIPTION
Features added:
- Maps now detect if player is in war, using the scoreboards. If so, they use configurable coordiante values to open the map. This centers the map at the desired coordinates, makes it so that the world maps can be used even in wars without the need to scroll unreasonable distances.
- Added a default zoom setting: Useful for guild activities, as the map zooms in too much often times. This way users can set a default zoom so they can view bigger regions without zooming out every time.