### PR TITLE
Fix a (catched) exception when using Chunk Caching

### DIFF
--- a/src/main/java/com/wynntils/modules/visual/managers/CachedChunkManager.java
+++ b/src/main/java/com/wynntils/modules/visual/managers/CachedChunkManager.java
@@ -17,8 +17,10 @@ import org.apache.commons.io.FileUtils;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -38,7 +40,7 @@ public class CachedChunkManager {
             .setNameFormat("Wynntils-CachedChunks-%d").build()
     );
 
-    private static final Set<ChunkPos> ignoredChunks = new HashSet<>();
+    private static final Set<ChunkPos> ignoredChunks = Collections.newSetFromMap(new ConcurrentHashMap<>());
     private static boolean running = false;
 
     /**


### PR DESCRIPTION
Fixed a (catched) `java.util.ConcurrentModificationException` in `CachedChunkManager`. The issue was likely caused by the set not syncing properly. 

```
[02:12:36] [Wynntils-CachedChunks-955/INFO] [STDERR]: [com.wynntils.modules.visual.managers.CachedChunkManager:startChunkLoader:222]: java.util.ConcurrentModificationException
[02:12:36] [Wynntils-CachedChunks-955/INFO] [STDERR]: [com.wynntils.modules.visual.managers.CachedChunkManager:startChunkLoader:222]:     at java.util.HashMap$HashIterator.nextNode(HashMap.java:1429)
[02:12:36] [Wynntils-CachedChunks-955/INFO] [STDERR]: [com.wynntils.modules.visual.managers.CachedChunkManager:startChunkLoader:222]:     at java.util.HashMap$KeyIterator.next(HashMap.java:1453)
[02:12:36] [Wynntils-CachedChunks-955/INFO] [STDERR]: [com.wynntils.modules.visual.managers.CachedChunkManager:startChunkLoader:222]:     at java.util.Collection.removeIf(Collection.java:414)
[02:12:36] [Wynntils-CachedChunks-955/INFO] [STDERR]: [com.wynntils.modules.visual.managers.CachedChunkManager:startChunkLoader:222]:     at com.wynntils.modules.visual.managers.CachedChunkManager.startChunkLoader(CachedChunkManager.java:172)
[02:12:36] [Wynntils-CachedChunks-955/INFO] [STDERR]: [com.wynntils.modules.visual.managers.CachedChunkManager:startChunkLoader:222]:     at com.wynntils.modules.visual.managers.CachedChunkManager$$Lambda$757/1991017734.run(Unknown Source)
[02:12:36] [Wynntils-CachedChunks-955/INFO] [STDERR]: [com.wynntils.modules.visual.managers.CachedChunkManager:startChunkLoader:222]:     at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
[02:12:36] [Wynntils-CachedChunks-955/INFO] [STDERR]: [com.wynntils.modules.visual.managers.CachedChunkManager:startChunkLoader:222]:     at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
[02:12:36] [Wynntils-CachedChunks-955/INFO] [STDERR]: [com.wynntils.modules.visual.managers.CachedChunkManager:startChunkLoader:222]:     at java.lang.Thread.run(Thread.java:745)
```


Note: `Collections.newSetFromMap(new ConcurrentHashMap<>())` seems a little strange at first look, but according to documentation it also copies the concurrency of the `HashMap`, so it does exactly what we need.

https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/Collections.html#newSetFromMap(java.util.Map)
> Returns a set backed by the specified map. The resulting set displays the same ordering, concurrency, and performance characteristics as the backing map. 