### PR TITLE
Dialogue and chat improvements

### DIFF
--- a/src/main/java/com/wynntils/modules/chat/configs/ChatConfig.java
+++ b/src/main/java/com/wynntils/modules/chat/configs/ChatConfig.java
@@ -83,6 +83,9 @@ public class ChatConfig extends SettingsClass {
     @Setting(displayName = "Clickable Duel Requests", description = "Should duel requests provide a clickable command?", order = 19)
     public boolean clickableDuelMessage = true;
 
+    @Setting(displayName = "Right Click for Dialogue", description = "Should dialogue progress when you right click the NPC?\n\n§8This may not work on every NPC.", order = 20)
+    public boolean rightClickDialogue = false;
+
     public enum Presets {
         a,
         b,

--- a/src/main/java/com/wynntils/modules/chat/configs/ChatConfig.java
+++ b/src/main/java/com/wynntils/modules/chat/configs/ChatConfig.java
@@ -77,14 +77,8 @@ public class ChatConfig extends SettingsClass {
     @Setting(displayName = "Use brackets for translation", description = "Should text be translated to Wynnic and Gavellian using a button or curly brackets for Wynnic and angle brackets for gavellian?", order = 15)
     public boolean useBrackets = false;
 
-    @Setting(displayName = "Clickable Party Invites", description = "Should party invites provide a clickable command?", order = 16)
-    public boolean clickablePartyInvites = true;
-
     @Setting(displayName = "Clickable Coordinates", description = "Should coordinates that are displayed in chat be clickable as a '/compass' command?", order = 17)
     public boolean clickableCoordinates = true;
-
-    @Setting(displayName = "Clickable Trade Requests", description = "Should trade requests provide a clickable command?", order = 18)
-    public boolean clickableTradeMessage = true;
 
     @Setting(displayName = "Clickable Duel Requests", description = "Should duel requests provide a clickable command?", order = 19)
     public boolean clickableDuelMessage = true;

--- a/src/main/java/com/wynntils/modules/chat/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/chat/events/ClientEvents.java
@@ -144,8 +144,6 @@ public class ClientEvents implements Listener {
         }
     }
 
-    private boolean outgoingSneak = false;
-
     @SubscribeEvent
     public void onClickNPC(PacketEvent<CPacketUseEntity> e) {
         if (!ChatConfig.INSTANCE.rightClickDialogue) return;
@@ -159,23 +157,7 @@ public class ClientEvents implements Listener {
         String name = clicked.getName();
         if (!name.contains("NPC") && !name.contains("\u0001")) return; // (probably) not an NPC
 
-        if (outgoingSneak) return;
-        outgoingSneak = true; // stop multiple packets from being sent at once
-
-        // send the sneak packet, then stop sneaking once the dialogue progresses
-        CPacketEntityAction sneakPacket = new CPacketEntityAction(player, CPacketEntityAction.Action.START_SNEAKING);
-        PacketQueue.queueComplexPacket(sneakPacket, SPacketCustomSound.class, p -> verifyDialogue(((SPacketCustomSound) p)));
-    }
-
-    private boolean verifyDialogue(SPacketCustomSound p) {
-        boolean success = p.getSoundName().equals("block.lava.pop"); // dialogue progression sound
-        if (success) {
-            outgoingSneak = false;
-            // immediately send the unsneak packet, no need to queue it
-            CPacketEntityAction unsneakPacket = new CPacketEntityAction(McIf.player(), CPacketEntityAction.Action.STOP_SNEAKING);
-            McIf.mc().getConnection().sendPacket(unsneakPacket);
-        }
-        return success;
+        ChatManager.progressDialogue();
     }
 
 }

--- a/src/main/java/com/wynntils/modules/chat/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/chat/events/ClientEvents.java
@@ -6,10 +6,12 @@ package com.wynntils.modules.chat.events;
 
 import com.wynntils.McIf;
 import com.wynntils.Reference;
+import com.wynntils.core.events.custom.PacketEvent;
 import com.wynntils.core.events.custom.WynnClassChangeEvent;
 import com.wynntils.core.events.custom.WynnWorldEvent;
 import com.wynntils.core.events.custom.WynncraftServerEvent;
 import com.wynntils.core.framework.interfaces.Listener;
+import com.wynntils.core.utils.ItemUtils;
 import com.wynntils.core.utils.objects.Pair;
 import com.wynntils.core.utils.reflections.ReflectionFields;
 import com.wynntils.modules.chat.configs.ChatConfig;
@@ -17,10 +19,20 @@ import com.wynntils.modules.chat.managers.ChatManager;
 import com.wynntils.modules.chat.managers.HeldItemChatManager;
 import com.wynntils.modules.chat.overlays.ChatOverlay;
 import com.wynntils.modules.chat.overlays.gui.ChatGUI;
+import com.wynntils.modules.core.managers.PacketQueue;
 import com.wynntils.modules.questbook.enums.AnalysePosition;
 import com.wynntils.modules.questbook.events.custom.QuestBookUpdateEvent;
+import com.wynntils.modules.utilities.configs.UtilitiesConfig;
+import com.wynntils.webapi.profiles.item.enums.ItemType;
 import com.wynntils.webapi.services.TranslationManager;
+import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.client.gui.GuiChat;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.network.play.client.CPacketEntityAction;
+import net.minecraft.network.play.client.CPacketUseEntity;
+import net.minecraft.network.play.server.SPacketCustomSound;
+import net.minecraft.network.play.server.SPacketSoundEffect;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.client.event.ClientChatEvent;
@@ -130,6 +142,40 @@ public class ClientEvents implements Listener {
             ChatManager.setDiscoveriesLoaded(true);
             ChatOverlay.getChat().processQueues();
         }
+    }
+
+    private boolean outgoingSneak = false;
+
+    @SubscribeEvent
+    public void onClickNPC(PacketEvent<CPacketUseEntity> e) {
+        if (!ChatConfig.INSTANCE.rightClickDialogue) return;
+        if (e.getPacket().getAction() != CPacketUseEntity.Action.INTERACT) return; // only right click
+        if (!ChatManager.inDialogue) return;
+
+        EntityPlayerSP player = McIf.player();
+        Entity clicked = e.getPacket().getEntityFromWorld(player.world);
+
+        if (clicked.getTeam() != null) return; // entity is another player
+        String name = clicked.getName();
+        if (!name.contains("NPC") && !name.contains("\u0001")) return; // (probably) not an NPC
+
+        if (outgoingSneak) return;
+        outgoingSneak = true; // stop multiple packets from being sent at once
+
+        // send the sneak packet, then stop sneaking once the dialogue progresses
+        CPacketEntityAction sneakPacket = new CPacketEntityAction(player, CPacketEntityAction.Action.START_SNEAKING);
+        PacketQueue.queueComplexPacket(sneakPacket, SPacketCustomSound.class, p -> verifyDialogue(((SPacketCustomSound) p)));
+    }
+
+    private boolean verifyDialogue(SPacketCustomSound p) {
+        boolean success = p.getSoundName().equals("block.lava.pop"); // dialogue progression sound
+        if (success) {
+            outgoingSneak = false;
+            // immediately send the unsneak packet, no need to queue it
+            CPacketEntityAction unsneakPacket = new CPacketEntityAction(McIf.player(), CPacketEntityAction.Action.STOP_SNEAKING);
+            McIf.mc().getConnection().sendPacket(unsneakPacket);
+        }
+        return success;
     }
 
 }

