### PR TITLE
Spellcasting by hotkeys is greatly improved

### DIFF
--- a/src/main/java/com/wynntils/core/framework/instances/data/ActionBarData.java
+++ b/src/main/java/com/wynntils/core/framework/instances/data/ActionBarData.java
@@ -61,6 +61,8 @@ public class ActionBarData extends PlayerData {
 
                     spellData.setLastSpell(lastSpell, McIf.player().inventory.currentItem);
                 }
+                else if (spellData.getLastSpell() != SpellData.NO_SPELL)
+                    spellData.setLastSpell(SpellData.NO_SPELL, -1);
             }
         }
 

--- a/src/main/java/com/wynntils/core/framework/instances/data/ActionBarData.java
+++ b/src/main/java/com/wynntils/core/framework/instances/data/ActionBarData.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.core.framework.instances.data;
 
+import com.wynntils.McIf;
 import com.wynntils.core.framework.enums.ClassType;
 import com.wynntils.core.framework.instances.containers.PlayerData;
 import com.wynntils.core.utils.StringUtils;
@@ -58,7 +59,7 @@ public class ActionBarData extends PlayerData {
                         lastSpell[i] = match.group(i + 3).charAt(0) == 'R' ? SpellData.SPELL_RIGHT : SpellData.SPELL_LEFT;
                     }
 
-                    spellData.setLastSpell(lastSpell);
+                    spellData.setLastSpell(lastSpell, McIf.player().inventory.currentItem);
                 }
             }
         }

