### PR TITLE
Multiple new guild related features (and a bugfix)

### DIFF
--- a/src/main/java/com/wynntils/modules/chat/configs/ChatConfig.java
+++ b/src/main/java/com/wynntils/modules/chat/configs/ChatConfig.java
@@ -55,6 +55,9 @@ public class ChatConfig extends SettingsClass {
     @Setting(displayName = "Recolor Guild War Messages", description = "Should successful guild war messages be colored green instead of red?", order = 15)
     public boolean recolorGuildWarSuccess = true;
 
+    @Setting(displayName = "Use Guild Role Names", description = "Should guild stars be translated into guild roles in the chat?", order = 16)
+    public boolean guildRoleNames = false;
+
     @Setting(displayName = "Chat History Length", description = "How many messages should be saved in the chat history?", order = 1)
     @Setting.Limitations.IntLimit(min = 10, max = 2000)
     public int chatHistorySize = 100;

--- a/src/main/java/com/wynntils/modules/chat/configs/ChatConfig.java
+++ b/src/main/java/com/wynntils/modules/chat/configs/ChatConfig.java
@@ -49,6 +49,9 @@ public class ChatConfig extends SettingsClass {
     @Setting(displayName = "Show Held Item Chat Message", description = "Should details of your compass and soul points be shown in chat while you are holding them?", order = 12)
     public boolean heldItemChat = true;
 
+    @Setting(displayName = "Recolor Guild War Messages", description = "Should successful guild war messages be colored green instead of red?", order = 15)
+    public boolean recolorGuildWarSuccess = true;
+
     @Setting(displayName = "Chat History Length", description = "How many messages should be saved in the chat history?", order = 1)
     @Setting.Limitations.IntLimit(min = 10, max = 2000)
     public int chatHistorySize = 100;

--- a/src/main/java/com/wynntils/modules/chat/configs/ChatConfig.java
+++ b/src/main/java/com/wynntils/modules/chat/configs/ChatConfig.java
@@ -46,6 +46,9 @@ public class ChatConfig extends SettingsClass {
     @Setting(displayName = "Filter Territory Enter", description = "Should territory enter messages be hidden from chat?\n\n§8Territory enter messages look like §7[You are now entering Detlas]§8.", order = 10)
     public boolean filterTerritoryEnter = true;
 
+    @Setting(displayName = "Filter Resource Warnings", description = "Should guild territory resource production warnings be hidden from chat?", order = 15)
+    public boolean filterResourceWarnings = false;
+
     @Setting(displayName = "Show Held Item Chat Message", description = "Should details of your compass and soul points be shown in chat while you are holding them?", order = 12)
     public boolean heldItemChat = true;
 

--- a/src/main/java/com/wynntils/modules/chat/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/chat/events/ClientEvents.java
@@ -11,7 +11,6 @@ import com.wynntils.core.events.custom.WynnClassChangeEvent;
 import com.wynntils.core.events.custom.WynnWorldEvent;
 import com.wynntils.core.events.custom.WynncraftServerEvent;
 import com.wynntils.core.framework.interfaces.Listener;
-import com.wynntils.core.utils.ItemUtils;
 import com.wynntils.core.utils.objects.Pair;
 import com.wynntils.core.utils.reflections.ReflectionFields;
 import com.wynntils.modules.chat.configs.ChatConfig;
@@ -19,21 +18,16 @@ import com.wynntils.modules.chat.managers.ChatManager;
 import com.wynntils.modules.chat.managers.HeldItemChatManager;
 import com.wynntils.modules.chat.overlays.ChatOverlay;
 import com.wynntils.modules.chat.overlays.gui.ChatGUI;
-import com.wynntils.modules.core.managers.PacketQueue;
 import com.wynntils.modules.questbook.enums.AnalysePosition;
 import com.wynntils.modules.questbook.events.custom.QuestBookUpdateEvent;
-import com.wynntils.modules.utilities.configs.UtilitiesConfig;
-import com.wynntils.webapi.profiles.item.enums.ItemType;
 import com.wynntils.webapi.services.TranslationManager;
 import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.client.gui.GuiChat;
 import net.minecraft.entity.Entity;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.network.play.client.CPacketEntityAction;
 import net.minecraft.network.play.client.CPacketUseEntity;
-import net.minecraft.network.play.server.SPacketCustomSound;
-import net.minecraft.network.play.server.SPacketSoundEffect;
+import net.minecraft.util.StringUtils;
 import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.TextComponentString;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.client.event.ClientChatEvent;
 import net.minecraftforge.client.event.ClientChatReceivedEvent;
@@ -66,6 +60,10 @@ public class ClientEvents implements Listener {
             e.setCanceled(true);
         } else if (McIf.getFormattedText(msg).startsWith(TextFormatting.GRAY + "[You are now leaving") && ChatConfig.INSTANCE.filterTerritoryEnter) {
             e.setCanceled(true);
+        } else if (ChatConfig.INSTANCE.recolorGuildWarSuccess && McIf.getFormattedText(msg).startsWith(TextFormatting.DARK_AQUA + "[WAR") && StringUtils.stripControlCodes(McIf.getUnformattedText(msg)).startsWith("[WAR] You have taken control of")) {
+            e.setMessage(new TextComponentString(TextFormatting.DARK_AQUA + "[WAR] " + TextFormatting.GREEN + StringUtils.stripControlCodes(McIf.getUnformattedText(msg)).substring(6)));
+        } else if (ChatConfig.INSTANCE.recolorGuildWarSuccess && McIf.getFormattedText(msg).startsWith(TextFormatting.DARK_AQUA + "[WAR") && StringUtils.stripControlCodes(McIf.getUnformattedText(msg)).startsWith("[WAR] Your guild has successfully defended")) {
+            e.setMessage(new TextComponentString(TextFormatting.DARK_AQUA + "[WAR] " + TextFormatting.GREEN + StringUtils.stripControlCodes(McIf.getUnformattedText(msg)).substring(6)));
         }
     }
 

--- a/src/main/java/com/wynntils/modules/chat/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/chat/events/ClientEvents.java
@@ -78,8 +78,11 @@ public class ClientEvents implements Listener {
             Matcher matcher = GUILD_CHAT_MESSAGE.matcher(strippedMsg);
             if (matcher.matches()) {
                 String roleName = PlayerStatsProfile.GuildRank.getRoleNameFromStars(matcher.group(1).length());
-                String playerName = msg.getUnformattedText().contains(TextFormatting.ITALIC + matcher.group(2)) ? TextFormatting.ITALIC + matcher.group(2) + TextFormatting.RESET : matcher.group(2);
-                e.setMessage(new TextComponentString(TextFormatting.DARK_AQUA + "[" + TextFormatting.AQUA + roleName + " " + TextFormatting.DARK_AQUA + playerName + "] " + TextFormatting.AQUA + matcher.group(3)));
+                String playerName = msg.getUnformattedText().contains(TextFormatting.ITALIC + matcher.group(2)) ? TextFormatting.ITALIC + matcher.group(2) + TextFormatting.RESET + TextFormatting.DARK_AQUA : matcher.group(2);
+                TextComponentString message = new TextComponentString(TextFormatting.DARK_AQUA + "[" + TextFormatting.AQUA + roleName + " " + TextFormatting.DARK_AQUA + playerName + "] " + TextFormatting.AQUA + matcher.group(3));
+                if (e.getMessage().getStyle().getHoverEvent() != null)
+                    message.getStyle().setHoverEvent(e.getMessage().getStyle().getHoverEvent());
+                e.setMessage(message);
             }
         }
     }

--- a/src/main/java/com/wynntils/modules/chat/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/chat/events/ClientEvents.java
@@ -74,7 +74,7 @@ public class ClientEvents implements Listener {
             e.setMessage(new TextComponentString(TextFormatting.DARK_AQUA + "[WAR] " + TextFormatting.GREEN + strippedMsg.substring(6)));
         } else if (ChatConfig.INSTANCE.filterResourceWarnings && McIf.getFormattedText(msg).startsWith(TextFormatting.DARK_AQUA + "[INFO") && GUILD_RESOURCE_WARNING.matcher(strippedMsg).matches()) {
             e.setCanceled(true);
-        } else if (ChatConfig.INSTANCE.guildRoleNames && McIf.getFormattedText(msg).startsWith(TextFormatting.DARK_AQUA + "[")) {
+        } else if (ChatConfig.INSTANCE.guildRoleNames && McIf.getFormattedText(msg).startsWith(TextFormatting.DARK_AQUA + "[") && !strippedMsg.startsWith("[WAR]") && !strippedMsg.startsWith("[INFO]")) {
             Matcher matcher = GUILD_CHAT_MESSAGE.matcher(strippedMsg);
             if (matcher.matches()) {
                 String roleName = PlayerStatsProfile.GuildRank.getRoleNameFromStars(matcher.group(1).length());

--- a/src/main/java/com/wynntils/modules/chat/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/chat/events/ClientEvents.java
@@ -78,7 +78,8 @@ public class ClientEvents implements Listener {
             Matcher matcher = GUILD_CHAT_MESSAGE.matcher(strippedMsg);
             if (matcher.matches()) {
                 String roleName = PlayerStatsProfile.GuildRank.getRoleNameFromStars(matcher.group(1).length());
-                e.setMessage(new TextComponentString(TextFormatting.DARK_AQUA + "[" + TextFormatting.AQUA + roleName + " " + TextFormatting.DARK_AQUA + matcher.group(2) + "] " + TextFormatting.AQUA + matcher.group(3)));
+                String playerName = msg.getUnformattedText().contains(TextFormatting.ITALIC + matcher.group(2)) ? TextFormatting.ITALIC + matcher.group(2) + TextFormatting.RESET : matcher.group(2);
+                e.setMessage(new TextComponentString(TextFormatting.DARK_AQUA + "[" + TextFormatting.AQUA + roleName + " " + TextFormatting.DARK_AQUA + playerName + "] " + TextFormatting.AQUA + matcher.group(3)));
             }
         }
     }

--- a/src/main/java/com/wynntils/modules/chat/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/chat/events/ClientEvents.java
@@ -20,6 +20,7 @@ import com.wynntils.modules.chat.overlays.ChatOverlay;
 import com.wynntils.modules.chat.overlays.gui.ChatGUI;
 import com.wynntils.modules.questbook.enums.AnalysePosition;
 import com.wynntils.modules.questbook.events.custom.QuestBookUpdateEvent;
+import com.wynntils.webapi.profiles.player.PlayerStatsProfile;
 import com.wynntils.webapi.services.TranslationManager;
 import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.client.gui.GuiChat;
@@ -36,11 +37,13 @@ import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
 
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class ClientEvents implements Listener {
 
     private static final Pattern GUILD_RESOURCE_WARNING = Pattern.compile("\\[INFO\\] Territory .+ is producing more .+");
+    private static final Pattern GUILD_CHAT_MESSAGE = Pattern.compile("\\[(★{0,5})(.+)\\] (.+)");
 
     @SubscribeEvent
     public void onGuiOpen(GuiOpenEvent e) {
@@ -71,6 +74,12 @@ public class ClientEvents implements Listener {
             e.setMessage(new TextComponentString(TextFormatting.DARK_AQUA + "[WAR] " + TextFormatting.GREEN + strippedMsg.substring(6)));
         } else if (ChatConfig.INSTANCE.filterResourceWarnings && McIf.getFormattedText(msg).startsWith(TextFormatting.DARK_AQUA + "[INFO") && GUILD_RESOURCE_WARNING.matcher(strippedMsg).matches()) {
             e.setCanceled(true);
+        } else if (ChatConfig.INSTANCE.guildRoleNames && McIf.getFormattedText(msg).startsWith(TextFormatting.DARK_AQUA + "[")) {
+            Matcher matcher = GUILD_CHAT_MESSAGE.matcher(strippedMsg);
+            if (matcher.matches()) {
+                String roleName = PlayerStatsProfile.GuildRank.getRoleNameFromStars(matcher.group(1).length());
+                e.setMessage(new TextComponentString(TextFormatting.DARK_AQUA + "[" + TextFormatting.AQUA + roleName + " " + TextFormatting.DARK_AQUA + matcher.group(2) + "] " + TextFormatting.AQUA + matcher.group(3)));
+            }
         }
     }
 

--- a/src/main/java/com/wynntils/modules/chat/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/chat/events/ClientEvents.java
@@ -82,8 +82,8 @@ public class ClientEvents implements Listener {
      * /xp -> /guild xp
      *
      * /guild att/a -> attack
-     *        def/d -> defend
-     *        c -> contribute
+     *        defend/def/d -> territory (/guild territory is the old /guild defend)
+     *        man/m -> manage
      * /party j -> join
      *        i -> invite
      *        l -> leave
@@ -93,7 +93,7 @@ public class ClientEvents implements Listener {
     public void commandReplacements(ClientChatEvent e) {
         if (e.getMessage().startsWith("/tell")) e.setMessage(e.getMessage().replaceFirst("/tell", "/msg"));
         else if (e.getMessage().startsWith("/xp")) e.setMessage(e.getMessage().replaceFirst("/xp", "/guild xp"));
-        else if (e.getMessage().startsWith("/gu")) e.setMessage(e.getMessage().replaceFirst(" att$", " attack").replaceFirst(" a$", " attack").replaceFirst(" def$", " defend").replaceFirst(" d$", " defend").replaceFirst(" c$", " contribute"));
+        else if (e.getMessage().startsWith("/gu")) e.setMessage(e.getMessage().replaceFirst(" att$", " attack").replaceFirst(" a$", " attack").replaceFirst(" defend$", " territory").replaceFirst(" def$", " territory").replaceFirst(" d$", " territory").replaceFirst(" man$", " manage").replaceFirst(" m$", " manage"));
         else if (e.getMessage().startsWith("/pa")) e.setMessage(e.getMessage().replaceFirst(" j ", " join ").replaceFirst(" i ", " invite ").replaceFirst(" l$", " leave").replaceFirst(" c$", " create"));
     }
 

--- a/src/main/java/com/wynntils/modules/chat/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/chat/events/ClientEvents.java
@@ -36,7 +36,11 @@ import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
 
+import java.util.regex.Pattern;
+
 public class ClientEvents implements Listener {
+
+    private static final Pattern GUILD_RESOURCE_WARNING = Pattern.compile("\\[INFO\\] Territory .+ is producing more .+");
 
     @SubscribeEvent
     public void onGuiOpen(GuiOpenEvent e) {
@@ -51,6 +55,7 @@ public class ClientEvents implements Listener {
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onChatReceived(ClientChatReceivedEvent e) {
         ITextComponent msg = e.getMessage();
+        String strippedMsg = StringUtils.stripControlCodes(McIf.getUnformattedText(msg));
         if (McIf.getUnformattedText(msg).startsWith("[Info] ") && ChatConfig.INSTANCE.filterWynncraftInfo) {
             e.setCanceled(true);
         } else if (McIf.getFormattedText(msg).startsWith("\n                       " + TextFormatting.GOLD + TextFormatting.BOLD + "Welcome to Wynncraft!") &&
@@ -60,10 +65,12 @@ public class ClientEvents implements Listener {
             e.setCanceled(true);
         } else if (McIf.getFormattedText(msg).startsWith(TextFormatting.GRAY + "[You are now leaving") && ChatConfig.INSTANCE.filterTerritoryEnter) {
             e.setCanceled(true);
-        } else if (ChatConfig.INSTANCE.recolorGuildWarSuccess && McIf.getFormattedText(msg).startsWith(TextFormatting.DARK_AQUA + "[WAR") && StringUtils.stripControlCodes(McIf.getUnformattedText(msg)).startsWith("[WAR] You have taken control of")) {
-            e.setMessage(new TextComponentString(TextFormatting.DARK_AQUA + "[WAR] " + TextFormatting.GREEN + StringUtils.stripControlCodes(McIf.getUnformattedText(msg)).substring(6)));
-        } else if (ChatConfig.INSTANCE.recolorGuildWarSuccess && McIf.getFormattedText(msg).startsWith(TextFormatting.DARK_AQUA + "[WAR") && StringUtils.stripControlCodes(McIf.getUnformattedText(msg)).startsWith("[WAR] Your guild has successfully defended")) {
-            e.setMessage(new TextComponentString(TextFormatting.DARK_AQUA + "[WAR] " + TextFormatting.GREEN + StringUtils.stripControlCodes(McIf.getUnformattedText(msg)).substring(6)));
+        } else if (ChatConfig.INSTANCE.recolorGuildWarSuccess && McIf.getFormattedText(msg).startsWith(TextFormatting.DARK_AQUA + "[WAR") && strippedMsg.startsWith("[WAR] You have taken control of")) {
+            e.setMessage(new TextComponentString(TextFormatting.DARK_AQUA + "[WAR] " + TextFormatting.GREEN + strippedMsg.substring(6)));
+        } else if (ChatConfig.INSTANCE.recolorGuildWarSuccess && McIf.getFormattedText(msg).startsWith(TextFormatting.DARK_AQUA + "[WAR") && strippedMsg.startsWith("[WAR] Your guild has successfully defended")) {
+            e.setMessage(new TextComponentString(TextFormatting.DARK_AQUA + "[WAR] " + TextFormatting.GREEN + strippedMsg.substring(6)));
+        } else if (ChatConfig.INSTANCE.filterResourceWarnings && McIf.getFormattedText(msg).startsWith(TextFormatting.DARK_AQUA + "[INFO") && GUILD_RESOURCE_WARNING.matcher(strippedMsg).matches()) {
+            e.setCanceled(true);
         }
     }
 

--- a/src/main/java/com/wynntils/modules/utilities/UtilitiesModule.java
+++ b/src/main/java/com/wynntils/modules/utilities/UtilitiesModule.java
@@ -52,6 +52,7 @@ public class UtilitiesModule extends Module {
         registerEvents(new BankOverlay());
         registerEvents(new ServerSelectorOverlay());
         registerEvents(new FavoriteItemsOverlay());
+        registerEvents(new GuildTerritoryManageOverlay());
 
         // Real overlays
         registerOverlay(new WarTimerOverlay(), Priority.LOWEST);

--- a/src/main/java/com/wynntils/modules/utilities/configs/OverlayConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/OverlayConfig.java
@@ -746,6 +746,9 @@ public class OverlayConfig extends SettingsClass {
         @Setting(displayName = "Text Colour", description = "What colour should the objective text be?\n\n§aClick the coloured box to open the colour wheel.")
         public CustomColor textColour = CommonColors.GREEN;
 
+        @Setting(displayName = "Text Colour", description = "What colour should the guild objective text be?\n\n§aClick the coloured box to open the colour wheel.")
+        public CustomColor guildTextColour = CommonColors.LIGHT_BLUE;
+
         @Setting(displayName = "Text Shadow", description = "What should the text shadow look like?")
         public SmartFontRenderer.TextShadow textShadow = SmartFontRenderer.TextShadow.OUTLINE;
 

--- a/src/main/java/com/wynntils/modules/utilities/configs/OverlayConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/OverlayConfig.java
@@ -38,6 +38,9 @@ public class OverlayConfig extends SettingsClass {
     @Setting(displayName = "Use Y Position on Action Bar", description = "Should the action bar display your elevation instead of your orientation?")
     public boolean replaceDirection = false;
 
+    @Setting(displayName = "Remove Guild War Timers", description = "Should guild war timers be removed from the scoreboard?")
+    public boolean removeGuildWarTimers = false;
+
     @SettingsInfo(name = "health_settings", displayPath = "Utilities/Overlays/Health")
     public static class Health extends SettingsClass {
         public static Health INSTANCE;
@@ -748,7 +751,7 @@ public class OverlayConfig extends SettingsClass {
 
         @Setting(displayName = "Guild Objective Text Colour", description = "What colour should the guild objective text be?\n\n§aClick the coloured box to open the colour wheel.")
         public CustomColor guildTextColour = CommonColors.LIGHT_BLUE;
-        
+
         @Setting(displayName = "Text Shadow", description = "What should the text shadow look like?")
         public SmartFontRenderer.TextShadow textShadow = SmartFontRenderer.TextShadow.OUTLINE;
 

--- a/src/main/java/com/wynntils/modules/utilities/configs/OverlayConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/OverlayConfig.java
@@ -743,12 +743,12 @@ public class OverlayConfig extends SettingsClass {
         @Setting(displayName = "Objectives Bar Texture", description = "What texture should be used for the objectives bar?")
         public objectivesTextures objectivesTexture = objectivesTextures.a;
 
-        @Setting(displayName = "Text Colour", description = "What colour should the objective text be?\n\n§aClick the coloured box to open the colour wheel.")
+        @Setting(displayName = "Objective Text Colour", description = "What colour should the objective text be?\n\n§aClick the coloured box to open the colour wheel.")
         public CustomColor textColour = CommonColors.GREEN;
 
-        @Setting(displayName = "Text Colour", description = "What colour should the guild objective text be?\n\n§aClick the coloured box to open the colour wheel.")
+        @Setting(displayName = "Guild Objective Text Colour", description = "What colour should the guild objective text be?\n\n§aClick the coloured box to open the colour wheel.")
         public CustomColor guildTextColour = CommonColors.LIGHT_BLUE;
-
+        
         @Setting(displayName = "Text Shadow", description = "What should the text shadow look like?")
         public SmartFontRenderer.TextShadow textShadow = SmartFontRenderer.TextShadow.OUTLINE;
 

--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -80,6 +80,12 @@ public class UtilitiesConfig extends SettingsClass {
     @Setting(displayName = "FOV Scaling Function", description = "What scaling function should be used for speed-based FOV changes?", order = 21)
     public FovScalingFunction fovScalingFunction = FovScalingFunction.Vanilla;
 
+    @Setting(displayName = "Show Guild Manage Territory Search Bar", description = "Should the search bar be shown in the guild manage territory GUI?\n\n§8Territories that match the search will be highlighted.", order = 22)
+    public boolean showGuildTerritoryManageSearchbar = true;
+
+    @Setting(displayName = "Searched Item Highlight Colour", description = "What colour should the highlight for searched items be?\n\n§aClick the coloured box to open the colour wheel.", order = 23)
+    public CustomColor guildTerritoryMenuSearchHighlightColor = new CustomColor(80, 242, 242);
+
     @Setting(displayName = "Auto Mount Horse", description = "Should you mount your horse automatically when it is summoned?", order = 2)
     public boolean autoMount = false;
 

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/ObjectivesOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/ObjectivesOverlay.java
@@ -12,6 +12,7 @@ import com.wynntils.core.framework.rendering.SmartFontRenderer;
 import com.wynntils.core.framework.rendering.colors.CustomColor;
 import com.wynntils.core.framework.rendering.textures.Textures;
 import com.wynntils.modules.utilities.configs.OverlayConfig;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.network.play.server.SPacketDisplayObjective;
 import net.minecraft.network.play.server.SPacketScoreboardObjective;
 import net.minecraft.network.play.server.SPacketUpdateScore;
@@ -26,17 +27,21 @@ import java.util.regex.Pattern;
 public class ObjectivesOverlay extends Overlay {
 
     public static final Pattern OBJECTIVE_PATTERN = Pattern.compile("^[- ] (.*): *([0-9]+)/([0-9]+)$");
-    public static final Pattern HEADER_PATTERN = Pattern.compile("(★ )?(Daily )?Objectives?:");
+    public static final Pattern OBJECTIVE_HEADER_PATTERN = Pattern.compile("(★ )?(Daily )?Objectives?:");
+    public static final Pattern GUILD_OBJECTIVE_HEADER_PATTERN = Pattern.compile("Guild Obj: (.+)");
 
     private static final int WIDTH = 130;
-    private static final int HEIGHT = 52;
+    private static final int HEIGHT = 70;
     private static final int MAX_OBJECTIVES = 3;
 
     private static final Objective[] objectives = new Objective[MAX_OBJECTIVES];
+    private static Objective guildObjectives = null;
     private static String sidebarObjectiveName;
     private static long keepVisibleTimestamp;
     private static int objectivesPosition;
     private static int objectivesEnd;
+    private static int guildObjectivesPosition;
+    private static int guildObjectivesEnd;
 
     public ObjectivesOverlay() {
         super("Objectives", WIDTH, HEIGHT, true, 1f, 1f, -1, -1, OverlayGrowFrom.BOTTOM_RIGHT);
@@ -106,7 +111,7 @@ public class ObjectivesOverlay extends Overlay {
         if (updateScore.getObjectiveName().equals(sidebarObjectiveName)) {
             if (updateScore.getScoreAction() == SPacketUpdateScore.Action.REMOVE) {
                 String objectiveLine = TextFormatting.getTextWithoutFormattingCodes(updateScore.getPlayerName());
-                if (HEADER_PATTERN.matcher(objectiveLine).matches()) {
+                if (OBJECTIVE_HEADER_PATTERN.matcher(objectiveLine).matches()) {
                     objectivesPosition = 0;
                     return true;
                 }
@@ -116,14 +121,23 @@ public class ObjectivesOverlay extends Overlay {
             }
 
             String text = TextFormatting.getTextWithoutFormattingCodes(updateScore.getPlayerName());
-            if (HEADER_PATTERN.matcher(text).matches()) {
+            if (OBJECTIVE_HEADER_PATTERN.matcher(text).matches()) {
                 objectivesPosition = updateScore.getScoreValue();
                 return true;
-            } else if (updateScore.getPlayerName().equals(TextFormatting.BLACK.toString())) {
+            } else if (updateScore.getPlayerName().equals("ÀÀ")) {
                 objectivesEnd = updateScore.getScoreValue();
                 return true;
             }
 
+            if (GUILD_OBJECTIVE_HEADER_PATTERN.matcher(text).matches()) {
+                guildObjectivesPosition = updateScore.getScoreValue();
+                return true;
+            } else if (updateScore.getPlayerName().equals("ÀÀÀ")) {
+                guildObjectivesEnd = updateScore.getScoreValue();
+                return true;
+            }
+
+            // Normal objective
             if (updateScore.getScoreValue() < objectivesPosition && (objectivesEnd == 0 || updateScore.getScoreValue() > objectivesEnd)) {
                 int pos = objectivesPosition - 1 - updateScore.getScoreValue();
                 if (pos + 1 > MAX_OBJECTIVES) {
@@ -134,6 +148,14 @@ public class ObjectivesOverlay extends Overlay {
                 String objectiveLine = TextFormatting.getTextWithoutFormattingCodes(updateScore.getPlayerName());
                 if (OBJECTIVE_PATTERN.matcher(objectiveLine).find()) // only create objective if it matches the format
                     objectives[pos] = parseObjectiveLine(objectiveLine);
+                return true;
+            }
+
+            // Guild objective
+            if (updateScore.getScoreValue() < guildObjectivesPosition && (guildObjectivesEnd == 0 || updateScore.getScoreValue() > guildObjectivesEnd)) {
+                String objectiveLine = TextFormatting.getTextWithoutFormattingCodes(updateScore.getPlayerName());
+                if (OBJECTIVE_PATTERN.matcher(objectiveLine).find()) // only create objective if it matches the format
+                    guildObjectives = parseObjectiveLine(objectiveLine);
                 return true;
             }
         }
@@ -192,13 +214,16 @@ public class ObjectivesOverlay extends Overlay {
         }
     }
 
-    private CustomColor getAlphaAdjustedColor(float fadeAlpha) {
+    private CustomColor getAlphaAdjustedColor(float fadeAlpha, boolean guildObjective) {
         CustomColor color = new CustomColor(OverlayConfig.Objectives.INSTANCE.textColour);
+        if (guildObjective) {
+            color = new CustomColor(OverlayConfig.Objectives.INSTANCE.guildTextColour);
+        }
         color.setA(OverlayConfig.Objectives.INSTANCE.objectivesAlpha * fadeAlpha);
         return color;
     }
 
-    private void renderObjective(Objective objective, int height) {
+    private void renderObjective(Objective objective, int height, boolean guildObjective) {
         float fadeAlpha = 1.0f;
 
         if (OverlayConfig.Objectives.INSTANCE.hideOnInactivity) {
@@ -209,7 +234,7 @@ public class ObjectivesOverlay extends Overlay {
             }
         }
 
-        drawString(objective.toString(), -WIDTH, -HEIGHT + height + 1, getAlphaAdjustedColor(fadeAlpha),
+        drawString(objective.toString(), -WIDTH, -HEIGHT + height + 1, getAlphaAdjustedColor(fadeAlpha, guildObjective),
                 SmartFontRenderer.TextAlignment.LEFT_RIGHT, OverlayConfig.Objectives.INSTANCE.textShadow);
 
         if (OverlayConfig.Objectives.INSTANCE.enableProgressBar && objective.hasProgress()) {
@@ -224,24 +249,31 @@ public class ObjectivesOverlay extends Overlay {
         if (!Reference.onWorld || !OverlayConfig.Objectives.INSTANCE.enabled ||
                 event.getType() != RenderGameOverlayEvent.ElementType.ALL) return;
 
-        int height = 36;
+        int height = 54;
+
+        if (guildObjectives != null) {
+            renderObjective(guildObjectives, height, true);
+            height -= 18;
+        } else if (!OverlayConfig.Objectives.INSTANCE.growFromBottom) {
+            height -= 18;
+        }
 
         if (objectives[2] != null) {
-            renderObjective(objectives[2], height);
+            renderObjective(objectives[2], height, false);
             height -= 18;
         } else if (!OverlayConfig.Objectives.INSTANCE.growFromBottom) {
             height -= 18;
         }
 
         if (objectives[1] != null) {
-            renderObjective(objectives[1], height);
+            renderObjective(objectives[1], height, false);
             height -= 18;
         } else if (!OverlayConfig.Objectives.INSTANCE.growFromBottom) {
             height -= 18;
         }
 
         if (objectives[0] != null) {
-            renderObjective(objectives[0], height);
+            renderObjective(objectives[0], height, false);
         }
     }
 

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/ScoreboardOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/ScoreboardOverlay.java
@@ -23,8 +23,11 @@ import net.minecraftforge.client.event.RenderGameOverlayEvent;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 public class ScoreboardOverlay extends Overlay {
+
+    private static final Pattern GUILD_WAR_TIMER = Pattern.compile("- (\\d+\\d+:\\d+\\d+) (.+)");
 
     public ScoreboardOverlay() {
         super("Scoreboard", 125, 60, true, 1, 0.5f, 0, 0, OverlayGrowFrom.MIDDLE_RIGHT);
@@ -49,6 +52,7 @@ public class ScoreboardOverlay extends Overlay {
 
         // remove objective, compass lines, quest lines, then remove unnecessary blanks
         if (OverlayConfig.Objectives.INSTANCE.enabled) removeObjectiveLines(scores);
+        if (OverlayConfig.INSTANCE.removeGuildWarTimers) removeGuildWarTimerLines(scores);
         if (!OverlayConfig.Scoreboard.INSTANCE.showCompass || QuestBookConfig.INSTANCE.autoUpdateQuestbook) removeCompassLines(scores);
         if (QuestBookConfig.INSTANCE.autoUpdateQuestbook) removeQuestLines(scores);
         trimBlankLines(scores);
@@ -94,6 +98,11 @@ public class ScoreboardOverlay extends Overlay {
             }
         }
 
+    }
+
+    private void removeGuildWarTimerLines(List<Score> scores) {
+        scores.removeIf(s -> TextFormatting.getTextWithoutFormattingCodes(s.getPlayerName()).matches(GUILD_WAR_TIMER.pattern()));
+        scores.removeIf(s -> TextFormatting.getTextWithoutFormattingCodes(s.getPlayerName()).equalsIgnoreCase("Upcoming Attacks:"));
     }
 
     private void removeObjectiveLines(List<Score> scores) {

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/ScoreboardOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/ScoreboardOverlay.java
@@ -97,10 +97,10 @@ public class ScoreboardOverlay extends Overlay {
     }
 
     private void removeObjectiveLines(List<Score> scores) {
-        scores.removeIf(s -> TextFormatting.getTextWithoutFormattingCodes(s.getPlayerName()).matches(ObjectivesOverlay.OBJECTIVE_PATTERN.pattern())
-                && !s.getPlayerName().startsWith(TextFormatting.AQUA.toString()));
+        scores.removeIf(s -> TextFormatting.getTextWithoutFormattingCodes(s.getPlayerName()).matches(ObjectivesOverlay.OBJECTIVE_PATTERN.pattern()));
         scores.removeIf(s -> TextFormatting.getTextWithoutFormattingCodes(s.getPlayerName()).matches("- All done"));
-        scores.removeIf(s -> TextFormatting.getTextWithoutFormattingCodes(s.getPlayerName()).matches(ObjectivesOverlay.HEADER_PATTERN.pattern()));
+        scores.removeIf(s -> TextFormatting.getTextWithoutFormattingCodes(s.getPlayerName()).matches(ObjectivesOverlay.OBJECTIVE_HEADER_PATTERN.pattern()));
+        scores.removeIf(s -> TextFormatting.getTextWithoutFormattingCodes(s.getPlayerName()).matches(ObjectivesOverlay.GUILD_OBJECTIVE_HEADER_PATTERN.pattern()));
 
         scores.removeIf(s -> s.getPlayerName().startsWith(TextFormatting.RED + "- "));
     }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/GuildTerritoryManageOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/GuildTerritoryManageOverlay.java
@@ -1,0 +1,117 @@
+package com.wynntils.modules.utilities.overlays.inventories;
+
+import com.wynntils.McIf;
+import com.wynntils.core.events.custom.GuiOverlapEvent;
+import com.wynntils.core.framework.interfaces.Listener;
+import com.wynntils.core.framework.rendering.ScreenRenderer;
+import com.wynntils.core.framework.rendering.SpecialRendering;
+import com.wynntils.core.framework.ui.elements.GuiTextFieldWynn;
+import com.wynntils.modules.utilities.configs.UtilitiesConfig;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.init.Items;
+import net.minecraft.inventory.Slot;
+import net.minecraft.util.StringUtils;
+import net.minecraft.util.text.TextFormatting;
+import net.minecraftforge.fml.common.eventhandler.EventPriority;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import org.lwjgl.input.Keyboard;
+
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class GuildTerritoryManageOverlay implements Listener {
+    private static final Pattern GUI_PATTERN = Pattern.compile("(.+): Territories");
+
+    private GuiTextFieldWynn searchField = null;
+    private boolean inTerritoryManageMenu = false;
+
+    @SubscribeEvent
+    public void onInit(GuiOverlapEvent.ChestOverlap.InitGui e) {
+        Matcher m = GUI_PATTERN.matcher(TextFormatting.getTextWithoutFormattingCodes(e.getGui().getLowerInv().getName()));
+        if (!m.matches()) return;
+
+        inTerritoryManageMenu = true;
+
+        if (searchField == null && UtilitiesConfig.INSTANCE.showGuildTerritoryManageSearchbar) {
+            int nameWidth = McIf.mc().fontRenderer.getStringWidth(McIf.getUnformattedText(e.getGui().getUpperInv().getDisplayName()));
+            searchField = new GuiTextFieldWynn(201, McIf.mc().fontRenderer, nameWidth + 13, 108, 157 - nameWidth, 10);
+            searchField.setText("Search...");
+        }
+
+        Keyboard.enableRepeatEvents(true);
+    }
+
+    @SubscribeEvent
+    public void onClose(GuiOverlapEvent.ChestOverlap.GuiClosed e) {
+        // reset everything
+        searchField = null;
+        inTerritoryManageMenu = false;
+        Keyboard.enableRepeatEvents(false);
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOWEST)
+    public void onDrawBackground(GuiOverlapEvent.ChestOverlap.DrawGuiContainerBackgroundLayer e) {
+        if (!inTerritoryManageMenu) return;
+
+        // search highlight
+        for (Slot s : e.getGui().inventorySlots.inventorySlots) {
+            if (s.getStack().isEmpty() || !s.getStack().hasDisplayName() || (s.getStack().getItem() != Items.MAP && s.getStack().getItem() != Items.PAPER)) continue;
+            if (!s.getStack().getDisplayName().startsWith(TextFormatting.WHITE + TextFormatting.BOLD.toString())) continue;
+            String displayName = StringUtils.stripControlCodes(s.getStack().getDisplayName()).toLowerCase(Locale.ROOT);
+            if (searchField.getText().isEmpty() || !displayName.contains(searchField.getText().toLowerCase(Locale.ROOT))) continue;
+
+            SpecialRendering.renderGodRays(e.getGui().getGuiLeft() + s.xPos + 5,
+                    e.getGui().getGuiTop() + s.yPos + 6, 0, 5f, 35, UtilitiesConfig.INSTANCE.guildTerritoryMenuSearchHighlightColor);
+        }
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOWEST)
+    public void onDrawForeground(GuiOverlapEvent.ChestOverlap.DrawGuiContainerForegroundLayer e) {
+        if (!inTerritoryManageMenu) return;
+
+        ScreenRenderer.beginGL(0, 0);
+        GlStateManager.translate(0, 0, 300F);
+        if (searchField != null) searchField.drawTextBox();
+        GlStateManager.translate(0, 0, -300F);
+        ScreenRenderer.endGL();
+    }
+
+    @SubscribeEvent
+    public void onMouseClicked(GuiOverlapEvent.ChestOverlap.MouseClicked e) {
+        if (!inTerritoryManageMenu) return;
+
+        int offsetMouseX = e.getMouseX() - e.getGui().getGuiLeft();
+        int offsetMouseY = e.getMouseY() - e.getGui().getGuiTop();
+
+        // handle mouse input on search box
+        if (searchField != null) {
+            searchField.mouseClicked(offsetMouseX, offsetMouseY, e.getMouseButton());
+            if (e.getMouseButton() == 0) { // left click
+                if (searchField.isFocused()) {
+                    searchField.setCursorPositionEnd();
+                    searchField.setSelectionPos(0);
+                } else {
+                    searchField.setSelectionPos(searchField.getCursorPosition());
+                }
+            }
+        }
+    }
+
+    @SubscribeEvent
+    public void onKeyTyped(GuiOverlapEvent.ChestOverlap.KeyTyped e) {
+        if (!inTerritoryManageMenu) return;
+
+        if (searchField != null && searchField.isFocused()) {
+            e.setCanceled(true);
+            if (e.getKeyCode() == Keyboard.KEY_ESCAPE) {
+                searchField.setFocused(false);
+            } else {
+                searchField.textboxKeyTyped(e.getTypedChar(), e.getKeyCode());
+            }
+        } else if (e.getKeyCode() == Keyboard.KEY_ESCAPE || e.getKeyCode() == McIf.mc().gameSettings.keyBindInventory.getKeyCode()) { // bank was closed by player
+            searchField = null;
+            inTerritoryManageMenu = false;
+        }
+    }
+}

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/GuildTerritoryManageOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/GuildTerritoryManageOverlay.java
@@ -85,33 +85,42 @@ public class GuildTerritoryManageOverlay implements Listener {
         int offsetMouseY = e.getMouseY() - e.getGui().getGuiTop();
 
         // handle mouse input on search box
-        if (searchField != null) {
-            searchField.mouseClicked(offsetMouseX, offsetMouseY, e.getMouseButton());
-            if (e.getMouseButton() == 0) { // left click
-                if (searchField.isFocused()) {
-                    searchField.setCursorPositionEnd();
-                    searchField.setSelectionPos(0);
-                } else {
-                    searchField.setSelectionPos(searchField.getCursorPosition());
-                }
-            }
+        if (searchField == null) {
+            return;
         }
+
+        // Process the search field click interaction
+        searchField.mouseClicked(offsetMouseX, offsetMouseY, e.getMouseButton());
+
+        // Only listen for left clicks
+        if (e.getMouseButton() != 0) {
+            return;
+        }
+
+        if (searchField.isFocused()) {
+            searchField.setCursorPositionEnd();
+            searchField.setSelectionPos(0);
+            return;
+        }
+
+        searchField.setSelectionPos(searchField.getCursorPosition());
     }
 
     @SubscribeEvent
     public void onKeyTyped(GuiOverlapEvent.ChestOverlap.KeyTyped e) {
         if (!inTerritoryManageMenu) return;
 
-        if (searchField != null && searchField.isFocused()) {
-            e.setCanceled(true);
-            if (e.getKeyCode() == Keyboard.KEY_ESCAPE) {
-                searchField.setFocused(false);
-            } else {
-                searchField.textboxKeyTyped(e.getTypedChar(), e.getKeyCode());
-            }
-        } else if (e.getKeyCode() == Keyboard.KEY_ESCAPE || e.getKeyCode() == McIf.mc().gameSettings.keyBindInventory.getKeyCode()) { // bank was closed by player
-            searchField = null;
-            inTerritoryManageMenu = false;
+        if (searchField == null || !searchField.isFocused()) {
+            return;
         }
+
+        e.setCanceled(true);
+
+        if (e.getKeyCode() == Keyboard.KEY_ESCAPE) {
+            searchField.setFocused(false);
+            return;
+        }
+
+        searchField.textboxKeyTyped(e.getTypedChar(), e.getKeyCode());
     }
 }

--- a/src/main/java/com/wynntils/webapi/profiles/player/PlayerStatsProfile.java
+++ b/src/main/java/com/wynntils/webapi/profiles/player/PlayerStatsProfile.java
@@ -364,6 +364,25 @@ public class PlayerStatsProfile {
         public String getStars() {
             return stars;
         }
+
+        public static String getRoleNameFromStars(int starCount) {
+            switch (starCount) {
+                case 5:
+                    return "Owner";
+                case 4:
+                    return "Chief";
+                case 3:
+                    return "Strategist";
+                case 2:
+                    return "Captain";
+                case 1:
+                    return "Recruiter";
+                case 0:
+                    return "Recruit";
+                default:
+                    return "";
+            }
+        }
     }
 
     public static class PlayerStatsProfileDeserializer implements JsonDeserializer<PlayerStatsProfile> {


### PR DESCRIPTION
List of new features:
- Ability to recolor successful guild war related info to green (when the player's guild took a territory or successfully defended it)
- Added support for guild objective overlay (the commit (https://github.com/Wynntils/Wynntils/commit/89e3ccacaf1b06180b8ead7b161a824bc03d1a0e) also includes a fix to a bug where the index of the last scoreboard line displaying objective tasks was not calculated correctly, causing spam in the logger)
- Added an option to filter guild resource warnings from chat (disabled by default)
- Updated multiple guild related command aliases (read https://github.com/Wynntils/Wynntils/commit/e93bab14624cc86bcdf092336e52dee4dfbe3049 for more info) 
- Added an overlay to the guild manage menu so territories can be highlighted with a search box
- Added the ability to disable guild war times from the scoreboard (disabled by default)
- Added the ability to replace stars in guild chat names and use proper guild role names (`**** -> Chief`, `** -> Captain`)