--- a/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
+++ b/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
@@ -108,7 +108,7 @@ public class ChatManager {
 
         // timestamps
         if (ChatConfig.INSTANCE.addTimestampsToChat) {
-            addTimestamp(in);
+            in = addTimestamp(in);
         }
 
         // popup sound
@@ -984,13 +984,13 @@ public class ChatManager {
 
                 // most recent message
                 ITextComponent newMessage = siblings.get(siblings.size() - lineCount - 1);
-                // filter out info messages because they wont be caught through the normal checks
-                if (!newMessage.getUnformattedText().startsWith("[Info] ") || !ChatConfig.INSTANCE.filterWynncraftInfo) {
+                // filter out any disabled messages
+                if (ForgeEventFactory.onClientChat(ChatType.SYSTEM, newMessage) != null) {
                     if (dialogueChat == null) {
                         dialogueChat = newMessage;
                     } else {
                         if (ChatConfig.INSTANCE.addTimestampsToChat) {
-                            addTimestamp(newMessage); // add timestamps to new lines for consistency
+                            newMessage = addTimestamp(newMessage); // add timestamps to new lines for consistency
                         }
                         dialogueChat.appendSibling(newMessage);
                     }
@@ -1019,7 +1019,7 @@ public class ChatManager {
         ChatOverlay.getChat().deleteChatLine(ChatOverlay.WYNN_DIALOGUE_ID);
     }
 
-    private static void addTimestamp(ITextComponent in) {
+    private static ITextComponent addTimestamp(ITextComponent in) {
         if (dateFormat == null || !validDateFormat) {
             try {
                 dateFormat = new SimpleDateFormat(ChatConfig.INSTANCE.timestampFormat);
@@ -1029,10 +1029,10 @@ public class ChatManager {
             }
         }
 
-        List<ITextComponent> timeStamp = new ArrayList<>();
+        ITextComponent timeStamp = new TextComponentString("");
         ITextComponent startBracket = new TextComponentString("[");
         startBracket.getStyle().setColor(TextFormatting.DARK_GRAY);
-        timeStamp.add(startBracket);
+        timeStamp.appendSibling(startBracket);
         ITextComponent time;
         if (validDateFormat) {
             time = new TextComponentString(dateFormat.format(new Date()));
@@ -1041,11 +1041,13 @@ public class ChatManager {
             time = new TextComponentString("Invalid Format");
             time.getStyle().setColor(TextFormatting.RED);
         }
-        timeStamp.add(time);
+        timeStamp.appendSibling(time);
         ITextComponent endBracket = new TextComponentString("] ");
         endBracket.getStyle().setColor(TextFormatting.DARK_GRAY);
-        timeStamp.add(endBracket);
-        in.getSiblings().addAll(0, timeStamp);
+        timeStamp.appendSibling(endBracket);
+
+        timeStamp.appendSibling(in);
+        return timeStamp;
     }
 
     public static void setDiscoveriesLoaded(boolean discoveriesLoaded) {

--- a/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
+++ b/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
@@ -78,9 +78,7 @@ public class ChatManager {
     private static final String nonTranslatable = "[^a-zA-Z.!?]";
     private static final String optionalTranslatable = "[.!?]";
 
-    private static final Pattern inviteReg = Pattern.compile("((" + TextFormatting.GOLD + "|" + TextFormatting.AQUA + ")/(party|guild) join [a-zA-Z0-9._\\- ]+)");
-    private static final Pattern tradeReg = Pattern.compile("[\\w ]+ would like to trade! Type /trade [\\w ]+ to accept\\.");
-    private static final Pattern duelReg = Pattern.compile("[\\w ]+ \\[Lv\\. \\d+] would like to duel! Type /duel [\\w ]+ to accept\\.");
+    private static final Pattern duelReg = Pattern.compile("[\\w ]+ would like to duel! Type (/duel [\\w ]+) to accept\\.");
     private static final Pattern coordinateReg = Pattern.compile("(-?\\d{1,5}[ ,]{1,2})(\\d{1,3}[ ,]{1,2})?(-?\\d{1,5})");
 
     private static boolean discoveriesLoaded = false;
@@ -237,37 +235,12 @@ public class ChatManager {
             }
         }
 
-        // clickable party invites
-        if (ChatConfig.INSTANCE.clickablePartyInvites && inviteReg.matcher(McIf.getFormattedText(in)).find()) {
-            for (ITextComponent textComponent : in.getSiblings()) {
-                if (textComponent.getUnformattedComponentText().startsWith("/")) {
-                    String command = textComponent.getUnformattedComponentText();
-                    textComponent.getStyle()
-                            .setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, command))
-                            .setUnderlined(true)
-                            .setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new TextComponentString("Join!")));
-                }
-            }
-        }
-
-        // clickable trade messages
-        if (ChatConfig.INSTANCE.clickableTradeMessage && tradeReg.matcher(McIf.getUnformattedText(in)).find()) {
-            for (ITextComponent textComponent : in.getSiblings()) {
-                if (textComponent.getUnformattedComponentText().startsWith("/")) {
-                    String command = textComponent.getUnformattedComponentText();
-                    textComponent.getStyle()
-                            .setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, command))
-                            .setUnderlined(true)
-                            .setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new TextComponentString("Trade!")));
-                }
-            }
-        }
-
         // clickable duel messages
