### PR TITLE
Fix issues related to zooming on world map introduced by #430

### DIFF
--- a/src/main/java/com/wynntils/modules/map/overlays/ui/WorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/WorldMapUI.java
@@ -426,9 +426,9 @@ public class WorldMapUI extends GuiMovementScreen {
     }
 
     protected void handleZoomAcceleration(float partialTicks) {
-        if (System.nanoTime() > zoomEnd) return;
+        if (McIf.getSystemTime() > zoomEnd) return;
 
-        float percentage = MathHelper.clamp(1f - (zoomEnd - System.nanoTime()) / ZOOM_RESISTANCE, 0f, 1f);
+        float percentage = MathHelper.clamp(1f - (zoomEnd - McIf.getSystemTime()) / ZOOM_RESISTANCE, 0f, 1f);
         double toIncrease = (zoomTarget - zoomInitial) * Math.sin((Math.PI / 2f) * percentage);
 
         zoom = zoomInitial + (float) toIncrease;
@@ -472,7 +472,7 @@ public class WorldMapUI extends GuiMovementScreen {
         double zoomScale = Math.pow(ZOOM_SCALE_FACTOR, -by);
         zoomTarget = (float) MathHelper.clamp(zoomScale * (zoom + 50) - 50, MIN_ZOOM, MAX_ZOOM);
 
-        zoomEnd = System.nanoTime() + ZOOM_RESISTANCE;
+        zoomEnd = McIf.getSystemTime() + ZOOM_RESISTANCE;
         zoomInitial = zoom;
     }
 


### PR DESCRIPTION
Using `System.nanoTime()` causes issues for some users, reverting the change and let's just use `McIf.getSystemTime()`. The old bug should not come back, as clamping takes care of that.

I don't see any obvious reason why `McIf.getSystemTime()` would work better, but using it solves the issue. Also note that I was not able to reproduce the issue myself (zooming works fine for me), but this revert was tested by someone with the issue and it fixed it for them. 

If there is any obvious thing I missed, please let me know.

EDIT: Link to the PR causing this issue: https://github.com/Wynntils/Wynntils/pull/430