--- a/src/main/java/com/wynntils/core/framework/instances/data/SpellData.java
+++ b/src/main/java/com/wynntils/core/framework/instances/data/SpellData.java
@@ -22,7 +22,7 @@ public class SpellData extends PlayerData {
 
     private static final Pattern LEVEL_1_SPELL_PATTERN = Pattern.compile("^(Left|Right|\\?)-(Left|Right|\\?)-(Left|Right|\\?)$");
     private static final Pattern LOW_LEVEL_SPELL_PATTERN = Pattern.compile("^([LR?])-([LR?])-([LR?])$");
-    private static final boolean[] NO_SPELL = new boolean[0];
+    public static final boolean[] NO_SPELL = new boolean[0];
 
     /** Represents `L` in the currently casting spell */
     public static final boolean SPELL_LEFT = false;
@@ -31,14 +31,10 @@ public class SpellData extends PlayerData {
 
     private String lastParsedTitle = null;
     private boolean[] lastSpell = NO_SPELL;
-    private int lastSpellWeaponSlot = -1;
+    public int lastSpellWeaponSlot = -1;
 
     public SpellData() {
-        FrameworkManager.getEventBus().register(this);
-    }
 
-    protected void finalize() {
-        FrameworkManager.getEventBus().unregister(this);
     }
 
     public boolean[] parseSpellFromTitle(String subtitle) {
@@ -88,23 +84,11 @@ public class SpellData extends PlayerData {
             return parseSpellFromTitle(subtitle);
         }
 
-
         return lastSpell;
     }
 
     public void setLastSpell(boolean[] lastSpell, int heldItemSlot) {
         this.lastSpell = lastSpell;
         this.lastSpellWeaponSlot = heldItemSlot;
-    }
-
-    //Make sure we don't get into a stuck phase where spells can't be cast until the player casts one manually
-    @SubscribeEvent
-    public void onWeaponChange(PacketEvent<CPacketHeldItemChange> e) {
-        if (!Reference.onWorld) return;
-
-        if (e.getPacket().getSlotId() != this.lastSpellWeaponSlot) {
-            this.lastSpellWeaponSlot = -1;
-            this.lastSpell = NO_SPELL;
-        }
     }
 }

--- a/src/main/java/com/wynntils/core/framework/instances/data/SpellData.java
+++ b/src/main/java/com/wynntils/core/framework/instances/data/SpellData.java
@@ -5,9 +5,15 @@
 package com.wynntils.core.framework.instances.data;
 
 import com.wynntils.McIf;
+import com.wynntils.Reference;
+import com.wynntils.core.events.custom.PacketEvent;
+import com.wynntils.core.framework.FrameworkManager;
 import com.wynntils.core.framework.instances.containers.PlayerData;
 import com.wynntils.core.utils.reflections.ReflectionFields;
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.play.client.CPacketHeldItemChange;
 import net.minecraft.util.text.TextFormatting;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -25,8 +31,15 @@ public class SpellData extends PlayerData {
 
     private String lastParsedTitle = null;
     private boolean[] lastSpell = NO_SPELL;
+    private int lastSpellWeaponSlot = -1;
 
-    public SpellData() { }
+    public SpellData() {
+        FrameworkManager.getEventBus().register(this);
+    }
+
+    protected void finalize() {
+        FrameworkManager.getEventBus().unregister(this);
+    }
 
     public boolean[] parseSpellFromTitle(String subtitle) {
         // Level 1: Left-Right-? in subtitle
@@ -37,6 +50,7 @@ public class SpellData extends PlayerData {
 
         lastParsedTitle = subtitle;
         if (subtitle.isEmpty()) {
+            lastSpellWeaponSlot = -1;
             return (lastSpell = NO_SPELL);
         }
 
@@ -52,6 +66,8 @@ public class SpellData extends PlayerData {
         if (m.group(3).equals("?")) return (lastSpell = new boolean[]{ spell1, spell2 });
 
         boolean spell3 = m.group(3).equals(right) ? SPELL_RIGHT : SPELL_LEFT;
+
+        lastSpellWeaponSlot = McIf.player().inventory.currentItem;
         return (lastSpell = new boolean[]{ spell1, spell2, spell3 });
     }
 
@@ -72,11 +88,24 @@ public class SpellData extends PlayerData {
             return parseSpellFromTitle(subtitle);
         }
 
+
         return lastSpell;
     }
 
-    public void setLastSpell(boolean[] lastSpell) {
+    public void setLastSpell(boolean[] lastSpell, int heldItemSlot) {
         this.lastSpell = lastSpell;
+        this.lastSpellWeaponSlot = heldItemSlot;
     }
 
+    //Make sure we don't get into a stuck phase where spells can't be cast until the player casts one manually
+    @SubscribeEvent
+    public void onWeaponChange(PacketEvent<CPacketHeldItemChange> e) {
+        if (!Reference.onWorld) return;
+
+        if (e.getPacket().getSlotId() != this.lastSpellWeaponSlot) {
+            System.out.println("Weapon changed");
+            this.lastSpellWeaponSlot = -1;
+            this.lastSpell = NO_SPELL;
+        }
+    }
 }

--- a/src/main/java/com/wynntils/core/framework/instances/data/SpellData.java
+++ b/src/main/java/com/wynntils/core/framework/instances/data/SpellData.java
@@ -103,7 +103,6 @@ public class SpellData extends PlayerData {
         if (!Reference.onWorld) return;
 
         if (e.getPacket().getSlotId() != this.lastSpellWeaponSlot) {
-            System.out.println("Weapon changed");
             this.lastSpellWeaponSlot = -1;
             this.lastSpell = NO_SPELL;
         }

--- a/src/main/java/com/wynntils/modules/core/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/core/events/ClientEvents.java
@@ -16,6 +16,7 @@ import com.wynntils.core.framework.enums.professions.ProfessionType;
 import com.wynntils.core.framework.instances.PlayerInfo;
 import com.wynntils.core.framework.instances.data.ActionBarData;
 import com.wynntils.core.framework.instances.data.CharacterData;
+import com.wynntils.core.framework.instances.data.SpellData;
 import com.wynntils.core.framework.interfaces.Listener;
 import com.wynntils.core.utils.ItemUtils;
 import com.wynntils.core.utils.Utils;
@@ -34,6 +35,7 @@ import com.wynntils.modules.core.overlays.inventories.InventoryReplacer;
 import com.wynntils.modules.utilities.UtilitiesModule;
 import com.wynntils.modules.utilities.managers.KillsManager;
 import com.wynntils.modules.utilities.managers.LevelingManager;
+import com.wynntils.modules.utilities.managers.QuickCastManager;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.gui.GuiIngameMenu;
@@ -525,6 +527,29 @@ public class ClientEvents implements Listener {
     @SubscribeEvent
     public void onWeaponChange(PacketEvent<CPacketHeldItemChange> e) {
         totemTracker.onWeaponChange(e);
+
+        //Make sure we don't get into a stuck phase where spells can't be cast until the player casts one manually
+        if (!Reference.onWorld) return;
+
+        SpellData spellData = PlayerInfo.get(SpellData.class);
+
+        if (spellData == null) return;
+
+        if (e.getPacket().getSlotId() != spellData.lastSpellWeaponSlot) {
+            spellData.setLastSpell(SpellData.NO_SPELL, -1);
+        }
     }
 
+
+    @SubscribeEvent
+    public void onClassChange(WynnClassChangeEvent e) {
+        if (!Reference.onWorld) return;
+
+        SpellData spellData = PlayerInfo.get(SpellData.class);
+
+        if (spellData == null) return;
+
+        spellData.setLastSpell(SpellData.NO_SPELL, -1);
+        QuickCastManager.spellInProgress = QuickCastManager.NO_SPELL;
+    }
 }

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -1353,13 +1353,4 @@ public class ClientEvents implements Listener {
         nbt.setIntArray("originalItems", originalSlots);
         ItemUtils.replaceLore(itemStack, groupedItemLore);
     }
-
-    //If we successfully casted the last part of the spell, reset the boolean, allowing the keybind to cast spells again
-    @SubscribeEvent
-    public void onSpellCast(SpellEvent.Cast e) {
-        String spell = e.getSpell();
-        System.out.println("Casted: " + spell);
-        //TODO: Check if this is the correct spell before reset
-        QuickCastManager.spellInProgress = QuickCastManager.NO_SPELL;
-    }
 }

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -1353,4 +1353,13 @@ public class ClientEvents implements Listener {
         nbt.setIntArray("originalItems", originalSlots);
         ItemUtils.replaceLore(itemStack, groupedItemLore);
     }
+
+    //If we successfully casted the last part of the spell, reset the boolean, allowing the keybind to cast spells again
+    @SubscribeEvent
+    public void onSpellCast(SpellEvent.Cast e) {
+        String spell = e.getSpell();
+        System.out.println("Casted: " + spell);
+        //TODO: Check if this is the correct spell before reset
+        QuickCastManager.spellInProgress = QuickCastManager.NO_SPELL;
+    }
 }

--- a/src/main/java/com/wynntils/modules/utilities/managers/QuickCastManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/QuickCastManager.java
@@ -193,7 +193,7 @@ public class QuickCastManager {
 
         if (notReachedSpellPointRequirements != null) {
             McIf.player().sendMessage(new TextComponentString(
-                    TextFormatting.GRAY + "The current class does not have enough " + notReachedSpellPointRequirements + " to use the held weapon."
+                    TextFormatting.GRAY + "The current class does not have enough " + notReachedSpellPointRequirements + " assigned to use the held weapon."
             ));
             return false;
         }

--- a/src/main/java/com/wynntils/modules/utilities/managers/QuickCastManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/QuickCastManager.java
@@ -13,7 +13,6 @@ import com.wynntils.core.framework.instances.data.CharacterData;
 import com.wynntils.core.framework.instances.data.SpellData;
 import com.wynntils.core.utils.ItemUtils;
 import com.wynntils.modules.core.managers.PacketQueue;
-import net.minecraft.client.Minecraft;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.Packet;
 import net.minecraft.network.play.client.CPacketAnimation;
@@ -28,6 +27,10 @@ import net.minecraft.util.text.ChatType;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraft.util.text.TextFormatting;
 
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import static com.wynntils.core.framework.instances.data.SpellData.SPELL_LEFT;
 import static com.wynntils.core.framework.instances.data.SpellData.SPELL_RIGHT;
 
@@ -38,6 +41,11 @@ public class QuickCastManager {
     private static final CPacketPlayerDigging releaseClick = new CPacketPlayerDigging(CPacketPlayerDigging.Action.RELEASE_USE_ITEM, BlockPos.ORIGIN, EnumFacing.DOWN);
 
     private static final int[] spellUnlock = { 1, 11, 21, 31 };
+
+    private static final Pattern WEAPON_SPEED_PATTERN = Pattern.compile("§7.+ Attack Speed");
+    private static final Pattern CLASS_REQ_OK_PATTERN = Pattern.compile("§a✔§7 Class Req:.+");
+    private static final Pattern COMBAT_LVL_REQ_OK_PATTERN = Pattern.compile("§a✔§7 Combat Lv. Min:.+");
+    private static final Pattern SPELL_POINT_MIN_NOT_REACHED_PATTERN = Pattern.compile("§c✖§7 (.+) Min: (\\d+)");
 
     private static void queueSpell(int spellNumber, boolean a, boolean b, boolean c) {
         if (!canCastSpell(spellNumber)) return;
@@ -51,7 +59,6 @@ public class QuickCastManager {
     }
 
     public static void castFirstSpell() {
-        if (!ItemUtils.getStringLore(McIf.player().getHeldItemMainhand()).contains("§7 Class Req:")) return;
         if (PlayerInfo.get(CharacterData.class).getCurrentClass() == ClassType.ARCHER) {
             queueSpell(1, SPELL_LEFT, SPELL_RIGHT, SPELL_LEFT);
             return;
@@ -61,7 +68,6 @@ public class QuickCastManager {
     }
 
     public static void castSecondSpell() {
-        if (!ItemUtils.getStringLore(McIf.player().getHeldItemMainhand()).contains("§7 Class Req:")) return;
         if (PlayerInfo.get(CharacterData.class).getCurrentClass() == ClassType.ARCHER) {
             queueSpell(2, SPELL_LEFT, SPELL_LEFT, SPELL_LEFT);
             return;
@@ -71,7 +77,6 @@ public class QuickCastManager {
     }
 
     public static void castThirdSpell() {
-        if (!ItemUtils.getStringLore(McIf.player().getHeldItemMainhand()).contains("§7 Class Req:")) return;
         if (PlayerInfo.get(CharacterData.class).getCurrentClass() == ClassType.ARCHER) {
             queueSpell(3, SPELL_LEFT, SPELL_RIGHT, SPELL_RIGHT);
             return;
@@ -81,7 +86,6 @@ public class QuickCastManager {
     }
 
     public static void castFourthSpell() {
-        if (!ItemUtils.getStringLore(McIf.player().getHeldItemMainhand()).contains("§7 Class Req:")) return;
         if (PlayerInfo.get(CharacterData.class).getCurrentClass() == ClassType.ARCHER) {
             queueSpell(4, SPELL_LEFT, SPELL_LEFT, SPELL_RIGHT);
             return;
@@ -98,6 +102,91 @@ public class QuickCastManager {
         if (PlayerInfo.get(CharacterData.class).getLevel() < spellUnlock[spell - 1]) {
             McIf.player().sendMessage(new TextComponentString(
                     TextFormatting.GRAY + "You have not yet unlocked this spell! You need to be level " + spellUnlock[spell - 1]
+            ));
+            return false;
+        }
+
+        if (PlayerInfo.get(CharacterData.class).getCurrentMana() == 0) {
+            McIf.player().sendMessage(new TextComponentString(
+                    TextFormatting.GRAY + "You do not have enough mana to cast this spell!"
+            ));
+            return false;
+        }
+
+        ItemStack heldItem = McIf.player().getHeldItemMainhand();
+
+        List<String> lore = ItemUtils.getLore(heldItem);
+
+        //If item has attack speed line, it is a weapon
+        boolean isWeapon = false;
+        //Check class reqs to see if the weapon can be used by current class
+        boolean classReqOk = false;
+        //Is the current combat level enough to use the weapon
+        boolean combatLvlMinReached = false;
+        //If there is a spell point requirement that is not reached, store it and print it later
+        String notReachedSpellPointRequirements = null;
+
+        int i = 0;
+        for (; i < lore.size(); i++) {
+            if (WEAPON_SPEED_PATTERN.matcher(lore.get(i)).matches())
+            {
+                isWeapon = true;
+                break;
+            }
+        }
+
+        if (!isWeapon)
+        {
+            McIf.player().sendMessage(new TextComponentString(
+                    TextFormatting.GRAY + "The held item is not a weapon."
+            ));
+            return false;
+        }
+
+        for (; i < lore.size(); i++) {
+            if (CLASS_REQ_OK_PATTERN.matcher(lore.get(i)).matches())
+            {
+                classReqOk = true;
+                break;
+            }
+        }
+
+        if (!classReqOk)
+        {
+            McIf.player().sendMessage(new TextComponentString(
+                    TextFormatting.GRAY + "The held weapon is not for this class."
+            ));
+            return false;
+        }
+
+        for (; i < lore.size(); i++) {
+            if (COMBAT_LVL_REQ_OK_PATTERN.matcher(lore.get(i)).matches())
+            {
+                combatLvlMinReached = true;
+                break;
+            }
+        }
+
+        if (!combatLvlMinReached)
+        {
+            McIf.player().sendMessage(new TextComponentString(
+                    TextFormatting.GRAY + "The current class level is too low to use the held weapon."
+            ));
+            return false;
+        }
+
+        for (; i < lore.size(); i++) {
+            Matcher matcher = SPELL_POINT_MIN_NOT_REACHED_PATTERN.matcher(lore.get(i));
+            if (matcher.matches())
+            {
+                notReachedSpellPointRequirements = matcher.group(1);
+                break;
+            }
+        }
+
+        if (notReachedSpellPointRequirements != null) {
+            McIf.player().sendMessage(new TextComponentString(
+                    TextFormatting.GRAY + "The current class does not have enough "+notReachedSpellPointRequirements+" to use the held weapon."
             ));
             return false;
         }

--- a/src/main/java/com/wynntils/modules/utilities/managers/QuickCastManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/QuickCastManager.java
@@ -231,8 +231,17 @@ public class QuickCastManager {
 
         boolean successful = pos < spell.length && spell[pos] == clickType;
 
-        //If we successfully casted the last part of the spell, reset the boolean, allowing the keybind to cast spells again
-        if (successful && pos == 2) {
+        //If we sent the last part of the spell, reset the boolean, allowing the keybind to cast spells again
+        /*
+        Bolyai:
+        This might not be 100% safe without checking if successful is true,
+        as user interference during spell casting happens and we need to reset spellInProgress or it will get stuck,
+        this case it should be fine, as there are other checks to make sure we don't spam spells.
+
+        If spell casting is still very spammy, the if statement below should be changed to: if ((successful && pos == 2) || isThisLastResend)
+        isThisLastResend should be true if PacketResponse's tries >= maxTries (or by simply counting retries and assuming maxTries was not changed).
+        */
+        if (pos == 2) {
             spellInProgress = NO_SPELL;
         }
         return successful;


### PR DESCRIPTION
List of changes and fixes:
- Added checks to make sure the currently held item can be used for casting spells:
  - Check if the currently held item is a weapon
  - Check if the class' level is high enough to use it
  - Check if the class type is the correct one to use the weapon
  - Check if the class has all necessary spell points assigned to use the weapon
- Added safeguards in the case when the spell cast hotkeys are spammed/run in repetition:
  - `QuickCastManager` does not allow queueing spells if there is one already queued, but yet to be executed
- If the player starts casting a spell, but does not finish it, then presses a spell cast keybinding, the spell will not try to cast, causing unintentional spell casts and attacks (and the `PacketQueue` will not try to resend the packets, causing spam).

EDIT: Added a change, if there is a spell casting in progress by the player, but then a keybind is pressed, it will try to finish the spell. For more info scroll below.

If any of these checks fail, the user will receive a chat message stating the fail condition (the first one that fails the checks).

![image](https://user-images.githubusercontent.com/49001742/147842489-05b46b6f-271a-42c2-8aa3-be2565bef0bb.png)
![image](https://user-images.githubusercontent.com/49001742/147842499-99b4b041-b6b0-4993-abea-f45ff4679560.png)
![image](https://user-images.githubusercontent.com/49001742/147842501-c6b53245-22c0-4edf-bdbb-515ca192460f.png)
![image](https://user-images.githubusercontent.com/49001742/147842504-0484760c-5a90-4a87-9f43-3e5a1b0b9b7b.png)

