### PR TITLE
Fixing hotbar highlight colours and settings

### DIFF
--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -367,8 +367,12 @@ public class UtilitiesConfig extends SettingsClass {
         @Setting(displayName = "Highlight Common Cosmetics", description = "Should common cosmetic items be highlighted?", order = 34)
         public boolean commonEffectsHighlight = true;
 
-        @Setting(displayName = "Highlight Crafting Ingredients", description = "Should crafting ingredients be highlighted according to their tier?", order = 40)
+        @Setting(displayName = "Highlight Crafting Ingredients", description = "Should crafting ingredients be highlighted according to their tier?", order = 39)
         public boolean ingredientHighlight = true;
+
+        @Setting(displayName = "Minimum Ingredient Tier Highlight", description = "What should the minimum tier of crafting ingredients be for them to be highlighted?", order = 40)
+        @Setting.Limitations.IntLimit(min = 1, max = 3)
+        public int minCraftingIngredientHighlightTier = 1;
 
         @Setting(displayName = "Highlight Duplicate Cosmetics", description = "Should duplicate cosmetics be highlighted in the scrap menu?", order = 41)
         public boolean highlightCosmeticDuplicates = true;

--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -349,6 +349,9 @@ public class UtilitiesConfig extends SettingsClass {
         @Setting(displayName = "Highlight Normal Items", description = "Should normal items be highlighted?", order = 28)
         public boolean normalHighlight = false;
 
+        @Setting(displayName = "Highlight Crafted Items", description = "Should crafted items be highlighted?", order = 29)
+        public boolean craftedHighlight = true;
+
         @Setting(displayName = "Highlight Black Market Cosmetics", description = "Should black market cosmetic items be highlighted?", order = 30)
         public boolean blackMarketEffectsHighlight = true;
 

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/HotbarOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/HotbarOverlay.java
@@ -60,21 +60,21 @@ public class HotbarOverlay extends Overlay {
                 CustomColor color = null;
 
                 if (description.contains(ItemTier.NORMAL.asFormattedName()) && UtilitiesConfig.Items.INSTANCE.normalHighlight)
-                    color = UtilitiesConfig.Items.INSTANCE.normalHighlightColor;
+                    color = ItemTier.NORMAL.getCustomizedHighlightColor();
                 else if (description.contains(ItemTier.UNIQUE.asFormattedName()) && UtilitiesConfig.Items.INSTANCE.uniqueHighlight)
-                    color = UtilitiesConfig.Items.INSTANCE.uniqueHighlightColor;
+                    color = ItemTier.UNIQUE.getCustomizedHighlightColor();
                 else if (description.contains(ItemTier.RARE.asFormattedName()) && UtilitiesConfig.Items.INSTANCE.rareHighlight)
-                    color = UtilitiesConfig.Items.INSTANCE.rareHighlightColor;
+                    color = ItemTier.RARE.getCustomizedHighlightColor();
                 else if (description.contains(ItemTier.SET.asFormattedName()) && UtilitiesConfig.Items.INSTANCE.setHighlight)
-                    color = UtilitiesConfig.Items.INSTANCE.setHighlightColor;
+                    color = ItemTier.SET.getCustomizedHighlightColor();
                 else if (description.contains(ItemTier.LEGENDARY.asFormattedName()) && UtilitiesConfig.Items.INSTANCE.legendaryHighlight)
-                    color = UtilitiesConfig.Items.INSTANCE.legendaryHighlightColor;
+                    color = ItemTier.LEGENDARY.getCustomizedHighlightColor();
                 else if (description.contains(ItemTier.FABLED.asFormattedName()) && UtilitiesConfig.Items.INSTANCE.fabledHighlight)
-                    color = UtilitiesConfig.Items.INSTANCE.fabledHighlightColor;
+                    color = ItemTier.FABLED.getCustomizedHighlightColor();
                 else if (description.contains(ItemTier.MYTHIC.asFormattedName()) && UtilitiesConfig.Items.INSTANCE.mythicHighlight)
-                    color = UtilitiesConfig.Items.INSTANCE.mythicHighlightColor;
+                    color = ItemTier.MYTHIC.getCustomizedHighlightColor();
                 else if (description.contains(ItemTier.CRAFTED.asFormattedName()) && UtilitiesConfig.Items.INSTANCE.craftedHighlight)
-                    color = UtilitiesConfig.Items.INSTANCE.craftedHighlightColor;
+                    color = ItemTier.CRAFTED.getCustomizedHighlightColor();
 
                 if (color != null) {
                     color.setA(UtilitiesConfig.Items.INSTANCE.hotbarAlpha / 100);

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/HotbarOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/HotbarOverlay.java
@@ -59,21 +59,21 @@ public class HotbarOverlay extends Overlay {
             if (UtilitiesConfig.Items.INSTANCE.hotbarHighlight && UtilitiesConfig.Items.INSTANCE.hotbarAlpha > 0 && !description.isEmpty()) {
                 CustomColor color = null;
 
-                if (description.contains(ItemTier.NORMAL.asFormattedName()) && UtilitiesConfig.Items.INSTANCE.normalHighlight)
+                if (UtilitiesConfig.Items.INSTANCE.normalHighlight && description.contains(ItemTier.NORMAL.asFormattedName()))
                     color = ItemTier.NORMAL.getCustomizedHighlightColor();
-                else if (description.contains(ItemTier.UNIQUE.asFormattedName()) && UtilitiesConfig.Items.INSTANCE.uniqueHighlight)
+                else if (UtilitiesConfig.Items.INSTANCE.uniqueHighlight && description.contains(ItemTier.UNIQUE.asFormattedName()))
                     color = ItemTier.UNIQUE.getCustomizedHighlightColor();
-                else if (description.contains(ItemTier.RARE.asFormattedName()) && UtilitiesConfig.Items.INSTANCE.rareHighlight)
+                else if (UtilitiesConfig.Items.INSTANCE.rareHighlight && description.contains(ItemTier.RARE.asFormattedName()))
                     color = ItemTier.RARE.getCustomizedHighlightColor();
-                else if (description.contains(ItemTier.SET.asFormattedName()) && UtilitiesConfig.Items.INSTANCE.setHighlight)
+                else if (UtilitiesConfig.Items.INSTANCE.setHighlight && description.contains(ItemTier.SET.asFormattedName()))
                     color = ItemTier.SET.getCustomizedHighlightColor();
-                else if (description.contains(ItemTier.LEGENDARY.asFormattedName()) && UtilitiesConfig.Items.INSTANCE.legendaryHighlight)
+                else if (UtilitiesConfig.Items.INSTANCE.legendaryHighlight && description.contains(ItemTier.LEGENDARY.asFormattedName()))
                     color = ItemTier.LEGENDARY.getCustomizedHighlightColor();
-                else if (description.contains(ItemTier.FABLED.asFormattedName()) && UtilitiesConfig.Items.INSTANCE.fabledHighlight)
+                else if (UtilitiesConfig.Items.INSTANCE.fabledHighlight && description.contains(ItemTier.FABLED.asFormattedName()))
                     color = ItemTier.FABLED.getCustomizedHighlightColor();
-                else if (description.contains(ItemTier.MYTHIC.asFormattedName()) && UtilitiesConfig.Items.INSTANCE.mythicHighlight)
+                else if (UtilitiesConfig.Items.INSTANCE.mythicHighlight && description.contains(ItemTier.MYTHIC.asFormattedName()))
                     color = ItemTier.MYTHIC.getCustomizedHighlightColor();
-                else if (description.contains(ItemTier.CRAFTED.asFormattedName()) && UtilitiesConfig.Items.INSTANCE.craftedHighlight)
+                else if (UtilitiesConfig.Items.INSTANCE.craftedHighlight && description.contains(ItemTier.CRAFTED.asFormattedName()))
                     color = ItemTier.CRAFTED.getCustomizedHighlightColor();
 
                 if (color != null) {

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/HotbarOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/HotbarOverlay.java
@@ -73,7 +73,7 @@ public class HotbarOverlay extends Overlay {
                     color = UtilitiesConfig.Items.INSTANCE.fabledHighlightColor;
                 else if (description.contains(ItemTier.MYTHIC.asFormattedName()) && UtilitiesConfig.Items.INSTANCE.mythicHighlight)
                     color = UtilitiesConfig.Items.INSTANCE.mythicHighlightColor;
-                else if (description.contains(ItemTier.CRAFTED.asFormattedName()))
+                else if (description.contains(ItemTier.CRAFTED.asFormattedName()) && UtilitiesConfig.Items.INSTANCE.craftedHighlight)
                     color = UtilitiesConfig.Items.INSTANCE.craftedHighlightColor;
 
                 if (color != null) {

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/HotbarOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/HotbarOverlay.java
@@ -59,13 +59,22 @@ public class HotbarOverlay extends Overlay {
             if (UtilitiesConfig.Items.INSTANCE.hotbarHighlight && UtilitiesConfig.Items.INSTANCE.hotbarAlpha > 0 && !description.isEmpty()) {
                 CustomColor color = null;
 
-                if (description.contains(ItemTier.UNIQUE.asFormattedName())) color = UtilitiesConfig.Items.INSTANCE.uniqueHighlightColor;
-                else if (description.contains(ItemTier.RARE.asFormattedName())) color = UtilitiesConfig.Items.INSTANCE.rareHighlightColor;
-                else if (description.contains(ItemTier.SET.asFormattedName())) color = UtilitiesConfig.Items.INSTANCE.setHighlightColor;
-                else if (description.contains(ItemTier.LEGENDARY.asFormattedName())) color = UtilitiesConfig.Items.INSTANCE.legendaryHighlightColor;
-                else if (description.contains(ItemTier.FABLED.asFormattedName())) color = UtilitiesConfig.Items.INSTANCE.fabledHighlightColor;
-                else if (description.contains(ItemTier.MYTHIC.asFormattedName())) color = UtilitiesConfig.Items.INSTANCE.mythicHighlightColor;
-                else if (description.contains(ItemTier.CRAFTED.asFormattedName())) color = UtilitiesConfig.Items.INSTANCE.craftedHighlightColor;
+                if (description.contains(ItemTier.NORMAL.asFormattedName()) && UtilitiesConfig.Items.INSTANCE.normalHighlight)
+                    color = UtilitiesConfig.Items.INSTANCE.normalHighlightColor;
+                else if (description.contains(ItemTier.UNIQUE.asFormattedName()) && UtilitiesConfig.Items.INSTANCE.uniqueHighlight)
+                    color = UtilitiesConfig.Items.INSTANCE.uniqueHighlightColor;
+                else if (description.contains(ItemTier.RARE.asFormattedName()) && UtilitiesConfig.Items.INSTANCE.rareHighlight)
+                    color = UtilitiesConfig.Items.INSTANCE.rareHighlightColor;
+                else if (description.contains(ItemTier.SET.asFormattedName()) && UtilitiesConfig.Items.INSTANCE.setHighlight)
+                    color = UtilitiesConfig.Items.INSTANCE.setHighlightColor;
+                else if (description.contains(ItemTier.LEGENDARY.asFormattedName()) && UtilitiesConfig.Items.INSTANCE.legendaryHighlight)
+                    color = UtilitiesConfig.Items.INSTANCE.legendaryHighlightColor;
+                else if (description.contains(ItemTier.FABLED.asFormattedName()) && UtilitiesConfig.Items.INSTANCE.fabledHighlight)
+                    color = UtilitiesConfig.Items.INSTANCE.fabledHighlightColor;
+                else if (description.contains(ItemTier.MYTHIC.asFormattedName()) && UtilitiesConfig.Items.INSTANCE.mythicHighlight)
+                    color = UtilitiesConfig.Items.INSTANCE.mythicHighlightColor;
+                else if (description.contains(ItemTier.CRAFTED.asFormattedName()))
+                    color = UtilitiesConfig.Items.INSTANCE.craftedHighlightColor;
 
                 if (color != null) {
                     color.setA(UtilitiesConfig.Items.INSTANCE.hotbarAlpha / 100);

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/RarityColorOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/RarityColorOverlay.java
@@ -166,7 +166,7 @@ public class RarityColorOverlay implements Listener {
         if (lore.contains(ItemTier.MYTHIC.asFormattedName()) && UtilitiesConfig.Items.INSTANCE.mythicHighlight) {
             return ItemTier.MYTHIC.getCustomizedHighlightColor();
         }
-        if (name.matches("^(" + TextFormatting.DARK_AQUA + ".*%.*)$")) {
+        if (name.matches("^(" + TextFormatting.DARK_AQUA + ".*%.*)$") && UtilitiesConfig.Items.INSTANCE.craftedHighlight) {
             return ItemTier.CRAFTED.getCustomizedHighlightColor();
         }
         if (UtilitiesConfig.Items.INSTANCE.ingredientHighlight && !(is.getCount() == 0)) {

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/RarityColorOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/RarityColorOverlay.java
@@ -128,45 +128,45 @@ public class RarityColorOverlay implements Listener {
                 return new CustomColor(0f, 1f, 0f);
             }
             if (lore.contains("Reward")) {
-                if (lore.contains(TextFormatting.GOLD + "Epic") && UtilitiesConfig.Items.INSTANCE.epicEffectsHighlight) {
+                if (UtilitiesConfig.Items.INSTANCE.epicEffectsHighlight && lore.contains(TextFormatting.GOLD + "Epic")) {
                     return new CustomColor(1f, 0.666f, 0f);
                 }
-                if (lore.contains(TextFormatting.RED + "Godly") && UtilitiesConfig.Items.INSTANCE.godlyEffectsHighlight) {
+                if (UtilitiesConfig.Items.INSTANCE.godlyEffectsHighlight && lore.contains(TextFormatting.RED + "Godly")) {
                     return new CustomColor(1f, 0f, 0f);
                 }
-                if (lore.contains(TextFormatting.LIGHT_PURPLE + "Rare") && UtilitiesConfig.Items.INSTANCE.rareEffectsHighlight) {
+                if (UtilitiesConfig.Items.INSTANCE.rareEffectsHighlight && lore.contains(TextFormatting.LIGHT_PURPLE + "Rare")) {
                     return new CustomColor(1f, 0f, 1f);
                 }
-                if (lore.contains(TextFormatting.WHITE + "Common") && UtilitiesConfig.Items.INSTANCE.commonEffectsHighlight) {
+                if (UtilitiesConfig.Items.INSTANCE.commonEffectsHighlight && lore.contains(TextFormatting.WHITE + "Common")) {
                     return new CustomColor(1f, 1f, 1f);
                 }
-                if (lore.contains(TextFormatting.DARK_RED + " Black Market") && UtilitiesConfig.Items.INSTANCE.blackMarketEffectsHighlight) {
+                if (UtilitiesConfig.Items.INSTANCE.blackMarketEffectsHighlight && lore.contains(TextFormatting.DARK_RED + " Black Market")) {
                     return new CustomColor(0f, 0f, 0f);
                 }
             }
         }
-        if (lore.contains(ItemTier.NORMAL.asFormattedName()) && UtilitiesConfig.Items.INSTANCE.normalHighlight) {
+        if (UtilitiesConfig.Items.INSTANCE.normalHighlight && lore.contains(ItemTier.NORMAL.asFormattedName())) {
             return ItemTier.NORMAL.getCustomizedHighlightColor();
         }
-        if (lore.contains(ItemTier.UNIQUE.asFormattedName()) && UtilitiesConfig.Items.INSTANCE.uniqueHighlight) {
+        if (UtilitiesConfig.Items.INSTANCE.uniqueHighlight && lore.contains(ItemTier.UNIQUE.asFormattedName())) {
             return ItemTier.UNIQUE.getCustomizedHighlightColor();
         }
-        if (lore.contains(ItemTier.RARE.asFormattedName()) && UtilitiesConfig.Items.INSTANCE.rareHighlight) {
+        if (UtilitiesConfig.Items.INSTANCE.rareHighlight && lore.contains(ItemTier.RARE.asFormattedName())) {
             return ItemTier.RARE.getCustomizedHighlightColor();
         }
-        if (lore.contains(ItemTier.SET.asFormattedName()) && UtilitiesConfig.Items.INSTANCE.setHighlight) {
+        if (UtilitiesConfig.Items.INSTANCE.setHighlight && lore.contains(ItemTier.SET.asFormattedName())) {
             return ItemTier.SET.getCustomizedHighlightColor();
         }
-        if (lore.contains(ItemTier.LEGENDARY.asFormattedName()) && UtilitiesConfig.Items.INSTANCE.legendaryHighlight) {
+        if (UtilitiesConfig.Items.INSTANCE.legendaryHighlight && lore.contains(ItemTier.LEGENDARY.asFormattedName())) {
             return ItemTier.LEGENDARY.getCustomizedHighlightColor();
         }
-        if (lore.contains(ItemTier.FABLED.asFormattedName()) && UtilitiesConfig.Items.INSTANCE.fabledHighlight) {
+        if (UtilitiesConfig.Items.INSTANCE.fabledHighlight && lore.contains(ItemTier.FABLED.asFormattedName())) {
             return ItemTier.FABLED.getCustomizedHighlightColor();
         }
-        if (lore.contains(ItemTier.MYTHIC.asFormattedName()) && UtilitiesConfig.Items.INSTANCE.mythicHighlight) {
+        if (UtilitiesConfig.Items.INSTANCE.mythicHighlight && lore.contains(ItemTier.MYTHIC.asFormattedName())) {
             return ItemTier.MYTHIC.getCustomizedHighlightColor();
         }
-        if (name.matches("^(" + TextFormatting.DARK_AQUA + ".*%.*)$") && UtilitiesConfig.Items.INSTANCE.craftedHighlight) {
+        if (UtilitiesConfig.Items.INSTANCE.craftedHighlight && name.matches("^(" + TextFormatting.DARK_AQUA + ".*%.*)$")) {
             return ItemTier.CRAFTED.getCustomizedHighlightColor();
         }
         if (UtilitiesConfig.Items.INSTANCE.ingredientHighlight && !(is.getCount() == 0)) {

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/RarityColorOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/RarityColorOverlay.java
@@ -170,15 +170,18 @@ public class RarityColorOverlay implements Listener {
             return ItemTier.CRAFTED.getCustomizedHighlightColor();
         }
         if (UtilitiesConfig.Items.INSTANCE.ingredientHighlight && !(is.getCount() == 0)) {
-            if (name.endsWith(TextFormatting.GOLD + " [" + TextFormatting.YELLOW + "✫" + TextFormatting.DARK_GRAY + "✫✫" + TextFormatting.GOLD + "]")) {
+            if (UtilitiesConfig.Items.INSTANCE.minCraftingIngredientHighlightTier <= 1
+                    && name.endsWith(TextFormatting.GOLD + " [" + TextFormatting.YELLOW + "✫" + TextFormatting.DARK_GRAY + "✫✫" + TextFormatting.GOLD + "]")) {
                 return UtilitiesConfig.Items.INSTANCE.ingredientOneHighlightColor;
             }
-            if (name.endsWith(TextFormatting.GOLD + " [" + TextFormatting.YELLOW + "✫✫" + TextFormatting.DARK_GRAY + "✫" + TextFormatting.GOLD + "]") ||
-                    name.endsWith(TextFormatting.DARK_PURPLE + " [" + TextFormatting.LIGHT_PURPLE + "✫✫" + TextFormatting.DARK_GRAY + "✫" + TextFormatting.DARK_PURPLE + "]")) {
+            if (UtilitiesConfig.Items.INSTANCE.minCraftingIngredientHighlightTier <= 2
+                    && (name.endsWith(TextFormatting.GOLD + " [" + TextFormatting.YELLOW + "✫✫" + TextFormatting.DARK_GRAY + "✫" + TextFormatting.GOLD + "]") ||
+                    name.endsWith(TextFormatting.DARK_PURPLE + " [" + TextFormatting.LIGHT_PURPLE + "✫✫" + TextFormatting.DARK_GRAY + "✫" + TextFormatting.DARK_PURPLE + "]"))) {
                 return UtilitiesConfig.Items.INSTANCE.ingredientTwoHighlightColor;
             }
-            if (name.endsWith(TextFormatting.GOLD + " [" + TextFormatting.YELLOW + "✫✫✫" + TextFormatting.GOLD + "]") ||
-                    name.endsWith(TextFormatting.DARK_AQUA + " [" + TextFormatting.AQUA + "✫✫✫" + TextFormatting.DARK_AQUA + "]")) {
+            if (UtilitiesConfig.Items.INSTANCE.minCraftingIngredientHighlightTier <= 3
+                    && (name.endsWith(TextFormatting.GOLD + " [" + TextFormatting.YELLOW + "✫✫✫" + TextFormatting.GOLD + "]") ||
+                    name.endsWith(TextFormatting.DARK_AQUA + " [" + TextFormatting.AQUA + "✫✫✫" + TextFormatting.DARK_AQUA + "]"))) {
                 return UtilitiesConfig.Items.INSTANCE.ingredientThreeHighlightColor;
             }
         }


### PR DESCRIPTION
- Disabling highlights of specific tiers would not work on your hotbar.
- Hotbar colours would also not be customizable.
- Also added a setting for disabling crafted item highlights.