### PR TITLE
Quest book analysis will no longer break GUIs. 

### DIFF
--- a/src/main/java/com/wynntils/modules/core/instances/inventory/FakeInventory.java
+++ b/src/main/java/com/wynntils/modules/core/instances/inventory/FakeInventory.java
@@ -109,7 +109,10 @@ public class FakeInventory {
         isOpen = false;
 
         // No need to send close window packet on overlap, window was already closed.
-        if (windowId != -1 && result != InventoryResult.CLOSED_OVERLAP) McIf.mc().getConnection().sendPacket(new CPacketCloseWindow(windowId));
+        if (windowId != -1 && result != InventoryResult.CLOSED_OVERLAP) {
+            McIf.mc().getConnection().sendPacket(new CPacketCloseWindow(windowId));
+        }
+        
         windowId = -1;
 
         if(onClose != null) McIf.mc().addScheduledTask(() -> onClose.accept(this, result));

--- a/src/main/java/com/wynntils/modules/core/instances/inventory/FakeInventory.java
+++ b/src/main/java/com/wynntils/modules/core/instances/inventory/FakeInventory.java
@@ -108,7 +108,8 @@ public class FakeInventory {
         FrameworkManager.getEventBus().unregister(this);
         isOpen = false;
 
-        if (windowId != -1) McIf.mc().getConnection().sendPacket(new CPacketCloseWindow(windowId));
+        // No need to send close window packet on overlap, window was already closed.
+        if (windowId != -1 && result != InventoryResult.CLOSED_OVERLAP) McIf.mc().getConnection().sendPacket(new CPacketCloseWindow(windowId));
         windowId = -1;
 
         if(onClose != null) McIf.mc().addScheduledTask(() -> onClose.accept(this, result));


### PR DESCRIPTION
In `FakeInventory` a `CPacketCloseWindow` packet was sent when `result == InventoryResult.CLOSED_OVERLAP`. This behavior closed the window that overlapped the fake inventory, making not only the fake inventory close, but make the server think the opened window was closed when it is still open client-side.

In practice this makes quest book analyzation much safer and will prevent things like [this video](https://www.youtube.com/watch?v=AIXfVjBute8) from happening again.