### PR TITLE
Lootrunning features added: Dry streak, dry boxes, death message with coordinates

### DIFF
--- a/src/main/java/com/wynntils/modules/music/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/music/events/ClientEvents.java
@@ -98,30 +98,4 @@ public class ClientEvents implements Listener {
         if (BossTrackManager.isAlive()) return;
         AreaTrackManager.update(new Location(McIf.player()));
     }
-
-    // mythic found sfx
-    @SubscribeEvent
-    public void onMythicFound(PacketEvent<SPacketWindowItems> e) {
-        if (!MusicConfig.SoundEffects.INSTANCE.mythicFound) return;
-        if (McIf.mc().currentScreen == null) return;
-        if (!(McIf.mc().currentScreen instanceof ChestReplacer)) return;
-
-        ChestReplacer chest = (ChestReplacer) McIf.mc().currentScreen;
-        if (!chest.getLowerInv().getName().contains("Loot Chest") &&
-                !chest.getLowerInv().getName().contains("Daily Rewards") &&
-                !chest.getLowerInv().getName().contains("Objective Rewards")) return;
-
-        int size = Math.min(chest.getLowerInv().getSizeInventory(), e.getPacket().getItemStacks().size());
-        for (int i = 0; i < size; i++) {
-            ItemStack stack = e.getPacket().getItemStacks().get(i);
-            if (stack.isEmpty() || !stack.hasDisplayName()) continue;
-            if (!stack.getDisplayName().contains(TextFormatting.DARK_PURPLE.toString())) continue;
-            if (!stack.getDisplayName().contains("Unidentified")) continue;
-
-            SoundTrackManager.findTrack(WebManager.getMusicLocations().getEntryTrack("mythicFound"),
-                    true, false, false, false, true, false);
-            break;
-        }
-    }
-
 }

