### PR TITLE
Add the option to filter party finder and event messages

### DIFF
--- a/src/main/java/com/wynntils/modules/chat/configs/ChatConfig.java
+++ b/src/main/java/com/wynntils/modules/chat/configs/ChatConfig.java
@@ -50,7 +50,7 @@ public class ChatConfig extends SettingsClass {
     public boolean filterTerritoryEnter = true;
 
     @Setting(displayName = "Filter Party Finder Messages", description = "Should Party Finder recommendation messages be hidden from chat?.", order = 12)
-    public boolean filterPartyFinder = true;
+    public boolean filterPartyFinder = false;
 
     @Setting(displayName = "Show Held Item Chat Message", description = "Should details of your compass and soul points be shown in chat while you are holding them?", order = 13)
     public boolean heldItemChat = true;

--- a/src/main/java/com/wynntils/modules/chat/configs/ChatConfig.java
+++ b/src/main/java/com/wynntils/modules/chat/configs/ChatConfig.java
@@ -46,6 +46,9 @@ public class ChatConfig extends SettingsClass {
     @Setting(displayName = "Filter Territory Enter", description = "Should territory enter messages be hidden from chat?\n\n§8Territory enter messages look like §7[You are now entering Detlas]§8.", order = 10)
     public boolean filterTerritoryEnter = true;
 
+    @Setting(displayName = "Filter Party Finder Messages", description = "Should Party Finder recommendation messages be hidden from chat?.", order = 11)
+    public boolean filterPartyFinder = true;
+
     @Setting(displayName = "Show Held Item Chat Message", description = "Should details of your compass and soul points be shown in chat while you are holding them?", order = 12)
     public boolean heldItemChat = true;
 

--- a/src/main/java/com/wynntils/modules/chat/configs/ChatConfig.java
+++ b/src/main/java/com/wynntils/modules/chat/configs/ChatConfig.java
@@ -43,13 +43,16 @@ public class ChatConfig extends SettingsClass {
     @Setting(displayName = "Filter Join Messagse", description = "Should Wynncraft join messages be hidden from chat?", order = 9)
     public boolean filterJoinMessages = false;
 
-    @Setting(displayName = "Filter Territory Enter", description = "Should territory enter messages be hidden from chat?\n\n§8Territory enter messages look like §7[You are now entering Detlas]§8.", order = 10)
+    @Setting(displayName = "Filter Event Messages", description = "Should Wynncraft join messages be hidden from chat?\n\n§8Messages starting with §6[Event] will no longer appear in chat.", order = 10)
+    public boolean filterEventMessages = false;
+
+    @Setting(displayName = "Filter Territory Enter", description = "Should territory enter messages be hidden from chat?\n\n§8Territory enter messages look like §7[You are now entering Detlas]§8.", order = 11)
     public boolean filterTerritoryEnter = true;
 
-    @Setting(displayName = "Filter Party Finder Messages", description = "Should Party Finder recommendation messages be hidden from chat?.", order = 11)
+    @Setting(displayName = "Filter Party Finder Messages", description = "Should Party Finder recommendation messages be hidden from chat?.", order = 12)
     public boolean filterPartyFinder = true;
 
-    @Setting(displayName = "Show Held Item Chat Message", description = "Should details of your compass and soul points be shown in chat while you are holding them?", order = 12)
+    @Setting(displayName = "Show Held Item Chat Message", description = "Should details of your compass and soul points be shown in chat while you are holding them?", order = 13)
     public boolean heldItemChat = true;
 
     @Setting(displayName = "Chat History Length", description = "How many messages should be saved in the chat history?", order = 1)

--- a/src/main/java/com/wynntils/modules/chat/configs/ChatConfig.java
+++ b/src/main/java/com/wynntils/modules/chat/configs/ChatConfig.java
@@ -40,7 +40,7 @@ public class ChatConfig extends SettingsClass {
     @Setting(displayName = "Filter Info Messages", description = "Should Wynncraft info messages be hidden from chat?\n\n§8Messages starting with §4[Info]§8 will no longer appear in chat.", order = 8)
     public boolean filterWynncraftInfo = true;
 
-    @Setting(displayName = "Filter Join Messagse", description = "Should Wynncraft join messages be hidden from chat?", order = 9)
+    @Setting(displayName = "Filter Join Messages", description = "Should Wynncraft join messages be hidden from chat?", order = 9)
     public boolean filterJoinMessages = false;
 
     @Setting(displayName = "Filter Event Messages", description = "Should Wynncraft join messages be hidden from chat?\n\n§8Messages starting with §6[Event] will no longer appear in chat.", order = 10)

--- a/src/main/java/com/wynntils/modules/chat/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/chat/events/ClientEvents.java
@@ -68,6 +68,8 @@ public class ClientEvents implements Listener {
             e.setCanceled(true);
         } else if (ChatConfig.INSTANCE.filterPartyFinder && McIf.getFormattedText(msg).startsWith(TextFormatting.DARK_PURPLE + "Party Finder: Hey ")) {
             e.setCanceled(true);
+        } else if (ChatConfig.INSTANCE.filterEventMessages && McIf.getFormattedText(msg).startsWith(TextFormatting.GOLD + "[Event]")) {
+            e.setCanceled(true);
         }
     }
 

--- a/src/main/java/com/wynntils/modules/chat/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/chat/events/ClientEvents.java
@@ -57,14 +57,14 @@ public class ClientEvents implements Listener {
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onChatReceived(ClientChatReceivedEvent e) {
         ITextComponent msg = e.getMessage();
-        if (McIf.getUnformattedText(msg).startsWith("[Info] ") && ChatConfig.INSTANCE.filterWynncraftInfo) {
+        if (ChatConfig.INSTANCE.filterWynncraftInfo && McIf.getUnformattedText(msg).startsWith("[Info] ")) {
             e.setCanceled(true);
-        } else if (McIf.getFormattedText(msg).startsWith("\n                       " + TextFormatting.GOLD + TextFormatting.BOLD + "Welcome to Wynncraft!") &&
-                !McIf.getFormattedText(msg).contains("n the Trade Market") && ChatConfig.INSTANCE.filterJoinMessages) {
+        } else if (ChatConfig.INSTANCE.filterJoinMessages && McIf.getFormattedText(msg).startsWith("\n                       " + TextFormatting.GOLD + TextFormatting.BOLD + "Welcome to Wynncraft!") &&
+                !McIf.getFormattedText(msg).contains("n the Trade Market")) {
             e.setCanceled(true);
-        } else if (McIf.getFormattedText(msg).startsWith(TextFormatting.GRAY + "[You are now entering") && ChatConfig.INSTANCE.filterTerritoryEnter) {
+        } else if (ChatConfig.INSTANCE.filterTerritoryEnter && McIf.getFormattedText(msg).startsWith(TextFormatting.GRAY + "[You are now entering")) {
             e.setCanceled(true);
-        } else if (McIf.getFormattedText(msg).startsWith(TextFormatting.GRAY + "[You are now leaving") && ChatConfig.INSTANCE.filterTerritoryEnter) {
+        } else if (ChatConfig.INSTANCE.filterTerritoryEnter && McIf.getFormattedText(msg).startsWith(TextFormatting.GRAY + "[You are now leaving")) {
             e.setCanceled(true);
         } else if (ChatConfig.INSTANCE.filterPartyFinder && McIf.getFormattedText(msg).startsWith(TextFormatting.DARK_PURPLE + "Party Finder: Hey ")) {
             e.setCanceled(true);

--- a/src/main/java/com/wynntils/modules/chat/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/chat/events/ClientEvents.java
@@ -66,6 +66,8 @@ public class ClientEvents implements Listener {
             e.setCanceled(true);
         } else if (McIf.getFormattedText(msg).startsWith(TextFormatting.GRAY + "[You are now leaving") && ChatConfig.INSTANCE.filterTerritoryEnter) {
             e.setCanceled(true);
+        } else if (ChatConfig.INSTANCE.filterPartyFinder && McIf.getFormattedText(msg).startsWith(TextFormatting.DARK_PURPLE + "Party Finder: Hey ")) {
+            e.setCanceled(true);
         }
     }
 


### PR DESCRIPTION
Added the option to filter messages appearing in chat recommending the use of party finder. 
Example: `Party Finder: Hey bol, over here! Join the The Canyon Colossus queue and match up with 3 other players!`

Additionally, the order of conditions in `onChatReceived` was changed as I think it is more logical and faster to check if a feature is enabled before doing string operations.

EDIT: Also added the option to filter event messages from Wynncraft, by default, this feature is turned off.