### PR TITLE
Refactor BankOverlay and fix #378

### DIFF
--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -677,8 +677,6 @@ public class ClientEvents implements Listener {
         }
     }
 
-    private boolean bankPageConfirmed = false;
-
     @SubscribeEvent
     public void clickOnChest(GuiOverlapEvent.ChestOverlap.HandleMouseClick e) {
         if (e.getSlotIn() == null) return;
@@ -740,78 +738,10 @@ public class ClientEvents implements Listener {
             }
         }
 
-        // Bank dump confirm
-        if (e.getSlotIn().getStack().getDisplayName().equals("§dDump Inventory")) {
-            switch (UtilitiesConfig.INSTANCE.bankDumpButton) {
-                case Default:
-                    return;
-                case Confirm:
-                    ChestReplacer gui = e.getGui();
-                    ItemStack item = e.getSlotIn().getStack();
-                    CPacketClickWindow packet = new CPacketClickWindow(gui.inventorySlots.windowId, e.getSlotId(), e.getMouseButton(), e.getType(), item, e.getGui().inventorySlots.getNextTransactionID(McIf.player().inventory));
-                    McIf.mc().displayGuiScreen(new GuiParentedYesNo((result, parentButtonId) -> gui, (result, parentButtonID) -> {
-                        if (result) {
-                            McIf.mc().getConnection().sendPacket(packet);
-                            bankPageConfirmed = true;
-                        }
-                    }, "Are you sure you want to dump your inventory?", "This confirm may be disabled in the Wynntils config.", 0));
-                case Block:
-                    e.setCanceled(true);
-            }
-        }
-
-        // Bank quick stash confirm
-        if (e.getSlotIn().getStack().getDisplayName().equals("§dQuick Stash")) {
-            switch (UtilitiesConfig.INSTANCE.bankStashButton) {
-                case Default:
-                    return;
-                case Confirm:
-                    ChestReplacer gui = e.getGui();
-                    ItemStack item = e.getSlotIn().getStack();
-                    CPacketClickWindow packet = new CPacketClickWindow(gui.inventorySlots.windowId, e.getSlotId(), e.getMouseButton(), e.getType(), item, e.getGui().inventorySlots.getNextTransactionID(McIf.player().inventory));
-                    McIf.mc().displayGuiScreen(new GuiParentedYesNo((result, parentButtonId) -> gui, (result, parentButtonID) -> {
-                        if (result) {
-                            McIf.mc().getConnection().sendPacket(packet);
-                        }
-                    }, "Are you sure you want to quick stash?", "This confirm may be disabled in the Wynntils config.", 0));
-                case Block:
-                    e.setCanceled(true);
-            }
-        }
-
         if (UtilitiesConfig.INSTANCE.preventSlotClicking && e.getGui().getSlotUnderMouse() != null && e.getGui().getSlotUnderMouse().inventory instanceof InventoryPlayer) {
             if ((!EmeraldPouchManager.isEmeraldPouch(e.getGui().getSlotUnderMouse().getStack()) || e.getMouseButton() == 0) && checkDropState(e.getGui().getSlotUnderMouse().getSlotIndex())) {
                 e.setCanceled(true);
             }
-        }
-
-        if (UtilitiesConfig.Bank.INSTANCE.addBankConfirmation) {
-            if (McIf.getUnformattedText(e.getSlotIn().inventory.getDisplayName()).contains("[Pg. ") && e.getSlotIn().getHasStack()) {
-                ItemStack item = e.getSlotIn().getStack();
-                if (item.getDisplayName().contains(">" + TextFormatting.DARK_RED + ">" + TextFormatting.RED + ">" + TextFormatting.DARK_RED + ">" + TextFormatting.RED + ">")) {
-                    String lore = TextFormatting.getTextWithoutFormattingCodes(ItemUtils.getStringLore(item));
-                    String price = lore.substring(lore.indexOf(" Price: ") + 8);
-                    String itemName = item.getDisplayName();
-                    String pageNumber = itemName.substring(9, itemName.indexOf(TextFormatting.RED + " >"));
-                    ChestReplacer gui = e.getGui();
-                    CPacketClickWindow packet = new CPacketClickWindow(gui.inventorySlots.windowId, e.getSlotId(), e.getMouseButton(), e.getType(), item, e.getGui().inventorySlots.getNextTransactionID(McIf.player().inventory));
-                    McIf.mc().displayGuiScreen(new GuiParentedYesNo((result, parentButtonId) -> gui, (result, parentButtonID) -> {
-                        if (result) {
-                            McIf.mc().getConnection().sendPacket(packet);
-                        }
-                    }, "Are you sure you want to purchase another bank page?", "Page number: " + pageNumber + "\nCost: " + price, 0));
-                    e.setCanceled(true);
-                }
-            }
-        }
-    }
-
-    @SubscribeEvent
-    public void onSetSlot(PacketEvent<SPacketSetSlot> event) {
-        if (bankPageConfirmed && event.getPacket().getSlot() == 8) {
-            bankPageConfirmed = false;
-            CPacketClickWindow packet = new CPacketClickWindow(McIf.player().openContainer.windowId, 8, 0, ClickType.PICKUP, event.getPacket().getStack(), McIf.player().openContainer.getNextTransactionID(McIf.player().inventory));
-            McIf.mc().getConnection().sendPacket(packet);
         }
     }
 


### PR DESCRIPTION
Refactored and moved parts of the `BankOverlay` and related event code. This PR also fixes #378. 

NOTE: It seems that behavior related to buying new bank pages is broken on Wynncraft's side. Even with vanilla client, it is basically random if the server responds to the button press or not. We can't do anything about that, but the feature should work once the issue is fixed on Wynncraft's side.

NOTE EDIT: Turns out that behavior is intended, Wynn ignores that button for the few seconds you open the bank page to make sure you don't accidentally buy a page.