--- a/src/main/java/com/wynntils/modules/utilities/configs/OverlayConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/OverlayConfig.java
@@ -635,7 +635,8 @@ public class OverlayConfig extends SettingsClass {
             UNPROCESSED("Current amount of unprocessed materials"),
             UNPROCESSED_MAX("Max amount of unprocessed materials"),
             ADPS("Current area damage per second"),
-            DRY_STREAK("Number of opened chests since last mythic finding in chest.");
+            DRY_STREAK("Number of opened chests since last mythic finding in chest."),
+            DRY_BOXES("Number of item boxes found since last mythic finding in chest.");
 
             public final String displayName;
             public final String value;

--- a/src/main/java/com/wynntils/modules/utilities/configs/OverlayConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/OverlayConfig.java
@@ -641,7 +641,7 @@ public class OverlayConfig extends SettingsClass {
             UNPROCESSED_MAX("Max amount of unprocessed materials"),
             ADPS("Current area damage per second"),
             DRY_STREAK("Number of opened chests since last mythic finding in chest."),
-            DRY_BOXES("Number of item boxes found since last mythic finding in chest.");
+            DRY_BOXES("Number of item boxes found since last mythic finding in chest."),
             XPM_RAW("Current XP per Minute (Raw)"),
             XPM("Current XP per Minute (Formatted)"),
             XPPM("Current XP Percent per Minute"),

--- a/src/main/java/com/wynntils/modules/utilities/configs/OverlayConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/OverlayConfig.java
@@ -634,7 +634,8 @@ public class OverlayConfig extends SettingsClass {
             PARTY_OWNER("Owner of the current party"),
             UNPROCESSED("Current amount of unprocessed materials"),
             UNPROCESSED_MAX("Max amount of unprocessed materials"),
-            ADPS("Current area damage per second");
+            ADPS("Current area damage per second"),
+            DRY_STREAK("Number of opened chests since last mythic finding in chest.");
 
             public final String displayName;
             public final String value;

--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -114,7 +114,7 @@ public class UtilitiesConfig extends SettingsClass {
     @Setting(displayName = "Bulk Buy Amount", description = "How many items should be bought in bulk?")
     public int bulkBuyAmount = 3;
 
-    @Setting(displayName = "Show death message with coordinates", description = "Should there be a message with your death coordinates?")
+    @Setting(displayName = "Show Death Message with Coordinates", description = "Should there be a message with your death coordinates?")
     public boolean deathMessageWithCoords = true;
 
     @Setting(upload = false)

--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -105,6 +105,9 @@ public class UtilitiesConfig extends SettingsClass {
     @Setting(displayName = "Bulk Buy Amount", description = "How many items should be bought in bulk?")
     public int bulkBuyAmount = 3;
 
+    @Setting(displayName = "Show death message with coordinates", description = "Should there be a message with your death coordinates?")
+    public boolean deathMessageWithCoords = true;
+
     @Setting(upload = false)
     public String lastServerResourcePack = "";
 
@@ -356,7 +359,7 @@ public class UtilitiesConfig extends SettingsClass {
         @Setting(displayName = "Minimum Powder Tier Highlight", description = "What should the minimum tier of powders be for it to be highlighted?\n\n§8Set to 0 to disable.", order = 42)
         @Setting.Limitations.IntLimit(min = 0, max = 6)
         public int minPowderTier = 4;
-        
+
         @Setting(displayName = "Profession Filter Highlight Colour", description = "What colour should the highlight for filtered ingredients be?\n\n§aClick the coloured box to open the colour wheel.", order = 50)
         public CustomColor professionFilterHighlightColor = new CustomColor(0.078f, 0.35f, 0.8f);
 

--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -53,7 +53,7 @@ public class UtilitiesConfig extends SettingsClass {
     @Setting(displayName = "Prevent Clicking on Pouches in Loot Chests", description = "Should opening ingredient and emerald pouches be blocked in loot chests?")
     public boolean preventOpeningPouchesChest = true;
 
-    @Setting(displayName = "Count dry steak", description = "Should the number of chests since last mythic found in a chest counted?", order = 0)
+    @Setting(displayName = "Count Dry Streak", description = "Should the number of chests since last mythic found in a chest counted?", order = 0)
     public boolean enableDryStreak = true;
 
     @Setting

--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -53,6 +53,12 @@ public class UtilitiesConfig extends SettingsClass {
     @Setting(displayName = "Prevent Clicking on Pouches in Loot Chests", description = "Should opening ingredient and emerald pouches be blocked in loot chests?")
     public boolean preventOpeningPouchesChest = true;
 
+    @Setting(displayName = "Count dry steak", description = "Should the number of chests since last mythic found in a chest counted?", order = 0)
+    public boolean enableDryStreak = true;
+
+    @Setting
+    public int dryStreakCount = 0;
+
     @Setting(displayName = "Prevent Clicking on Locked Items", description = "Should moving items to and from locked inventory slots be blocked?")
     public boolean preventSlotClicking = false;
 

--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -59,6 +59,9 @@ public class UtilitiesConfig extends SettingsClass {
     @Setting
     public int dryStreakCount = 0;
 
+    @Setting
+    public int dryStreakBoxes = 0;
+
     @Setting(displayName = "Prevent Clicking on Locked Items", description = "Should moving items to and from locked inventory slots be blocked?")
     public boolean preventSlotClicking = false;
 

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -1147,12 +1147,17 @@ public class ClientEvents implements Listener {
     public void onPlayerDeath(GameEvent.PlayerDeath e) {
         if (lastPlayerLocation == null || !UtilitiesConfig.INSTANCE.deathMessageWithCoords) return;
 
-        ITextComponent textComponent = new TextComponentString(String.format("You have died at X: %d Y: %d Z: %d. Click here to set your waypoint there.", lastPlayerLocation.getX(), lastPlayerLocation.getY(), lastPlayerLocation.getZ()));
+        ITextComponent textComponent = new TextComponentString("You have died at ");
+        ITextComponent textComponentCoords = new TextComponentString(String.format("X: %d Y: %d Z: %d.", lastPlayerLocation.getX(), lastPlayerLocation.getY(), lastPlayerLocation.getZ()));
+
         textComponent.getStyle()
+                .setColor(TextFormatting.DARK_RED);
+        textComponentCoords.getStyle()
                 .setColor(TextFormatting.DARK_RED)
+                .setUnderlined(true)
                 .setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/compass " + lastPlayerLocation.getX() + " " + lastPlayerLocation.getY() + " " + lastPlayerLocation.getZ()));
 
-        McIf.player().sendMessage(textComponent);
+        McIf.player().sendMessage(textComponent.appendSibling(textComponentCoords));
     }
 
     //Dry streak counter, mythic music event
@@ -1163,7 +1168,7 @@ public class ClientEvents implements Listener {
         if (!UtilitiesConfig.INSTANCE.enableDryStreak) return;
 
         ChestReplacer chest = (ChestReplacer) McIf.mc().currentScreen;
-        //Dry streak counter
+        //Dry streak counter and sound sfx
         if (chest.getLowerInv().getName().contains("Loot Chest")) {
             //Only run at first time we get items, don't care about updating
             if (chest == lastOpenedChest) return;
@@ -1184,6 +1189,10 @@ public class ClientEvents implements Listener {
                 foundMythic = true;
                 UtilitiesConfig.INSTANCE.dryStreakCount = 0;
                 UtilitiesConfig.INSTANCE.dryStreakBoxes = 0;
+
+                SoundTrackManager.findTrack(WebManager.getMusicLocations().getEntryTrack("mythicFound"),
+                        true, false, false, false, true, false);
+
                 ITextComponent textComponent = new TextComponentString("Dry streak broken! Mythic found!");
                 textComponent.getStyle()
                         .setColor(TextFormatting.DARK_PURPLE)
@@ -1199,10 +1208,8 @@ public class ClientEvents implements Listener {
             UtilitiesConfig.INSTANCE.saveSettings(UtilitiesModule.getModule());
         }
 
-        //Mythic found sfx part
-        if (!chest.getLowerInv().getName().contains("Loot Chest") &&
-                !chest.getLowerInv().getName().contains("Daily Rewards") &&
-                !chest.getLowerInv().getName().contains("Objective Rewards")) return;
+        //Mythic found sfx for daily rewards and objective rewards
+        if (!chest.getLowerInv().getName().contains("Daily Rewards") && !chest.getLowerInv().getName().contains("Objective Rewards")) return;
 
         int size = Math.min(chest.getLowerInv().getSizeInventory(), e.getPacket().getItemStacks().size());
         for (int i = 0; i < size; i++) {

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -1146,7 +1146,7 @@ public class ClientEvents implements Listener {
     public void onPlayerDeath(GameEvent.PlayerDeath e) {
         if (lastPlayerLocation == null || !UtilitiesConfig.INSTANCE.deathMessageWithCoords) return;
 
-        ITextComponent textComponent = new TextComponentString(String.format("You died at X: %d Y: %d Z: %d. Click here to set your waypoint there.", lastPlayerLocation.getX(), lastPlayerLocation.getY(), lastPlayerLocation.getZ()));
+        ITextComponent textComponent = new TextComponentString(String.format("You have died at X: %d Y: %d Z: %d. Click here to set your waypoint there.", lastPlayerLocation.getX(), lastPlayerLocation.getY(), lastPlayerLocation.getZ()));
         textComponent.getStyle()
                 .setColor(TextFormatting.DARK_RED)
                 .setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/compass " + lastPlayerLocation.getX() + " " + lastPlayerLocation.getY() + " " + lastPlayerLocation.getZ()));

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -1226,21 +1226,22 @@ public class ClientEvents implements Listener {
 
                 if (!stack.getDisplayName().contains(TextFormatting.DARK_PURPLE.toString())) continue;
 
-                foundMythic = true;
-                UtilitiesConfig.INSTANCE.dryStreakCount = 0;
-                UtilitiesConfig.INSTANCE.dryStreakBoxes = 0;
-
                 if (MusicConfig.SoundEffects.INSTANCE.mythicFound)
                 SoundTrackManager.findTrack(WebManager.getMusicLocations().getEntryTrack("mythicFound"),
                         true, false, false, false, true, false);
 
                 if (UtilitiesConfig.INSTANCE.enableDryStreak) {
-                    ITextComponent textComponent = new TextComponentString("Dry streak broken! Mythic found!");
+                    ITextComponent textComponent = new TextComponentString(UtilitiesConfig.INSTANCE.dryStreakCount + " long dry streak broken! Mythic found! Found boxes since last mythic: " + UtilitiesConfig.INSTANCE.dryStreakBoxes);
                     textComponent.getStyle()
                             .setColor(TextFormatting.DARK_PURPLE)
                             .setBold(true);
                     McIf.player().sendMessage(textComponent);
                 }
+
+                foundMythic = true;
+                UtilitiesConfig.INSTANCE.dryStreakCount = 0;
+                UtilitiesConfig.INSTANCE.dryStreakBoxes = 0;
+
                 break;
             }
 

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -1206,6 +1206,7 @@ public class ClientEvents implements Listener {
                 UtilitiesConfig.INSTANCE.dryStreakCount += 1;
 
             UtilitiesConfig.INSTANCE.saveSettings(UtilitiesModule.getModule());
+            return;
         }
 
         //Mythic found sfx for daily rewards and objective rewards

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -115,7 +115,7 @@ public class ClientEvents implements Listener {
     private static final Pattern CRAFTED_USES = Pattern.compile(".* \\[(\\d)/\\d\\]");
 
     private static Vec3i lastPlayerLocation = null;
-    private static int lastProcessedOpenedLootchest = -1;
+    private static int lastProcessedOpenedChest = -1;
     private int lastOpenedChestWindowId = -1;
     private int lastOpenedRewardWindowId = -1;
     private Boolean isInInteractionDialogue = false;
@@ -1201,7 +1201,7 @@ public class ClientEvents implements Listener {
     @SubscribeEvent
     public void onWindowOpen(PacketEvent<SPacketOpenWindow> e){
         //System.out.println("Opened window with windowId: " + e.getPacket().getWindowId());
-        if (e.getPacket().getWindowTitle().getFormattedText().startsWith("Loot Chest"))
+        if (e.getPacket().getWindowTitle().getUnformattedText().startsWith("Loot Chest"))
             lastOpenedChestWindowId = e.getPacket().getWindowId();
         if (e.getPacket().getWindowTitle().toString().contains("Daily Rewards") || e.getPacket().getWindowTitle().toString().contains("Objective Rewards"))
             lastOpenedRewardWindowId = e.getPacket().getWindowId();
@@ -1216,13 +1216,13 @@ public class ClientEvents implements Listener {
         if (e.getPacket().getItemStacks().size() < 27)
             return;
 
+        //Only run at first time we get items, don't care about updating
+        if (e.getPacket().getWindowId() == lastProcessedOpenedChest) return;
+
+        lastProcessedOpenedChest = e.getPacket().getWindowId();
+
         //Dry streak counter and sound sfx
         if (UtilitiesConfig.INSTANCE.enableDryStreak && lastOpenedChestWindowId == e.getPacket().getWindowId()) {
-            //Only run at first time we get items, don't care about updating
-            if (e.getPacket().getWindowId() == lastProcessedOpenedLootchest) return;
-
-            lastProcessedOpenedLootchest = e.getPacket().getWindowId();
-
             boolean foundMythic = false;
             int size = e.getPacket().getItemStacks().size();
             for (int i = 0; i < size; i++) {

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -25,6 +25,7 @@ import com.wynntils.modules.core.overlays.inventories.ChestReplacer;
 import com.wynntils.modules.core.overlays.inventories.HorseReplacer;
 import com.wynntils.modules.core.overlays.inventories.InventoryReplacer;
 import com.wynntils.modules.map.managers.LootRunManager;
+import com.wynntils.modules.music.configs.MusicConfig;
 import com.wynntils.modules.music.managers.SoundTrackManager;
 import com.wynntils.modules.utilities.UtilitiesModule;
 import com.wynntils.modules.utilities.configs.OverlayConfig;
@@ -1205,11 +1206,10 @@ public class ClientEvents implements Listener {
     public void onMythicFound(PacketEvent<SPacketWindowItems> e) {
         if (McIf.mc().currentScreen == null) return;
         if (!(McIf.mc().currentScreen instanceof ChestReplacer)) return;
-        if (!UtilitiesConfig.INSTANCE.enableDryStreak) return;
 
         ChestReplacer chest = (ChestReplacer) McIf.mc().currentScreen;
         //Dry streak counter and sound sfx
-        if (chest.getLowerInv().getName().contains("Loot Chest")) {
+        if (UtilitiesConfig.INSTANCE.enableDryStreak && chest.getLowerInv().getName().contains("Loot Chest")) {
             //Only run at first time we get items, don't care about updating
             if (chest == lastOpenedChest) return;
 
@@ -1230,6 +1230,7 @@ public class ClientEvents implements Listener {
                 UtilitiesConfig.INSTANCE.dryStreakCount = 0;
                 UtilitiesConfig.INSTANCE.dryStreakBoxes = 0;
 
+                if (MusicConfig.SoundEffects.INSTANCE.mythicFound)
                 SoundTrackManager.findTrack(WebManager.getMusicLocations().getEntryTrack("mythicFound"),
                         true, false, false, false, true, false);
 
@@ -1250,7 +1251,7 @@ public class ClientEvents implements Listener {
         }
 
         //Mythic found sfx for daily rewards and objective rewards
-        if (!chest.getLowerInv().getName().contains("Daily Rewards") && !chest.getLowerInv().getName().contains("Objective Rewards")) return;
+        if (!MusicConfig.SoundEffects.INSTANCE.mythicFound && !chest.getLowerInv().getName().contains("Daily Rewards") && !chest.getLowerInv().getName().contains("Objective Rewards")) return;
 
         int size = Math.min(chest.getLowerInv().getSizeInventory(), e.getPacket().getItemStacks().size());
         for (int i = 0; i < size; i++) {
@@ -1264,7 +1265,7 @@ public class ClientEvents implements Listener {
             break;
         }
     }
-      
+
     @SubscribeEvent
     public void onIngredientPouchHovered(ItemTooltipEvent e) {
         // Is item Ingredient Pouch

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -1234,12 +1234,13 @@ public class ClientEvents implements Listener {
                 SoundTrackManager.findTrack(WebManager.getMusicLocations().getEntryTrack("mythicFound"),
                         true, false, false, false, true, false);
 
-                ITextComponent textComponent = new TextComponentString("Dry streak broken! Mythic found!");
-                textComponent.getStyle()
-                        .setColor(TextFormatting.DARK_PURPLE)
-                        .setBold(true);
-
-                McIf.player().sendMessage(textComponent);
+                if (UtilitiesConfig.INSTANCE.enableDryStreak) {
+                    ITextComponent textComponent = new TextComponentString("Dry streak broken! Mythic found!");
+                    textComponent.getStyle()
+                            .setColor(TextFormatting.DARK_PURPLE)
+                            .setBold(true);
+                    McIf.player().sendMessage(textComponent);
+                }
                 break;
             }
 

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -1174,11 +1174,15 @@ public class ClientEvents implements Listener {
         for (int i = 0; i < size; i++) {
             ItemStack stack = e.getPacket().getItemStacks().get(i);
             if (stack.isEmpty() || !stack.hasDisplayName()) continue;
-            if (!stack.getDisplayName().contains(TextFormatting.DARK_PURPLE.toString())) continue;
             if (!stack.getDisplayName().contains("Unidentified")) continue;
+
+            UtilitiesConfig.INSTANCE.dryStreakBoxes += 1;
+
+            if (!stack.getDisplayName().contains(TextFormatting.DARK_PURPLE.toString())) continue;
 
             foundMythic = true;
             UtilitiesConfig.INSTANCE.dryStreakCount = 0;
+            UtilitiesConfig.INSTANCE.dryStreakBoxes = 0;
             ITextComponent textComponent = new TextComponentString("Dry streak broken! Mythic found!");
             textComponent.getStyle()
                     .setColor(TextFormatting.DARK_PURPLE)

--- a/src/main/java/com/wynntils/modules/utilities/instances/InfoFormatter.java
+++ b/src/main/java/com/wynntils/modules/utilities/instances/InfoFormatter.java
@@ -463,6 +463,10 @@ public class InfoFormatter {
         registerFormatter((input) ->
                 !UtilitiesConfig.INSTANCE.enableDryStreak ? "-" : String.valueOf(UtilitiesConfig.INSTANCE.dryStreakCount),
                 "dry_streak");
+
+        registerFormatter((input) ->
+                        !UtilitiesConfig.INSTANCE.enableDryStreak ? "-" : String.valueOf(UtilitiesConfig.INSTANCE.dryStreakBoxes),
+                "dry_boxes", "dry_streak_boxes");
     }
 
     private void registerFormatter(InfoModule formatter, String... vars) {

--- a/src/main/java/com/wynntils/modules/utilities/instances/InfoFormatter.java
+++ b/src/main/java/com/wynntils/modules/utilities/instances/InfoFormatter.java
@@ -16,6 +16,7 @@ import com.wynntils.core.utils.objects.Location;
 import com.wynntils.core.utils.reference.EmeraldSymbols;
 import com.wynntils.modules.core.managers.CompassManager;
 import com.wynntils.modules.core.managers.PingManager;
+import com.wynntils.modules.utilities.configs.UtilitiesConfig;
 import com.wynntils.modules.utilities.interfaces.InfoModule;
 import com.wynntils.modules.utilities.managers.AreaDPSManager;
 import com.wynntils.modules.utilities.managers.ServerListManager;
@@ -457,6 +458,11 @@ public class InfoFormatter {
         registerFormatter((input) ->
                 Reference.inStream ? "-" : ServerListManager.getUptimeMinutes(Reference.getUserWorld()),
                 "uptime_m");
+
+        //Dry streak counter
+        registerFormatter((input) ->
+                !UtilitiesConfig.INSTANCE.enableDryStreak ? "-" : String.valueOf(UtilitiesConfig.INSTANCE.dryStreakCount),
+                "dry_streak");
     }
 
     private void registerFormatter(InfoModule formatter, String... vars) {


### PR DESCRIPTION
New features added:
- Toggleable option to have a message displaying the player's death position, clickable action to set waypoint there. Useful when lootrunners die during lootruns, they can go back to their exact position without remembering where they died.
![image](https://user-images.githubusercontent.com/49001742/147699553-1937ea45-181c-484c-8946-ac1affc33094.png)

- `%dry_streak%` and `%dry_boxes%` info variables added: Dry streak variable display how many chests were opened since last mythic finding in a loot chest, dry boxes count the number of unidentified item boxes since last mythic. This feature can be toggled.