### PR TITLE
feat: Add consumable charge count in hotbar

### DIFF
--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -129,6 +129,9 @@ public class UtilitiesConfig extends SettingsClass {
     @Setting(displayName = "Show Emerald Count as Text", description = "Should your emerald count be displayed as text instead of icons?", order = 26)
     public boolean emeraldCountText = false;
 
+    @Setting(displayName = "Show potion charges in hotbar", description = "Should healing and skill potion charges be shown in the hotbar?", order = 28)
+    public boolean showPotionChargesHotbar = true;
+
     @Setting(upload = false)
     public String lastServerResourcePack = "";
 

--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -129,8 +129,8 @@ public class UtilitiesConfig extends SettingsClass {
     @Setting(displayName = "Show Emerald Count as Text", description = "Should your emerald count be displayed as text instead of icons?", order = 26)
     public boolean emeraldCountText = false;
 
-    @Setting(displayName = "Show potion charges in hotbar", description = "Should healing and skill potion charges be shown in the hotbar?", order = 28)
-    public boolean showPotionChargesHotbar = true;
+    @Setting(displayName = "Show consumable charges in hotbar", description = "Should potion, food, and scroll charges be shown in the hotbar?", order = 28)
+    public boolean showConsumableChargesHotbar = true;
 
     @Setting(upload = false)
     public String lastServerResourcePack = "";

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemLevelOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemLevelOverlay.java
@@ -18,6 +18,7 @@ import com.wynntils.modules.utilities.managers.KeyManager;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
 import java.util.regex.Matcher;
@@ -63,12 +64,20 @@ public class ItemLevelOverlay implements Listener {
 
     @SubscribeEvent
     public void onItemOverlay(RenderEvent.DrawItemOverlay event) {
-        if (!UtilitiesConfig.Items.INSTANCE.itemLevelOverlayOutsideGui && McIf.mc().currentScreen == null) return;
-        if (!KeyManager.getShowLevelOverlayKey().isKeyDown()) return;
-
         ItemStack stack = event.getStack();
         Item item = stack.getItem();
         String name = stack.getDisplayName();
+
+        if (UtilitiesConfig.INSTANCE.showPotionChargesHotbar && item == Items.POTIONITEM) { // potion charge count in hotbar
+            String[] potionName = name.split(" ");
+            String[] charges = potionName[potionName.length - 1].split("/");
+            String remainingCharges = charges[0].replace("[", "");
+            event.setOverlayText(TextFormatting.getTextWithoutFormattingCodes(remainingCharges));
+        }
+
+        if (!UtilitiesConfig.Items.INSTANCE.itemLevelOverlayOutsideGui && McIf.mc().currentScreen == null) return;
+        if (!KeyManager.getShowLevelOverlayKey().isKeyDown()) return;
+
 
         // powder tier
         if (item == Items.DYE || item == Items.GUNPOWDER || item == Items.CLAY_BALL || item == Items.SUGAR) {

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemLevelOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemLevelOverlay.java
@@ -64,64 +64,64 @@ public class ItemLevelOverlay implements Listener {
 
     @SubscribeEvent
     public void onItemOverlay(RenderEvent.DrawItemOverlay event) {
+        if (!UtilitiesConfig.INSTANCE.showConsumableChargesHotbar && !UtilitiesConfig.Items.INSTANCE.itemLevelOverlayOutsideGui && McIf.mc().currentScreen == null) return;
         ItemStack stack = event.getStack();
         Item item = stack.getItem();
         String name = stack.getDisplayName();
 
+        if (KeyManager.getShowLevelOverlayKey().isKeyDown()) {
+            // powder tier
+            if (item == Items.DYE || item == Items.GUNPOWDER || item == Items.CLAY_BALL || item == Items.SUGAR) {
+                Matcher powderMatcher = Powder.POWDER_NAME_PATTERN.matcher(StringUtils.normalizeBadString(name));
+                if (powderMatcher.find()) {
+                    if (!UtilitiesConfig.Items.INSTANCE.levelKeyShowsItemTiers) return;
+                    if (UtilitiesConfig.Items.INSTANCE.romanNumeralItemTier) {
+                        event.setOverlayText(powderMatcher.group(1));
+                        return;
+                    }
+                    event.setOverlayText(romanToArabic(powderMatcher.group(1)));
+                    return;
+                }
+            }
+
+            // emerald pouch tier
+            if (EmeraldPouchManager.isEmeraldPouch(stack)) {
+                if (!UtilitiesConfig.Items.INSTANCE.levelKeyShowsItemTiers) return;
+                if (UtilitiesConfig.Items.INSTANCE.romanNumeralItemTier) {
+                    event.setOverlayText(EmeraldPouchManager.getPouchTier(stack));
+                    return;
+                }
+                event.setOverlayText(romanToArabic(EmeraldPouchManager.getPouchTier(stack)));
+                return;
+            }
+
+            // cork amp tier
+            if (CorkianAmplifierManager.isAmplifier(stack)) {
+                if (UtilitiesConfig.Items.INSTANCE.romanNumeralItemTier) {
+                    event.setOverlayText(CorkianAmplifierManager.getAmplifierTier(stack));
+                    return;
+                }
+                event.setOverlayText(romanToArabic(CorkianAmplifierManager.getAmplifierTier(stack)));
+                return;
+            }
+
+            String lore = ItemUtils.getStringLore(stack);
+
+            // item level
+            IntRange level = ItemUtils.getLevel(lore);
+            if (level != null) {
+                event.setOverlayText(UtilitiesConfig.Items.INSTANCE.averageUnidentifiedLevel ? level.toString() : Integer.toString(level.getAverage()));
+                return;
+            }
+        }
+
+        // Hotbar charges
         if (UtilitiesConfig.INSTANCE.showConsumableChargesHotbar && (item == Items.POTIONITEM || item == Items.DIAMOND_AXE)) { // potion charge count in hotbar
             if (!name.contains("[") || !name.contains("/")) return; // Make sure it's actually some consumable
             String[] consumable = name.split(" ");
             String[] charges = consumable[consumable.length - 1].split("/");
             String remainingCharges = charges[0].replace("[", "");
             event.setOverlayText(TextFormatting.getTextWithoutFormattingCodes(remainingCharges));
-        }
-
-        if (!UtilitiesConfig.Items.INSTANCE.itemLevelOverlayOutsideGui && McIf.mc().currentScreen == null) return;
-        if (!KeyManager.getShowLevelOverlayKey().isKeyDown()) return;
-
-
-        // powder tier
-        if (item == Items.DYE || item == Items.GUNPOWDER || item == Items.CLAY_BALL || item == Items.SUGAR) {
-            Matcher powderMatcher = Powder.POWDER_NAME_PATTERN.matcher(StringUtils.normalizeBadString(name));
-            if (powderMatcher.find()) {
-                if (!UtilitiesConfig.Items.INSTANCE.levelKeyShowsItemTiers) return;
-                if (UtilitiesConfig.Items.INSTANCE.romanNumeralItemTier) {
-                    event.setOverlayText(powderMatcher.group(1));
-                    return;
-                }
-                event.setOverlayText(romanToArabic(powderMatcher.group(1)));
-                return;
-            }
-        }
-
-        // emerald pouch tier
-        if (EmeraldPouchManager.isEmeraldPouch(stack)) {
-            if (!UtilitiesConfig.Items.INSTANCE.levelKeyShowsItemTiers) return;
-            if (UtilitiesConfig.Items.INSTANCE.romanNumeralItemTier) {
-                event.setOverlayText(EmeraldPouchManager.getPouchTier(stack));
-                return;
-            }
-            event.setOverlayText(romanToArabic(EmeraldPouchManager.getPouchTier(stack)));
-            return;
-        }
-
-        // cork amp tier
-        if (CorkianAmplifierManager.isAmplifier(stack)) {
-            if (UtilitiesConfig.Items.INSTANCE.romanNumeralItemTier) {
-                event.setOverlayText(CorkianAmplifierManager.getAmplifierTier(stack));
-                return;
-            }
-            event.setOverlayText(romanToArabic(CorkianAmplifierManager.getAmplifierTier(stack)));
-            return;
-        }
-
-        String lore = ItemUtils.getStringLore(stack);
-
-        // item level
-        IntRange level = ItemUtils.getLevel(lore);
-        if (level != null) {
-            event.setOverlayText(UtilitiesConfig.Items.INSTANCE.averageUnidentifiedLevel ? level.toString() : Integer.toString(level.getAverage()));
-            return;
         }
     }
 

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemLevelOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemLevelOverlay.java
@@ -119,6 +119,7 @@ public class ItemLevelOverlay implements Listener {
         if (UtilitiesConfig.INSTANCE.showConsumableChargesHotbar && (item == Items.POTIONITEM || item == Items.DIAMOND_AXE)) { // potion charge count in hotbar
             if (!name.contains("[") || !name.contains("/")) return; // Make sure it's actually some consumable
             String[] consumable = name.split(" ");
+            if (consumable.length < 2) return; // Make sure we actually split the consumable name
             String[] charges = consumable[consumable.length - 1].split("/");
             String remainingCharges = charges[0].replace("[", "");
             event.setOverlayText(TextFormatting.getTextWithoutFormattingCodes(remainingCharges));

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemLevelOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemLevelOverlay.java
@@ -68,9 +68,10 @@ public class ItemLevelOverlay implements Listener {
         Item item = stack.getItem();
         String name = stack.getDisplayName();
 
-        if (UtilitiesConfig.INSTANCE.showPotionChargesHotbar && item == Items.POTIONITEM) { // potion charge count in hotbar
-            String[] potionName = name.split(" ");
-            String[] charges = potionName[potionName.length - 1].split("/");
+        if (UtilitiesConfig.INSTANCE.showConsumableChargesHotbar && (item == Items.POTIONITEM || item == Items.DIAMOND_AXE)) { // potion charge count in hotbar
+            if (!name.contains("[") || !name.contains("/")) return; // Make sure it's actually some consumable
+            String[] consumable = name.split(" ");
+            String[] charges = consumable[consumable.length - 1].split("/");
             String remainingCharges = charges[0].replace("[", "");
             event.setOverlayText(TextFormatting.getTextWithoutFormattingCodes(remainingCharges));
         }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemLevelOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemLevelOverlay.java
@@ -121,6 +121,7 @@ public class ItemLevelOverlay implements Listener {
             String[] consumable = name.split(" ");
             if (consumable.length < 2) return; // Make sure we actually split the consumable name
             String[] charges = consumable[consumable.length - 1].split("/");
+            if (charges.length != 2) return; // Make sure we arent't splitting a / from anywhere else; charges always return 2 entries - one for charges remaining and one for total
             String remainingCharges = charges[0].replace("[", "");
             event.setOverlayText(TextFormatting.getTextWithoutFormattingCodes(remainingCharges));
         }


### PR DESCRIPTION
Didn't use any existing method of getting charges as they wouldn't work for healing, skill, and crafted all together. Also not sure if string manipulation is the best way to do this but I didn't think of another so...

Edit: now also works with scrolls and food
Edit 2: This also happens to overlay the charges in other inventories, which we can't really check for as that event doesn't return any inventory data. (Can't check for inventory slot num, if in bank, etc)

Looks like this (without the red background)
![image](https://user-images.githubusercontent.com/57310593/153502254-375e7c93-df0f-4cbd-a821-d66636aa31ce.png)
