### PR TITLE
Additional check to make sure the current chest is not a bank page when checking for mythic found

### DIFF
--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -1123,24 +1123,25 @@ public class ClientEvents implements Listener {
             lastOpenedRewardWindowId = e.getPacket().getWindowId();
     }
 
-    //Dry streak counter, mythic music event
+    // Dry streak counter, mythic music event
     @SubscribeEvent
     public void onMythicFound(PacketEvent<SPacketWindowItems> e) {
         if (lastOpenedChestWindowId != e.getPacket().getWindowId() && lastOpenedRewardWindowId != e.getPacket().getWindowId()) return;
 
-        //Get items in chest, return if there is not enough items
-        if (e.getPacket().getItemStacks().size() < 27)
+        // Get items in chest, return if there is not enough or too many items
+        // 63 is the size of a chest (27) + player inventory
+        if (e.getPacket().getItemStacks().size() != 63)
             return;
 
-        //Only run at first time we get items, don't care about updating
+        // Only run at first time we get items, don't care about updating
         if (e.getPacket().getWindowId() == lastProcessedOpenedChest) return;
 
         lastProcessedOpenedChest = e.getPacket().getWindowId();
 
-        //Dry streak counter and sound sfx
+        // Dry streak counter and sound sfx
         if (UtilitiesConfig.INSTANCE.enableDryStreak && lastOpenedChestWindowId == e.getPacket().getWindowId()) {
             boolean foundMythic = false;
-            //Size should be at least 27, checked for it earlier
+            // Size should be at least 27, checked for it earlier
             int size = 27;
             for (int i = 0; i < size; i++) {
                 ItemStack stack = e.getPacket().getItemStacks().get(i);
@@ -1183,10 +1184,10 @@ public class ClientEvents implements Listener {
             return;
         }
 
-        //Mythic found sfx for daily rewards and objective rewards
+        // Mythic found sfx for daily rewards and objective rewards
         if (!MusicConfig.SoundEffects.INSTANCE.mythicFound) return;
 
-        //Size should be at least 27, checked for it earlier
+        // Size should be at least 27, checked for it earlier
         int size = 27;
         for (int i = 0; i < size; i++) {
             ItemStack stack = e.getPacket().getItemStacks().get(i);


### PR DESCRIPTION
User submitted screenshot, seems like a bank page was detected as a loot chest or some kind of reward chest. To prevent this from happening, added a check to allow only inventories with exact size (63 = inventory size + chest size) to be checked for mythics.

![image](https://user-images.githubusercontent.com/49001742/147885671-c383b114-b9b9-4acd-a164-45d10dfd7a1c.png)