-        if (ChatConfig.INSTANCE.clickableDuelMessage && duelReg.matcher(McIf.getUnformattedText(in)).find()) {
+        Matcher duelMatcher = duelReg.matcher(McIf.getUnformattedText(in));
+        if (ChatConfig.INSTANCE.clickableDuelMessage && duelMatcher.find()) {
+            String command = duelMatcher.group(1);
             for (ITextComponent textComponent : in.getSiblings()) {
-                if (McIf.getUnformattedText(textComponent).startsWith("/")) {
-                    String command = textComponent.getUnformattedComponentText();
+                if (McIf.getUnformattedText(textComponent).contains("/duel")) {
                     textComponent.getStyle()
                             .setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, command))
                             .setUnderlined(true)

--- a/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
+++ b/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
@@ -962,12 +962,14 @@ public class ChatManager {
                 }
             }
             chat = siblings.subList(0, siblings.size() - lineCount).stream().map(McIf::getUnformattedText).collect(Collectors.joining());
+            chat = TextFormatting.getTextWithoutFormattingCodes(chat);
             chat = chat.substring(0, chat.length() - 1);
         } else if (inDialogue) {
             if (siblings.size() < lineCount) {
                 return new Pair<>(false, component);
             }
             chat = siblings.subList(0, siblings.size() - lineCount).stream().map(McIf::getUnformattedText).collect(Collectors.joining());
+            chat = TextFormatting.getTextWithoutFormattingCodes(chat);
             if (!chat.isEmpty()) chat = chat.substring(0, chat.length() - 1);
             dialogue = new ArrayList<>(siblings.subList(siblings.size() - lineCount, siblings.size()));
             if (!chat.equals(lastChat) && !dialogue.equals(last)) {

--- a/src/main/java/com/wynntils/modules/chat/overlays/ChatOverlay.java
+++ b/src/main/java/com/wynntils/modules/chat/overlays/ChatOverlay.java
@@ -159,13 +159,13 @@ public class ChatOverlay extends GuiNewChat {
 
         Pair<Boolean, ITextComponent> dialogue = ChatManager.applyToDialogue(chatComponent.createCopy());
         if (dialogue.a) {
+            chatComponent = dialogue.b;
+            chatLineId = WYNN_DIALOGUE_ID;
+
             if (dialogue.b == null) {
                 deleteChatLine(chatLineId);
                 return;
             }
-
-            chatComponent = dialogue.b;
-            chatLineId = WYNN_DIALOGUE_ID;
         }
 
         if (!noEvent) {


### PR DESCRIPTION
Most importantly, these changes finally fix the issue where dialogue would cause the chat history to be cleared. This was actually a one line fix, and the cause of the issue was code that was changed and pushed in #375 without being tested or reviewed.

Besides that fix, this PR fixes a small issue with chat timestamps, removes clickable message options made redundant by vanilla Wynncraft, fixes clickable duel messages, and adds an option to progress dialogue by right clicking the NPC (disabled by default). I also added a change to make the check for dialogue completion ignore color, which I hope will fix a sporadic issue with dialogue never being registered as over, which makes a complete mess of chat. However, I found no way to reliably reproduce this issue, nor could I pinpoint specifically what caused it, so this fix is mostly speculative (but does not break anything that currently works). Any further insight into this bug would be very useful.

These changes probably warrant a push to stable, since fixing dialogue issues is a big deal.