### PR TITLE
Fix numerous problems with emerald count overlay, including #386

### DIFF
--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -356,7 +356,7 @@ public class UtilitiesConfig extends SettingsClass {
         public boolean commonEffectsHighlight = true;
 
         // TODO: move these 3 configs
-        @Setting(displayName = "Show Emerald Count in Containers", description = "Should your emerald count be displayed in remote containers?\n\n§8Remote containers are items such as chests and banks.", order = 101)
+        @Setting(displayName = "Show Emerald Count in Containers", description = "Should your emerald count be displayed in remote containers?\n\n§8Remote containers are items such as chests, banks and emerald pouches.", order = 101)
         public boolean emeraldCountChest = true;
 
         @Setting(displayName = "Show Emerald Count in Inventory", description = "Should your emerald count be displayed in your inventory?", order = 102)

--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -123,6 +123,15 @@ public class UtilitiesConfig extends SettingsClass {
     @Setting(displayName = "Show Death Message with Coordinates", description = "Should there be a message with your death coordinates?")
     public boolean deathMessageWithCoords = true;
 
+    @Setting(displayName = "Show Emerald Count in Containers", description = "Should your emerald count be displayed in remote containers?\n\n§8Remote containers are items such as chests, banks and emerald pouches.", order = 101)
+    public boolean emeraldCountChest = true;
+
+    @Setting(displayName = "Show Emerald Count in Inventory", description = "Should your emerald count be displayed in your inventory?", order = 102)
+    public boolean emeraldCountInventory = true;
+
+    @Setting(displayName = "Show Emerald Count as Text", description = "Should your emerald count be displayed as text instead of icons?", order = 103)
+    public boolean emeraldCountText = false;
+
     @Setting(upload = false)
     public String lastServerResourcePack = "";
 
@@ -354,16 +363,6 @@ public class UtilitiesConfig extends SettingsClass {
 
         @Setting(displayName = "Highlight Common Cosmetics", description = "Should common cosmetic items be highlighted?", order = 34)
         public boolean commonEffectsHighlight = true;
-
-        // TODO: move these 3 configs
-        @Setting(displayName = "Show Emerald Count in Containers", description = "Should your emerald count be displayed in remote containers?\n\n§8Remote containers are items such as chests, banks and emerald pouches.", order = 101)
-        public boolean emeraldCountChest = true;
-
-        @Setting(displayName = "Show Emerald Count in Inventory", description = "Should your emerald count be displayed in your inventory?", order = 102)
-        public boolean emeraldCountInventory = true;
-
-        @Setting(displayName = "Show Emerald Count as Text", description = "Should your emerald count be displayed as text instead of icons?", order = 103)
-        public boolean emeraldCountText = false;
 
         @Setting(displayName = "Highlight Crafting Ingredients", description = "Should crafting ingredients be highlighted according to their tier?", order = 40)
         public boolean ingredientHighlight = true;

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/EmeraldCountOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/EmeraldCountOverlay.java
@@ -58,27 +58,27 @@ public class EmeraldCountOverlay implements Listener {
         //For some reason they are swapped?
         IInventory container = e.getGui().getLowerInv();
         String containerName = container.getName();
-        if (containerName.contains("Quests") || containerName.contains("points")) return;
 
         IInventory inventory = e.getGui().getUpperInv();
 
         boolean emeraldPouch = containerName.equals("EmeraldÀÀÀÀPouchÀ");
 
-        //List of containers that should not have their emerald count rendered
-        boolean shouldContainerRenderEmeraldCount = !containerName.equals("Trade Market") && !containerName.equals("Trade Overview") && !containerName.equals("Search Results") && !containerName.endsWith("Filter Items");
+        //Only render text and icons if there are emeralds in the container, fixes a lot of overlapping issues in containers, where emerald count is irrelevant, but we don't filter them manually
+        int containerMoneyAmount = ItemUtils.countMoney(container);
+        int inventoryMoneyAmount = ItemUtils.countMoney(inventory);
 
         if (UtilitiesConfig.INSTANCE.emeraldCountText) {
-            if (UtilitiesConfig.INSTANCE.emeraldCountChest && shouldContainerRenderEmeraldCount)
-                drawTextMoneyAmount(170, 5, ItemUtils.countMoney(container), renderer, textColor);
+            if (UtilitiesConfig.INSTANCE.emeraldCountChest && containerMoneyAmount > 0)
+                drawTextMoneyAmount(170, 5, containerMoneyAmount, renderer, textColor);
             if (UtilitiesConfig.INSTANCE.emeraldCountInventory)
-                drawTextMoneyAmount(170, 2 * (container.getSizeInventory() + 10), ItemUtils.countMoney(inventory), renderer, textColor);
+                drawTextMoneyAmount(170, 2 * (container.getSizeInventory() + 10), inventoryMoneyAmount, renderer, textColor);
             return;
         }
 
-        if (UtilitiesConfig.INSTANCE.emeraldCountChest && shouldContainerRenderEmeraldCount)
-            drawIconsMoneyAmount(178, 0, ItemUtils.countMoney(container), renderer);
+        if (UtilitiesConfig.INSTANCE.emeraldCountChest && containerMoneyAmount > 0)
+            drawIconsMoneyAmount(178, 0, containerMoneyAmount, renderer);
         if (UtilitiesConfig.INSTANCE.emeraldCountInventory && !emeraldPouch)
-            drawIconsMoneyAmount(178, 2 * (container.getSizeInventory() + 10), ItemUtils.countMoney(inventory), renderer);
+            drawIconsMoneyAmount(178, 2 * (container.getSizeInventory() + 10), inventoryMoneyAmount, renderer);
     }
 
     @SubscribeEvent

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/EmeraldCountOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/EmeraldCountOverlay.java
@@ -42,9 +42,9 @@ public class EmeraldCountOverlay implements Listener {
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onPlayerInventory(GuiOverlapEvent.InventoryOverlap.DrawGuiContainerForegroundLayer e) {
-        if (!Reference.onWorld || !UtilitiesConfig.Items.INSTANCE.emeraldCountInventory) return;
+        if (!Reference.onWorld || !UtilitiesConfig.INSTANCE.emeraldCountInventory) return;
 
-        if (UtilitiesConfig.Items.INSTANCE.emeraldCountText) {
+        if (UtilitiesConfig.INSTANCE.emeraldCountText) {
             drawTextMoneyAmount(170, -10, PlayerInfo.get(InventoryData.class).getMoney(), renderer, CommonColors.WHITE);
             return;
         }
@@ -53,7 +53,7 @@ public class EmeraldCountOverlay implements Listener {
 
     @SubscribeEvent
     public void onChestInventory(GuiOverlapEvent.ChestOverlap.DrawGuiContainerForegroundLayer e) {
-        if (!Reference.onWorld || !(UtilitiesConfig.Items.INSTANCE.emeraldCountInventory || UtilitiesConfig.Items.INSTANCE.emeraldCountChest)) return;
+        if (!Reference.onWorld || !(UtilitiesConfig.INSTANCE.emeraldCountInventory || UtilitiesConfig.INSTANCE.emeraldCountChest)) return;
 
         //For some reason they are swapped?
         IInventory container = e.getGui().getLowerInv();
@@ -63,27 +63,27 @@ public class EmeraldCountOverlay implements Listener {
 
         boolean emeraldPouch = container.getName().equals("EmeraldÀÀÀÀPouchÀ");
 
-        if (UtilitiesConfig.Items.INSTANCE.emeraldCountText) {
-            if (UtilitiesConfig.Items.INSTANCE.emeraldCountChest)
+        if (UtilitiesConfig.INSTANCE.emeraldCountText) {
+            if (UtilitiesConfig.INSTANCE.emeraldCountChest)
                 drawTextMoneyAmount(170, 5, ItemUtils.countMoney(container), renderer, textColor);
-            if (UtilitiesConfig.Items.INSTANCE.emeraldCountInventory)
+            if (UtilitiesConfig.INSTANCE.emeraldCountInventory)
                 drawTextMoneyAmount(170, 2 * (container.getSizeInventory() + 10), ItemUtils.countMoney(inventory), renderer, textColor);
             return;
         }
 
-        if (UtilitiesConfig.Items.INSTANCE.emeraldCountChest)
+        if (UtilitiesConfig.INSTANCE.emeraldCountChest)
             drawIconsMoneyAmount(178, 0, ItemUtils.countMoney(container), renderer);
-        if (UtilitiesConfig.Items.INSTANCE.emeraldCountInventory && !emeraldPouch)
+        if (UtilitiesConfig.INSTANCE.emeraldCountInventory && !emeraldPouch)
             drawIconsMoneyAmount(178, 2 * (container.getSizeInventory() + 10), ItemUtils.countMoney(inventory), renderer);
     }
 
     @SubscribeEvent
     public void onChestInventory(GuiOverlapEvent.HorseOverlap.DrawGuiContainerForegroundLayer e) {
-        if (!Reference.onWorld || !UtilitiesConfig.Items.INSTANCE.emeraldCountInventory) return;
+        if (!Reference.onWorld || !UtilitiesConfig.INSTANCE.emeraldCountInventory) return;
 
         IInventory lowerInv = e.getGui().getLowerInv();
 
-        if (UtilitiesConfig.Items.INSTANCE.emeraldCountText) {
+        if (UtilitiesConfig.INSTANCE.emeraldCountText) {
             drawTextMoneyAmount(170, 7, ItemUtils.countMoney(lowerInv), renderer, textColor);
             return;
         }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/EmeraldCountOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/EmeraldCountOverlay.java
@@ -45,7 +45,7 @@ public class EmeraldCountOverlay implements Listener {
         if (!Reference.onWorld || !UtilitiesConfig.Items.INSTANCE.emeraldCountInventory) return;
 
         if (UtilitiesConfig.Items.INSTANCE.emeraldCountText) {
-            drawTextMoneyAmount(170, 7, PlayerInfo.get(InventoryData.class).getMoney(), renderer, textColor);
+            drawTextMoneyAmount(170, -10, PlayerInfo.get(InventoryData.class).getMoney(), renderer, CommonColors.WHITE);
             return;
         }
         drawIconsMoneyAmount(178, 0, PlayerInfo.get(InventoryData.class).getMoney(), renderer);
@@ -55,22 +55,29 @@ public class EmeraldCountOverlay implements Listener {
     public void onChestInventory(GuiOverlapEvent.ChestOverlap.DrawGuiContainerForegroundLayer e) {
         if (!Reference.onWorld || !(UtilitiesConfig.Items.INSTANCE.emeraldCountInventory || UtilitiesConfig.Items.INSTANCE.emeraldCountChest)) return;
 
-        IInventory lowerInv = e.getGui().getLowerInv();
-        if (lowerInv.getName().contains("Quests") || lowerInv.getName().contains("points")) return;
+        //For some reason they are swapped?
+        IInventory container = e.getGui().getLowerInv();
+        if (container.getName().contains("Quests") || container.getName().contains("points")) return;
 
-        IInventory upperInv = e.getGui().getUpperInv();
+        IInventory inventory = e.getGui().getUpperInv();
+
+        boolean emeraldPouch = container.getName().equals("EmeraldÀÀÀÀPouchÀ");
 
         if (UtilitiesConfig.Items.INSTANCE.emeraldCountText) {
-            if (UtilitiesConfig.Items.INSTANCE.emeraldCountInventory)
-                drawTextMoneyAmount(170, -10, ItemUtils.countMoney(lowerInv), renderer, CommonColors.WHITE);
             if (UtilitiesConfig.Items.INSTANCE.emeraldCountChest)
-                drawTextMoneyAmount(170, 2 * (lowerInv.getSizeInventory() + 10), ItemUtils.countMoney(upperInv), renderer, textColor);
+                drawTextMoneyAmount(170, 5, ItemUtils.countMoney(container), renderer, textColor);
+            if (UtilitiesConfig.Items.INSTANCE.emeraldCountInventory)
+                drawTextMoneyAmount(170, 2 * (container.getSizeInventory() + 10), ItemUtils.countMoney(inventory), renderer, textColor);
             return;
         }
+        if (UtilitiesConfig.Items.INSTANCE.emeraldCountChest) {
+            if (!emeraldPouch)
+                drawIconsMoneyAmount(178, 2 * (container.getSizeInventory() + 10), ItemUtils.countMoney(inventory), renderer);
+            else
+                drawIconsMoneyAmount(202, 0, ItemUtils.countMoney(inventory), renderer);
+        }
         if (UtilitiesConfig.Items.INSTANCE.emeraldCountInventory)
-            drawIconsMoneyAmount(178, 0, ItemUtils.countMoney(lowerInv), renderer);
-        if (UtilitiesConfig.Items.INSTANCE.emeraldCountChest)
-            drawIconsMoneyAmount(178, 2 * (lowerInv.getSizeInventory() + 10), ItemUtils.countMoney(upperInv), renderer);
+            drawIconsMoneyAmount(178, 0, ItemUtils.countMoney(container), renderer);
     }
 
     @SubscribeEvent

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/EmeraldCountOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/EmeraldCountOverlay.java
@@ -57,21 +57,25 @@ public class EmeraldCountOverlay implements Listener {
 
         //For some reason they are swapped?
         IInventory container = e.getGui().getLowerInv();
-        if (container.getName().contains("Quests") || container.getName().contains("points")) return;
+        String containerName = container.getName();
+        if (containerName.contains("Quests") || containerName.contains("points")) return;
 
         IInventory inventory = e.getGui().getUpperInv();
 
-        boolean emeraldPouch = container.getName().equals("EmeraldÀÀÀÀPouchÀ");
+        boolean emeraldPouch = containerName.equals("EmeraldÀÀÀÀPouchÀ");
+
+        //List of containers that should not have their emerald count rendered
+        boolean shouldContainerRenderEmeraldCount = !containerName.equals("Trade Market") && !containerName.equals("Trade Overview") && !containerName.equals("Search Results") && !containerName.endsWith("Filter Items");
 
         if (UtilitiesConfig.INSTANCE.emeraldCountText) {
-            if (UtilitiesConfig.INSTANCE.emeraldCountChest)
+            if (UtilitiesConfig.INSTANCE.emeraldCountChest && shouldContainerRenderEmeraldCount)
                 drawTextMoneyAmount(170, 5, ItemUtils.countMoney(container), renderer, textColor);
             if (UtilitiesConfig.INSTANCE.emeraldCountInventory)
                 drawTextMoneyAmount(170, 2 * (container.getSizeInventory() + 10), ItemUtils.countMoney(inventory), renderer, textColor);
             return;
         }
 
-        if (UtilitiesConfig.INSTANCE.emeraldCountChest)
+        if (UtilitiesConfig.INSTANCE.emeraldCountChest && shouldContainerRenderEmeraldCount)
             drawIconsMoneyAmount(178, 0, ItemUtils.countMoney(container), renderer);
         if (UtilitiesConfig.INSTANCE.emeraldCountInventory && !emeraldPouch)
             drawIconsMoneyAmount(178, 2 * (container.getSizeInventory() + 10), ItemUtils.countMoney(inventory), renderer);

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/EmeraldCountOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/EmeraldCountOverlay.java
@@ -70,14 +70,11 @@ public class EmeraldCountOverlay implements Listener {
                 drawTextMoneyAmount(170, 2 * (container.getSizeInventory() + 10), ItemUtils.countMoney(inventory), renderer, textColor);
             return;
         }
-        if (UtilitiesConfig.Items.INSTANCE.emeraldCountChest) {
-            if (!emeraldPouch)
-                drawIconsMoneyAmount(178, 2 * (container.getSizeInventory() + 10), ItemUtils.countMoney(inventory), renderer);
-            else
-                drawIconsMoneyAmount(202, 0, ItemUtils.countMoney(inventory), renderer);
-        }
-        if (UtilitiesConfig.Items.INSTANCE.emeraldCountInventory)
+
+        if (UtilitiesConfig.Items.INSTANCE.emeraldCountChest)
             drawIconsMoneyAmount(178, 0, ItemUtils.countMoney(container), renderer);
+        if (UtilitiesConfig.Items.INSTANCE.emeraldCountInventory && !emeraldPouch)
+            drawIconsMoneyAmount(178, 2 * (container.getSizeInventory() + 10), ItemUtils.countMoney(inventory), renderer);
     }
 
     @SubscribeEvent


### PR DESCRIPTION
List of included fixes:
- Changed variable names to be clearer (`lowerInventory `-> `container`, `upperInventory `-> `inventory`) as they were confusing (because they are swapped for some reason?)
- Fixed problems when Emerald Count Overlay was in text mode:
  - When in player inventory, emerald count text renders in the correct place, not overlapping with the crafting menu text:
    - Old behaviour: ![image](https://user-images.githubusercontent.com/49001742/147821552-c79be2b3-8774-486a-af60-b23f15b91c8c.png)
    - Fixed version: ![image](https://user-images.githubusercontent.com/49001742/147821581-a785b297-b533-4baa-8b9b-5051c3b7ab52.png)
 - When in a container, emrald count text renders in the correct place:
   - Old (dont mind the red square, its just paint): ![image](https://user-images.githubusercontent.com/49001742/147821628-442cbba5-51b6-40d9-a223-7051c6d369e3.png)
   - Fixed: ![image](https://user-images.githubusercontent.com/49001742/147821654-7b0b9164-514f-476f-bf13-02daffb52bb1.png)
   - **This causes a lot of problems with gui texts overlapping, to fix, a check was added to count the emeralds in the container, if its less then 0, don't render at all. This also removes emerald count from almost all guis where it's irrelevant.**
- Fixed problems when Emerald Count Overlay is in normal, icon mode:
  - When having an emerald pouch open, only render the pouch's emerald count icons, fixes #386
    - ![image](https://user-images.githubusercontent.com/49001742/147821727-69ab31b8-0ccc-4f09-9ae8-bb083d338f83.png)

- Moved Emerald Count Overlay settings to the general Utilies settings tab, from Item Highlights, as it is a more fitting place for it

