### PR TITLE
Fix a crash related to chat rendering in `ChatOverlay`

### DIFF
--- a/src/main/java/com/wynntils/modules/chat/overlays/ChatOverlay.java
+++ b/src/main/java/com/wynntils/modules/chat/overlays/ChatOverlay.java
@@ -70,8 +70,10 @@ public class ChatOverlay extends GuiNewChat {
             GlStateManager.scale(chatScale, chatScale, 1.0F);
             int l = 0;
 
-            for (int i1 = 0; i1 + scrollPos < getCurrentTab().getCurrentMessages().size() && i1 < getLineCount(); ++i1) {
-                ChatLine chatline = getCurrentTab().getCurrentMessages().get(i1 + scrollPos);
+            List<ChatLine> currentMessages = getCurrentTab().getCurrentMessages();
+            int currentMessagesSize = currentMessages.size();
+            for (int i1 = 0; i1 + scrollPos < currentMessagesSize && i1 < getLineCount(); ++i1) {
+                ChatLine chatline = currentMessages.get(i1 + scrollPos);
 
                 if (chatline != null) {
                     int j1 = updateCounter - chatline.getUpdatedCounter();
@@ -108,13 +110,12 @@ public class ChatOverlay extends GuiNewChat {
 
             if (flag) {
                 // continuing chat render
-                int chatSize = getCurrentTab().getCurrentMessages().size();
-                if (chatSize > 0) {
+                if (currentMessagesSize > 0) {
                     int k2 = McIf.mc().fontRenderer.FONT_HEIGHT;
                     GlStateManager.translate(-3.0F, 0.0F, 0.0F);
-                    int l2 = chatSize * k2 + chatSize;
+                    int l2 = currentMessagesSize * k2 + currentMessagesSize;
                     int i3 = l * k2 + l;
-                    int j3 = scrollPos * i3 / chatSize;
+                    int j3 = scrollPos * i3 / currentMessagesSize;
                     int k1 = i3 * i3 / l2;
 
                     if (l2 != i3) {

--- a/src/main/java/com/wynntils/modules/chat/overlays/ChatOverlay.java
+++ b/src/main/java/com/wynntils/modules/chat/overlays/ChatOverlay.java
@@ -394,7 +394,7 @@ public class ChatOverlay extends GuiNewChat {
 
     public void updateLine(ChatTab tab, int id, Function<ITextComponent, ITextComponent> change) {
         updateLines(tab, new HashMap<Integer, Pair<Supplier<Boolean>, Function<ITextComponent, ITextComponent>>>()
-        {{ put(id, new Pair<>(() -> true, change)); }});
+            {{ put(id, new Pair<>(() -> true, change)); }});
     }
 
     public void refreshChat() {

--- a/src/main/java/com/wynntils/modules/chat/overlays/ChatOverlay.java
+++ b/src/main/java/com/wynntils/modules/chat/overlays/ChatOverlay.java
@@ -61,9 +61,7 @@ public class ChatOverlay extends GuiNewChat {
         if (McIf.mc().gameSettings.chatVisibility != EntityPlayer.EnumChatVisibility.HIDDEN) {
             getCurrentTab().checkNotifications();
 
-            boolean flag = false;
-
-            if (getChatOpen()) flag = true;
+            boolean flag = getChatOpen();
 
             float chatScale = getChatScale();
             int extraY = MathHelper.ceil((float)getChatWidth() / chatScale) + 4;

--- a/src/main/java/com/wynntils/modules/chat/overlays/ChatOverlay.java
+++ b/src/main/java/com/wynntils/modules/chat/overlays/ChatOverlay.java
@@ -59,8 +59,6 @@ public class ChatOverlay extends GuiNewChat {
 
     public void drawChat(int updateCounter) {
         if (McIf.mc().gameSettings.chatVisibility != EntityPlayer.EnumChatVisibility.HIDDEN) {
-            int chatSize = getCurrentTab().getCurrentMessages().size();
-
             getCurrentTab().checkNotifications();
 
             boolean flag = false;
@@ -74,7 +72,7 @@ public class ChatOverlay extends GuiNewChat {
             GlStateManager.scale(chatScale, chatScale, 1.0F);
             int l = 0;
 
-            for (int i1 = 0; i1 + scrollPos < chatSize && i1 < getLineCount(); ++i1) {
+            for (int i1 = 0; i1 + scrollPos < getCurrentTab().getCurrentMessages().size() && i1 < getLineCount(); ++i1) {
                 ChatLine chatline = getCurrentTab().getCurrentMessages().get(i1 + scrollPos);
 
                 if (chatline != null) {
@@ -112,6 +110,7 @@ public class ChatOverlay extends GuiNewChat {
 
             if (flag) {
                 // continuing chat render
+                int chatSize = getCurrentTab().getCurrentMessages().size();
                 if (chatSize > 0) {
                     int k2 = McIf.mc().fontRenderer.FONT_HEIGHT;
                     GlStateManager.translate(-3.0F, 0.0F, 0.0F);
@@ -395,7 +394,7 @@ public class ChatOverlay extends GuiNewChat {
 
     public void updateLine(ChatTab tab, int id, Function<ITextComponent, ITextComponent> change) {
         updateLines(tab, new HashMap<Integer, Pair<Supplier<Boolean>, Function<ITextComponent, ITextComponent>>>()
-            {{ put(id, new Pair<>(() -> true, change)); }});
+        {{ put(id, new Pair<>(() -> true, change)); }});
     }
 
     public void refreshChat() {


### PR DESCRIPTION
Fixes #403 (likely). Crash was likely caused because of the really unlikely event of `chatSize` getting outdated while running the for loop. Not "caching" the chat size will likely solve the issue.