### PR TITLE
feat: add guild territory defense level sorting

### DIFF
--- a/src/main/java/com/wynntils/modules/map/overlays/enums/MapButtonIcon.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/enums/MapButtonIcon.java
@@ -4,7 +4,7 @@
 
 package com.wynntils.modules.map.overlays.enums;
 
-public enum MapButtonType {
+public enum MapButtonIcon {
 
     PLUS(0, 46, 14, 60),
     PIN(14, 46, 26, 62),
@@ -23,7 +23,7 @@ public enum MapButtonType {
 
     boolean ignoreAction;
 
-    MapButtonType(int startX, int startY, int endX, int endY, boolean ignoreAction) {
+    MapButtonIcon(int startX, int startY, int endX, int endY, boolean ignoreAction) {
         this.startX = startX;
         this.startY = startY;
         this.endX = endX;
@@ -32,7 +32,7 @@ public enum MapButtonType {
         this.ignoreAction = ignoreAction;
     }
 
-    MapButtonType(int startX, int startY, int endX, int endY) {
+    MapButtonIcon(int startX, int startY, int endX, int endY) {
         this(startX, startY, endX, endY, false);
     }
 

--- a/src/main/java/com/wynntils/modules/map/overlays/objects/MapButton.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/objects/MapButton.java
@@ -13,7 +13,7 @@ import net.minecraft.init.SoundEvents;
 
 import java.util.List;
 import java.util.function.BiConsumer;
-import java.util.function.Function;
+import java.util.function.Supplier;
 
 import static net.minecraft.client.renderer.GlStateManager.*;
 
@@ -25,12 +25,12 @@ public class MapButton {
     MapButtonIcon icon;
     List<String> hoverLore;
     BiConsumer<MapButton, Integer> onClick;
-    Function<Void, Integer> state;
+    Supplier<Integer> state;
     Boolean isBool;
 
     ScreenRenderer renderer = new ScreenRenderer();
 
-    public MapButton(int posX, int posY, MapButtonIcon icon, List<String> hoverLore, Boolean isBool, Function<Void, Integer> state, BiConsumer<MapButton, Integer> onClick) {
+    public MapButton(int posX, int posY, MapButtonIcon icon, List<String> hoverLore, Boolean isBool, Supplier<Integer> state, BiConsumer<MapButton, Integer> onClick) {
         int halfWidth = icon.getWidth() / 2;
         int halfHeight = icon.getHeight() / 2;
 
@@ -53,7 +53,7 @@ public class MapButton {
     public void drawScreen(int mouseX, int mouseY, float partialTicks) {
         pushMatrix();
         {
-            if (this.isBool && !(state.apply(null) == 1)) {
+            if (this.isBool && state.get() != 1) {
                 color(.3f, .3f, .3f, 1f);
             } else {
                 color(1f, 1f, 1f, 1f);
@@ -75,7 +75,7 @@ public class MapButton {
     }
 
     public Boolean isEnabled() {
-        switch (state.apply(null)) {
+        switch (state.get()) {
             case 0:
                 return false;
             case 1:

--- a/src/main/java/com/wynntils/modules/map/overlays/objects/MapButton.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/objects/MapButton.java
@@ -13,6 +13,7 @@ import net.minecraft.init.SoundEvents;
 
 import java.util.List;
 import java.util.function.BiConsumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static net.minecraft.client.renderer.GlStateManager.*;
@@ -26,11 +27,11 @@ public class MapButton {
     List<String> hoverLore;
     BiConsumer<MapButton, Integer> onClick;
     Supplier<Integer> state;
-    Boolean isBool;
+    Function<Void, Boolean> isEnabled;
 
     ScreenRenderer renderer = new ScreenRenderer();
 
-    public MapButton(int posX, int posY, MapButtonIcon icon, List<String> hoverLore, Boolean isBool, Supplier<Integer> state, BiConsumer<MapButton, Integer> onClick) {
+    public MapButton(int posX, int posY, MapButtonIcon icon, List<String> hoverLore, Function<Void, Boolean> isEnabled, BiConsumer<MapButton, Integer> onClick) {
         int halfWidth = icon.getWidth() / 2;
         int halfHeight = icon.getHeight() / 2;
 
@@ -41,8 +42,7 @@ public class MapButton {
 
         this.icon = icon;
         this.hoverLore = hoverLore;
-        this.isBool = isBool;
-        this.state = state;
+        this.isEnabled = isEnabled;
         this.onClick = onClick;
     }
 
@@ -53,10 +53,10 @@ public class MapButton {
     public void drawScreen(int mouseX, int mouseY, float partialTicks) {
         pushMatrix();
         {
-            if (this.isBool && state.get() != 1) {
-                color(.3f, .3f, .3f, 1f);
-            } else {
+            if (isEnabled.apply(null)) {
                 color(1f, 1f, 1f, 1f);
+            } else {
+                color(.3f, .3f, .3f, 1f);
             }
 
             // icon itself
@@ -75,14 +75,7 @@ public class MapButton {
     }
 
     public Boolean isEnabled() {
-        switch (state.get()) {
-            case 0:
-                return false;
-            case 1:
-                return true;
-            default:
-                return null; // Generally it shouldn't return null but if it does there's a problem with related code
-        }
+        return isEnabled.apply(null);
     }
 
     public int getStartX() {

--- a/src/main/java/com/wynntils/modules/map/overlays/objects/MapButton.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/objects/MapButton.java
@@ -53,7 +53,7 @@ public class MapButton {
     public void drawScreen(int mouseX, int mouseY, float partialTicks) {
         pushMatrix();
         {
-            if (this.isBool && !Boolean.parseBoolean(String.valueOf(state.apply(null)))) {
+            if (this.isBool && !(state.apply(null) == 1)) {
                 color(.3f, .3f, .3f, 1f);
             } else {
                 color(1f, 1f, 1f, 1f);

--- a/src/main/java/com/wynntils/modules/map/overlays/objects/MapButton.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/objects/MapButton.java
@@ -7,7 +7,7 @@ package com.wynntils.modules.map.overlays.objects;
 import com.wynntils.McIf;
 import com.wynntils.core.framework.rendering.ScreenRenderer;
 import com.wynntils.core.framework.rendering.textures.Textures;
-import com.wynntils.modules.map.overlays.enums.MapButtonType;
+import com.wynntils.modules.map.overlays.enums.MapButtonIcon;
 import net.minecraft.client.audio.PositionedSoundRecord;
 import net.minecraft.init.SoundEvents;
 
@@ -22,23 +22,23 @@ public class MapButton {
     int startX, startY;
     int endX, endY;
 
-    MapButtonType type;
+    MapButtonIcon icon;
     List<String> hoverLore;
     BiConsumer<MapButton, Integer> onClick;
     Function<Void, Boolean> isEnabled;
 
     ScreenRenderer renderer = new ScreenRenderer();
 
-    public MapButton(int posX, int posY, MapButtonType type, List<String> hoverLore, Function<Void, Boolean> isEnabled, BiConsumer<MapButton, Integer> onClick) {
-        int halfWidth = type.getWidth() / 2;
-        int halfHeight = type.getHeight() / 2;
+    public MapButton(int posX, int posY, MapButtonIcon icon, List<String> hoverLore, Function<Void, Boolean> isEnabled, BiConsumer<MapButton, Integer> onClick) {
+        int halfWidth = icon.getWidth() / 2;
+        int halfHeight = icon.getHeight() / 2;
 
         this.startX = posX - halfWidth;
         this.startY = posY - halfHeight;
         this.endX = posX + halfWidth;
         this.endY = posY + halfHeight;
 
-        this.type = type;
+        this.icon = icon;
         this.hoverLore = hoverLore;
         this.isEnabled = isEnabled;
         this.onClick = onClick;
@@ -59,7 +59,7 @@ public class MapButton {
 
             // icon itself
             renderer.drawRect(Textures.Map.map_buttons, startX, startY, endX, endY,
-                    type.getStartX(), type.getStartY(), type.getEndX(), type.getEndY());
+                    icon.getStartX(), icon.getStartY(), icon.getEndX(), icon.getEndY());
         }
         popMatrix();
     }
@@ -88,8 +88,8 @@ public class MapButton {
         return hoverLore;
     }
 
-    public MapButtonType getType() {
-        return type;
+    public MapButtonIcon getIcon() {
+        return icon;
     }
 
 }

--- a/src/main/java/com/wynntils/modules/map/overlays/objects/MapButton.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/objects/MapButton.java
@@ -25,11 +25,12 @@ public class MapButton {
     MapButtonIcon icon;
     List<String> hoverLore;
     BiConsumer<MapButton, Integer> onClick;
-    Function<Void, Boolean> isEnabled;
+    Function<Void, Integer> state;
+    Boolean isBool;
 
     ScreenRenderer renderer = new ScreenRenderer();
 
-    public MapButton(int posX, int posY, MapButtonIcon icon, List<String> hoverLore, Function<Void, Boolean> isEnabled, BiConsumer<MapButton, Integer> onClick) {
+    public MapButton(int posX, int posY, MapButtonIcon icon, List<String> hoverLore, Boolean isBool, Function<Void, Integer> state, BiConsumer<MapButton, Integer> onClick) {
         int halfWidth = icon.getWidth() / 2;
         int halfHeight = icon.getHeight() / 2;
 
@@ -40,7 +41,8 @@ public class MapButton {
 
         this.icon = icon;
         this.hoverLore = hoverLore;
-        this.isEnabled = isEnabled;
+        this.isBool = isBool;
+        this.state = state;
         this.onClick = onClick;
     }
 
@@ -51,10 +53,10 @@ public class MapButton {
     public void drawScreen(int mouseX, int mouseY, float partialTicks) {
         pushMatrix();
         {
-            if (isEnabled.apply(null)) {
-                color(1f, 1f, 1f, 1f);
-            } else {
+            if (this.isBool && !Boolean.parseBoolean(String.valueOf(state.apply(null)))) {
                 color(.3f, .3f, .3f, 1f);
+            } else {
+                color(1f, 1f, 1f, 1f);
             }
 
             // icon itself
@@ -73,7 +75,7 @@ public class MapButton {
     }
 
     public Boolean isEnabled() {
-        return isEnabled.apply(null);
+        return Boolean.parseBoolean(String.valueOf(state.apply(null)));
     }
 
     public int getStartX() {

--- a/src/main/java/com/wynntils/modules/map/overlays/objects/MapButton.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/objects/MapButton.java
@@ -75,7 +75,14 @@ public class MapButton {
     }
 
     public Boolean isEnabled() {
-        return Boolean.parseBoolean(String.valueOf(state.apply(null)));
+        switch (state.apply(null)) {
+            case 0:
+                return false;
+            case 1:
+                return true;
+            default:
+                return null; // Generally it shouldn't return null but if it does there's a problem with related code
+        }
     }
 
     public int getStartX() {

--- a/src/main/java/com/wynntils/modules/map/overlays/objects/MapButton.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/objects/MapButton.java
@@ -94,4 +94,7 @@ public class MapButton {
         return icon;
     }
 
+    public void editHoverLore(List<String> newLore) {
+        this.hoverLore = newLore;
+    }
 }

--- a/src/main/java/com/wynntils/modules/map/overlays/objects/MapTerritory.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/objects/MapTerritory.java
@@ -106,7 +106,22 @@ public class MapTerritory {
         return territory;
     }
 
-    public
+    public int getDefenses() {
+        String def = resources.getDefences();
+        if (def.contains("Very Low")) {
+            return 1;
+        } else if (def.contains("Low")) {
+            return 2;
+        } else if (def.contains("Medium")) {
+            return 3;
+        } else if (def.contains("High")) {
+            return 4;
+        } else if (def.contains("Very High")) {
+            return 5;
+        } else {
+            return -1;
+        }
+    }
 
     public void drawScreen(int mouseX, int mouseY, float partialTicks, boolean territoryArea, boolean resourceColor, boolean showHeadquarters, boolean showNames) {
         if (!shouldRender || renderer == null) return;

--- a/src/main/java/com/wynntils/modules/map/overlays/objects/MapTerritory.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/objects/MapTerritory.java
@@ -106,6 +106,8 @@ public class MapTerritory {
         return territory;
     }
 
+    public
+
     public void drawScreen(int mouseX, int mouseY, float partialTicks, boolean territoryArea, boolean resourceColor, boolean showHeadquarters, boolean showNames) {
         if (!shouldRender || renderer == null) return;
 

--- a/src/main/java/com/wynntils/modules/map/overlays/objects/MapTerritory.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/objects/MapTerritory.java
@@ -107,20 +107,20 @@ public class MapTerritory {
     }
 
     public int getDefenses() {
-        // Switch statement and .equals do not work here
-        String def = resources.getDefences();
-        if (def.contains("Very Low")) {
-            return 1;
-        } else if (def.contains("Low")) {
-            return 2;
-        } else if (def.contains("Medium")) {
-            return 3;
-        } else if (def.contains("High")) {
-            return 4;
-        } else if (def.contains("Very High")) {
-            return 5;
-        } else {
-            return -1;
+        String def = net.minecraft.util.StringUtils.stripControlCodes(resources.getDefences());
+        switch (def) {
+            case "Very Low":
+                return 1;
+            case "Low":
+                return 2;
+            case "Medium":
+                return 3;
+            case "High":
+                return 4;
+            case "Very High":
+                return 5;
+            default:
+                return -1;
         }
     }
 

--- a/src/main/java/com/wynntils/modules/map/overlays/objects/MapTerritory.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/objects/MapTerritory.java
@@ -107,6 +107,7 @@ public class MapTerritory {
     }
 
     public int getDefenses() {
+        // Switch statement and .equals do not work here
         String def = resources.getDefences();
         if (def.contains("Very Low")) {
             return 1;

--- a/src/main/java/com/wynntils/modules/map/overlays/objects/MapTerritory.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/objects/MapTerritory.java
@@ -107,8 +107,7 @@ public class MapTerritory {
     }
 
     public int getDefenses() {
-        String def = net.minecraft.util.StringUtils.stripControlCodes(resources.getDefences());
-        switch (def) {
+        switch (net.minecraft.util.StringUtils.stripControlCodes(resources.getDefences())) {
             case "Very Low":
                 return 1;
             case "Low":

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/GuildWorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/GuildWorldMapUI.java
@@ -25,7 +25,9 @@ import org.lwjgl.opengl.GL11;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 
 import static net.minecraft.util.text.TextFormatting.*;
 
@@ -62,33 +64,45 @@ public class GuildWorldMapUI extends WorldMapUI {
                 AQUA + "[>] Show territory borders",
                 GRAY + "Click here to enable/disable",
                 GRAY + "territory borders."
-        ), (v) -> showTerritory, (i, btn) -> showTerritory = !showTerritory);
+        ), true, (v) -> showTerritory ? 1 : 0, (i, btn) -> showTerritory = !showTerritory);
 
         addButton(MapButtonIcon.PENCIL, 0, Arrays.asList(
                 YELLOW + "[>] Show territory owners",
                 GRAY + "Click here to enable/disable",
                 GRAY + "territory owners."
-        ), (v) -> showOwners, (i, btn) -> showOwners = !showOwners);
+        ), true, (v) -> showOwners ? 1 : 0, (i, btn) -> showOwners = !showOwners);
 
         addButton(MapButtonIcon.INFO, 1, Arrays.asList(
                 GOLD + "[>] Use resource generation colors",
                 GRAY + "Click here to switch between",
                 GRAY + "resource generation colors and",
                 GRAY + "guild colors."
-        ), (v) -> resourceColors, (i, btn) -> resourceColors = !resourceColors);
+        ), true, (v) -> resourceColors ? 1 : 0, (i, btn) -> resourceColors = !resourceColors);
 
         addButton(MapButtonIcon.PIN, 2, Arrays.asList(
                 LIGHT_PURPLE + "[>] Show trade routes",
                 GRAY + "Click here to enable/disable",
                 GRAY + "territory trade routes."
-        ), (v) -> showTradeRoutes, (i, btn) -> showTradeRoutes = !showTradeRoutes);
+        ), true, (v) -> showTradeRoutes ? 1 : 0, (i, btn) -> showTradeRoutes = !showTradeRoutes);
 
         addButton(MapButtonIcon.PLUS, 3, Arrays.asList(
                 RED + "[>] Shift + Right Click on a territory",
                 RED + "to open management menu.",
                 GRAY + "Click here to enable/disable",
                 GRAY + "territory management shortcut."
-        ), (v) -> territoryManageShortcut, (i, btn) -> territoryManageShortcut = !territoryManageShortcut);
+        ), true , (v) -> territoryManageShortcut ? 1 : 0, (i, btn) -> territoryManageShortcut = !territoryManageShortcut);
+
+        addButton(MapButtonIcon.PLUS, 4, Arrays.asList(
+                BLUE + "[>] Territory difficulty filter",
+                GRAY + "Click here to cycle territory",
+                GRAY + "difficulty filter."
+        ), false, (v) -> territoryDifficultyFilter, (i, btn) -> {
+            if (territoryDifficultyFilter == 5) {
+                territoryDifficultyFilter = 0;
+            } else {
+                territoryDifficultyFilter += 1;
+            }
+        });
     }
 
     @Override
@@ -138,6 +152,13 @@ public class GuildWorldMapUI extends WorldMapUI {
 
         drawPositionCursor(map);
         if (showTradeRoutes) generateTradeRoutes();
+
+        if (territoryDifficultyFilter != 0) {
+            HashMap<String, MapTerritory> renderableTerritories;
+            for (Map.Entry<String, MapTerritory> territory : territories.entrySet()) {
+                if territory.getValue().getTerritory().
+            }
+        }
 
         territories.values().forEach(c -> c.drawScreen(mouseX, mouseY, partialTicks, showTerritory, resourceColors, !showOwners, showOwners));
         territories.values().forEach(c -> c.postDraw(mouseX, mouseY, partialTicks, width, height));

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/GuildWorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/GuildWorldMapUI.java
@@ -72,40 +72,40 @@ public class GuildWorldMapUI extends WorldMapUI {
                 AQUA + "[>] Show territory borders",
                 GRAY + "Click here to enable/disable",
                 GRAY + "territory borders."
-        ), true, () -> showTerritory ? 1 : 0, (i, btn) -> showTerritory = !showTerritory);
+        ), (v) -> showTerritory, (i, btn) -> showTerritory = !showTerritory);
 
         addButton(MapButtonIcon.PENCIL, 0, Arrays.asList(
                 YELLOW + "[>] Show territory owners",
                 GRAY + "Click here to enable/disable",
                 GRAY + "territory owners."
-        ), true, () -> showOwners ? 1 : 0, (i, btn) -> showOwners = !showOwners);
+        ), (v) -> showOwners, (i, btn) -> showOwners = !showOwners);
 
         addButton(MapButtonIcon.INFO, 1, Arrays.asList(
                 GOLD + "[>] Use resource generation colors",
                 GRAY + "Click here to switch between",
                 GRAY + "resource generation colors and",
                 GRAY + "guild colors."
-        ), true, () -> resourceColors ? 1 : 0, (i, btn) -> resourceColors = !resourceColors);
+        ), (v) -> resourceColors, (i, btn) -> resourceColors = !resourceColors);
 
         addButton(MapButtonIcon.PIN, 2, Arrays.asList(
                 LIGHT_PURPLE + "[>] Show trade routes",
                 GRAY + "Click here to enable/disable",
                 GRAY + "territory trade routes."
-        ), true, () -> showTradeRoutes ? 1 : 0, (i, btn) -> showTradeRoutes = !showTradeRoutes);
+        ), (v) -> showTradeRoutes, (i, btn) -> showTradeRoutes = !showTradeRoutes);
 
         addButton(MapButtonIcon.PLUS, 3, Arrays.asList(
                 RED + "[>] Shift + Right Click on a territory",
                 RED + "to open management menu.",
                 GRAY + "Click here to enable/disable",
                 GRAY + "territory management shortcut."
-        ), true , () -> territoryManageShortcut ? 1 : 0, (i, btn) -> territoryManageShortcut = !territoryManageShortcut);
+        ), (v) -> territoryManageShortcut, (i, btn) -> territoryManageShortcut = !territoryManageShortcut);
 
         cycleButton = addButton(MapButtonIcon.SEARCH, 4, Arrays.asList(
                 BLUE + "[>] Territory defense filter",
                 GRAY + "Click here to cycle territory defense filter",
                 GRAY + "Hold SHIFT to filter higher, CTRL to filter lower",
                 GRAY + "Current value: " + getDefenseFilterText()
-        ), false, () -> territoryDefenseFilter, (i, btn) -> {
+        ), (v) -> true, (i, btn) -> {
             if (isShiftKeyDown()) {
                 territoryDefenseFilterType = TDFTypes.HIGHER;
             } else if (isCtrlKeyDown()) {

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/GuildWorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/GuildWorldMapUI.java
@@ -113,8 +113,6 @@ public class GuildWorldMapUI extends WorldMapUI {
 
     private String getDefenseFilterText(int defenseLevel) {
         switch (defenseLevel) {
-            default:
-                return "§7Off";
             case 1:
                 return "§aVery Low";
             case 2:
@@ -125,6 +123,8 @@ public class GuildWorldMapUI extends WorldMapUI {
                 return "§cHigh";
             case 5:
                 return "§cVery High";
+            default:
+                return "§7Off";
         }
     }
 

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/GuildWorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/GuildWorldMapUI.java
@@ -46,9 +46,19 @@ public class GuildWorldMapUI extends WorldMapUI {
     MapButton cycleButton;
     private int territoryDefenseFilter = 0; // See #getDefenseFilterText for number definitions
     private enum TDFTypes {
-        NORMAL,
-        HIGHER,
-        LOWER
+        NORMAL(""),
+        HIGHER(RESET + " and higher"),
+        LOWER(RESET + " and lower");
+
+        private final String typeText;
+
+        TDFTypes(String s) {
+            this.typeText = s;
+        }
+
+        public String getDefenseFilterTypeText() {
+            return this.typeText;
+        }
     }
     private TDFTypes territoryDefenseFilterType = TDFTypes.NORMAL;
     private HashMap<String, MapTerritory> filteredTerritories;
@@ -135,7 +145,6 @@ public class GuildWorldMapUI extends WorldMapUI {
 
     private String getDefenseFilterText() {
         String diff;
-        String type;
         switch (territoryDefenseFilter) {
             case 1:
                 diff = GREEN + "Very Low";
@@ -156,20 +165,7 @@ public class GuildWorldMapUI extends WorldMapUI {
                 return GRAY + "Off";
         }
 
-        switch (territoryDefenseFilterType) {
-            case HIGHER:
-                type = RESET + " and higher";
-                break;
-            case LOWER:
-                type = RESET + " and lower";
-                break;
-            case NORMAL:
-            default:
-                type = "";
-                break;
-        }
-
-        return diff + type;
+        return diff + territoryDefenseFilterType.getDefenseFilterTypeText();
     }
 
     @Override

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/GuildWorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/GuildWorldMapUI.java
@@ -158,10 +158,7 @@ public class GuildWorldMapUI extends WorldMapUI {
         HashMap<String, MapTerritory> renderableTerritories = new HashMap<>();
         if (territoryDefenseFilter != 0) { // If active
             for (Map.Entry<String, MapTerritory> territory : territories.entrySet()) {
-                System.out.println(territory.getValue().getDefenses());
-                System.out.println(territoryDefenseFilter);
                 if (territory.getValue().getDefenses() == territoryDefenseFilter) {
-                    System.out.println(true);
                     renderableTerritories.put(territory.getKey(), territory.getValue());
                 }
             }

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/GuildWorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/GuildWorldMapUI.java
@@ -240,10 +240,10 @@ public class GuildWorldMapUI extends WorldMapUI {
         createMask();
 
         drawPositionCursor(map);
-        if (showTradeRoutes) generateTradeRoutes();
-
 
         HashMap<String, MapTerritory> renderableTerritories = getFilteredTerritories();
+
+        if (showTradeRoutes) generateTradeRoutes(renderableTerritories);
 
         renderableTerritories.values().forEach(c -> c.drawScreen(mouseX, mouseY, partialTicks, showTerritory, resourceColors, !showOwners, showOwners));
         renderableTerritories.values().forEach(c -> c.postDraw(mouseX, mouseY, partialTicks, width, height));
@@ -251,18 +251,21 @@ public class GuildWorldMapUI extends WorldMapUI {
         clearMask();
     }
 
-    protected void generateTradeRoutes() {
+    protected void generateTradeRoutes(HashMap<String, MapTerritory> filteredTerritories) {
         HashSet<String> alreadyGenerated = new HashSet<>();
-        for (String territoryName : territories.keySet()) {
+        for (String territoryName : filteredTerritories.keySet()) {
             GuildResourceContainer resources = GuildResourceManager.getResources(territoryName);
             if (resources == null) continue;
 
-            MapTerritory origin = territories.get(territoryName);
+            MapTerritory origin = filteredTerritories.get(territoryName);
             for (String tradingRoute : resources.getTradingRoutes()) {
                 // we don't want lines to be duplicated from each route so we just draw them one time
                 if (alreadyGenerated.contains(tradingRoute + territoryName)) continue;
 
-                MapTerritory destination = territories.get(tradingRoute);
+                // Destination does not exist, ignore the routes that involve them
+                if (!filteredTerritories.containsKey(tradingRoute)) continue;
+
+                MapTerritory destination = filteredTerritories.get(tradingRoute);
 
                 alreadyGenerated.add(territoryName + tradingRoute);
                 drawTradeRoute(origin, destination);

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/GuildWorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/GuildWorldMapUI.java
@@ -72,40 +72,40 @@ public class GuildWorldMapUI extends WorldMapUI {
                 AQUA + "[>] Show territory borders",
                 GRAY + "Click here to enable/disable",
                 GRAY + "territory borders."
-        ), true, (v) -> showTerritory ? 1 : 0, (i, btn) -> showTerritory = !showTerritory);
+        ), true, () -> showTerritory ? 1 : 0, (i, btn) -> showTerritory = !showTerritory);
 
         addButton(MapButtonIcon.PENCIL, 0, Arrays.asList(
                 YELLOW + "[>] Show territory owners",
                 GRAY + "Click here to enable/disable",
                 GRAY + "territory owners."
-        ), true, (v) -> showOwners ? 1 : 0, (i, btn) -> showOwners = !showOwners);
+        ), true, () -> showOwners ? 1 : 0, (i, btn) -> showOwners = !showOwners);
 
         addButton(MapButtonIcon.INFO, 1, Arrays.asList(
                 GOLD + "[>] Use resource generation colors",
                 GRAY + "Click here to switch between",
                 GRAY + "resource generation colors and",
                 GRAY + "guild colors."
-        ), true, (v) -> resourceColors ? 1 : 0, (i, btn) -> resourceColors = !resourceColors);
+        ), true, () -> resourceColors ? 1 : 0, (i, btn) -> resourceColors = !resourceColors);
 
         addButton(MapButtonIcon.PIN, 2, Arrays.asList(
                 LIGHT_PURPLE + "[>] Show trade routes",
                 GRAY + "Click here to enable/disable",
                 GRAY + "territory trade routes."
-        ), true, (v) -> showTradeRoutes ? 1 : 0, (i, btn) -> showTradeRoutes = !showTradeRoutes);
+        ), true, () -> showTradeRoutes ? 1 : 0, (i, btn) -> showTradeRoutes = !showTradeRoutes);
 
         addButton(MapButtonIcon.PLUS, 3, Arrays.asList(
                 RED + "[>] Shift + Right Click on a territory",
                 RED + "to open management menu.",
                 GRAY + "Click here to enable/disable",
                 GRAY + "territory management shortcut."
-        ), true , (v) -> territoryManageShortcut ? 1 : 0, (i, btn) -> territoryManageShortcut = !territoryManageShortcut);
+        ), true , () -> territoryManageShortcut ? 1 : 0, (i, btn) -> territoryManageShortcut = !territoryManageShortcut);
 
         cycleButton = addButton(MapButtonIcon.SEARCH, 4, Arrays.asList(
                 BLUE + "[>] Territory defense filter",
                 GRAY + "Click here to cycle territory defense filter",
                 GRAY + "Hold SHIFT to filter higher, CTRL to filter lower",
                 GRAY + "Current value: " + getDefenseFilterText()
-        ), false, (v) -> territoryDefenseFilter, (i, btn) -> {
+        ), false, () -> territoryDefenseFilter, (i, btn) -> {
             if (isShiftKeyDown()) {
                 territoryDefenseFilterType = TDFTypes.HIGHER;
             } else if (isCtrlKeyDown()) {

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/GuildWorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/GuildWorldMapUI.java
@@ -14,6 +14,7 @@ import com.wynntils.modules.map.instances.GuildResourceContainer;
 import com.wynntils.modules.map.instances.MapProfile;
 import com.wynntils.modules.map.managers.GuildResourceManager;
 import com.wynntils.modules.map.overlays.enums.MapButtonIcon;
+import com.wynntils.modules.map.overlays.objects.MapButton;
 import com.wynntils.modules.map.overlays.objects.MapTerritory;
 import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.GlStateManager;
@@ -24,10 +25,7 @@ import org.lwjgl.input.Mouse;
 import org.lwjgl.opengl.GL11;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
+import java.util.*;
 
 import static net.minecraft.util.text.TextFormatting.*;
 
@@ -43,6 +41,8 @@ public class GuildWorldMapUI extends WorldMapUI {
     private boolean resourceColors = false;
     private boolean showTradeRoutes = true;
     private boolean territoryManageShortcut = true;
+
+    MapButton cycleButton;
     private int territoryDefenseFilter = 0; // 0=off; 1=verylow; 2=low; 3=med; 4=high; 5=veryhigh
 
     public GuildWorldMapUI() {
@@ -92,19 +92,40 @@ public class GuildWorldMapUI extends WorldMapUI {
                 GRAY + "territory management shortcut."
         ), true , (v) -> territoryManageShortcut ? 1 : 0, (i, btn) -> territoryManageShortcut = !territoryManageShortcut);
 
-        addButton(MapButtonIcon.PLUS, 4, Arrays.asList(
+        cycleButton = addButton(MapButtonIcon.SEARCH, 4, Arrays.asList(
                 BLUE + "[>] Territory defense filter",
                 GRAY + "Click here to cycle territory",
-                GRAY + "defense filter."
+                GRAY + "defense filter.",
+                "Current value: " + getDefenseFilterText(territoryDefenseFilter)
         ), false, (v) -> territoryDefenseFilter, (i, btn) -> {
             if (territoryDefenseFilter == 5) {
                 territoryDefenseFilter = 0;
             } else {
                 ++territoryDefenseFilter;
             }
-            System.out.println(territoryDefenseFilter);
-
+            cycleButton.editHoverLore(Arrays.asList(
+                    BLUE + "[>] Territory defense filter",
+                    GRAY + "Click here to cycle territory",
+                    GRAY + "defense filter.",
+                    "Current value: " + getDefenseFilterText(territoryDefenseFilter)));
         });
+    }
+
+    private String getDefenseFilterText(int defenseLevel) {
+        switch (defenseLevel) {
+            default:
+                return "§7Off";
+            case 1:
+                return "§aVery Low";
+            case 2:
+                return "§aLow";
+            case 3:
+                return "§eMedium";
+            case 4:
+                return "§cHigh";
+            case 5:
+                return "§cVery High";
+        }
     }
 
     @Override

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/GuildWorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/GuildWorldMapUI.java
@@ -147,7 +147,8 @@ public class GuildWorldMapUI extends WorldMapUI {
                 return RED + "High";
             case 5:
                 return RED + "Very High";
-            // 11, 15, 21, 25 missing as those correspond to verylow+higher, veryhigh+higher, verylow+lower, and veryhigh+lower respectively
+
+            // verylow+higher, veryhigh+higher, verylow+lower, and veryhigh+lower are missing because they're redundant
             case 12:
                 return GREEN + "Low" + RESET + " and higher";
             case 13:
@@ -216,7 +217,22 @@ public class GuildWorldMapUI extends WorldMapUI {
         if (showTradeRoutes) generateTradeRoutes();
 
         HashMap<String, MapTerritory> renderableTerritories = new HashMap<>();
-        if (territoryDefenseFilter != 0) { // If active
+        int calculatedFilter;
+        if (territoryDefenseFilter > 20) { // if "and lower" is active (Ctrl)
+            calculatedFilter = territoryDefenseFilter - 20; // Don't do math in the for loop
+            for (Map.Entry<String, MapTerritory> territory : territories.entrySet()) {
+                if (territory.getValue().getDefenses() <= calculatedFilter) {
+                    renderableTerritories.put(territory.getKey(), territory.getValue());
+                }
+            }
+        } else if (territoryDefenseFilter > 10) { // if "and higher" is active (Shift)
+            calculatedFilter = territoryDefenseFilter - 10;
+            for (Map.Entry<String, MapTerritory> territory : territories.entrySet()) {
+                if (territory.getValue().getDefenses() >= calculatedFilter) {
+                    renderableTerritories.put(territory.getKey(), territory.getValue());
+                }
+            }
+        } else if (territoryDefenseFilter != 0) { // If not off and also not higher/lower
             for (Map.Entry<String, MapTerritory> territory : territories.entrySet()) {
                 if (territory.getValue().getDefenses() == territoryDefenseFilter) {
                     renderableTerritories.put(territory.getKey(), territory.getValue());

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/GuildWorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/GuildWorldMapUI.java
@@ -13,7 +13,7 @@ import com.wynntils.modules.map.configs.MapConfig;
 import com.wynntils.modules.map.instances.GuildResourceContainer;
 import com.wynntils.modules.map.instances.MapProfile;
 import com.wynntils.modules.map.managers.GuildResourceManager;
-import com.wynntils.modules.map.overlays.enums.MapButtonType;
+import com.wynntils.modules.map.overlays.enums.MapButtonIcon;
 import com.wynntils.modules.map.overlays.objects.MapTerritory;
 import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.GlStateManager;
@@ -41,6 +41,7 @@ public class GuildWorldMapUI extends WorldMapUI {
     private boolean resourceColors = false;
     private boolean showTradeRoutes = true;
     private boolean territoryManageShortcut = true;
+    private int territoryDifficultyFilter = 0; // 0=off; 1=verylow; 2=low; 3=med; 4=high; 5=veryhigh
 
     public GuildWorldMapUI() {
         super((float) McIf.player().posX, (float) McIf.player().posZ);
@@ -57,32 +58,32 @@ public class GuildWorldMapUI extends WorldMapUI {
 
         this.mapButtons.clear();
 
-        addButton(MapButtonType.CENTER, 0, Arrays.asList(
+        addButton(MapButtonIcon.CENTER, 0, Arrays.asList(
                 AQUA + "[>] Show territory borders",
                 GRAY + "Click here to enable/disable",
                 GRAY + "territory borders."
         ), (v) -> showTerritory, (i, btn) -> showTerritory = !showTerritory);
 
-        addButton(MapButtonType.PENCIL, 0, Arrays.asList(
+        addButton(MapButtonIcon.PENCIL, 0, Arrays.asList(
                 YELLOW + "[>] Show territory owners",
                 GRAY + "Click here to enable/disable",
                 GRAY + "territory owners."
         ), (v) -> showOwners, (i, btn) -> showOwners = !showOwners);
 
-        addButton(MapButtonType.INFO, 1, Arrays.asList(
+        addButton(MapButtonIcon.INFO, 1, Arrays.asList(
                 GOLD + "[>] Use resource generation colors",
                 GRAY + "Click here to switch between",
                 GRAY + "resource generation colors and",
                 GRAY + "guild colors."
         ), (v) -> resourceColors, (i, btn) -> resourceColors = !resourceColors);
 
-        addButton(MapButtonType.PIN, 2, Arrays.asList(
+        addButton(MapButtonIcon.PIN, 2, Arrays.asList(
                 LIGHT_PURPLE + "[>] Show trade routes",
                 GRAY + "Click here to enable/disable",
                 GRAY + "territory trade routes."
         ), (v) -> showTradeRoutes, (i, btn) -> showTradeRoutes = !showTradeRoutes);
 
-        addButton(MapButtonType.PLUS, 3, Arrays.asList(
+        addButton(MapButtonIcon.PLUS, 3, Arrays.asList(
                 RED + "[>] Shift + Right Click on a territory",
                 RED + "to open management menu.",
                 GRAY + "Click here to enable/disable",

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/GuildWorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/GuildWorldMapUI.java
@@ -43,7 +43,7 @@ public class GuildWorldMapUI extends WorldMapUI {
     private boolean resourceColors = false;
     private boolean showTradeRoutes = true;
     private boolean territoryManageShortcut = true;
-    private int territoryDifficultyFilter = 0; // 0=off; 1=verylow; 2=low; 3=med; 4=high; 5=veryhigh
+    private int territoryDefenseFilter = 0; // 0=off; 1=verylow; 2=low; 3=med; 4=high; 5=veryhigh
 
     public GuildWorldMapUI() {
         super((float) McIf.player().posX, (float) McIf.player().posZ);
@@ -93,15 +93,17 @@ public class GuildWorldMapUI extends WorldMapUI {
         ), true , (v) -> territoryManageShortcut ? 1 : 0, (i, btn) -> territoryManageShortcut = !territoryManageShortcut);
 
         addButton(MapButtonIcon.PLUS, 4, Arrays.asList(
-                BLUE + "[>] Territory difficulty filter",
+                BLUE + "[>] Territory defense filter",
                 GRAY + "Click here to cycle territory",
-                GRAY + "difficulty filter."
-        ), false, (v) -> territoryDifficultyFilter, (i, btn) -> {
-            if (territoryDifficultyFilter == 5) {
-                territoryDifficultyFilter = 0;
+                GRAY + "defense filter."
+        ), false, (v) -> territoryDefenseFilter, (i, btn) -> {
+            if (territoryDefenseFilter == 5) {
+                territoryDefenseFilter = 0;
             } else {
-                territoryDifficultyFilter += 1;
+                ++territoryDefenseFilter;
             }
+            System.out.println(territoryDefenseFilter);
+
         });
     }
 
@@ -153,15 +155,22 @@ public class GuildWorldMapUI extends WorldMapUI {
         drawPositionCursor(map);
         if (showTradeRoutes) generateTradeRoutes();
 
-        if (territoryDifficultyFilter != 0) {
-            HashMap<String, MapTerritory> renderableTerritories;
+        HashMap<String, MapTerritory> renderableTerritories = new HashMap<>();
+        if (territoryDefenseFilter != 0) { // If active
             for (Map.Entry<String, MapTerritory> territory : territories.entrySet()) {
-                if territory.getValue().getTerritory().
+                System.out.println(territory.getValue().getDefenses());
+                System.out.println(territoryDefenseFilter);
+                if (territory.getValue().getDefenses() == territoryDefenseFilter) {
+                    System.out.println(true);
+                    renderableTerritories.put(territory.getKey(), territory.getValue());
+                }
             }
+        } else {
+            renderableTerritories = territories;
         }
 
-        territories.values().forEach(c -> c.drawScreen(mouseX, mouseY, partialTicks, showTerritory, resourceColors, !showOwners, showOwners));
-        territories.values().forEach(c -> c.postDraw(mouseX, mouseY, partialTicks, width, height));
+        renderableTerritories.values().forEach(c -> c.drawScreen(mouseX, mouseY, partialTicks, showTerritory, resourceColors, !showOwners, showOwners));
+        renderableTerritories.values().forEach(c -> c.postDraw(mouseX, mouseY, partialTicks, width, height));
 
         clearMask();
     }

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/GuildWorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/GuildWorldMapUI.java
@@ -51,6 +51,7 @@ public class GuildWorldMapUI extends WorldMapUI {
         LOWER
     }
     private TDFTypes territoryDefenseFilterType = TDFTypes.NORMAL;
+    private HashMap<String, MapTerritory> filteredTerritories;
 
     public GuildWorldMapUI() {
         super((float) McIf.player().posX, (float) McIf.player().posZ);
@@ -241,17 +242,17 @@ public class GuildWorldMapUI extends WorldMapUI {
 
         drawPositionCursor(map);
 
-        HashMap<String, MapTerritory> renderableTerritories = getFilteredTerritories();
+        filteredTerritories = getFilteredTerritories();
 
-        if (showTradeRoutes) generateTradeRoutes(renderableTerritories);
+        if (showTradeRoutes) generateTradeRoutes();
 
-        renderableTerritories.values().forEach(c -> c.drawScreen(mouseX, mouseY, partialTicks, showTerritory, resourceColors, !showOwners, showOwners));
-        renderableTerritories.values().forEach(c -> c.postDraw(mouseX, mouseY, partialTicks, width, height));
+        filteredTerritories.values().forEach(c -> c.drawScreen(mouseX, mouseY, partialTicks, showTerritory, resourceColors, !showOwners, showOwners));
+        filteredTerritories.values().forEach(c -> c.postDraw(mouseX, mouseY, partialTicks, width, height));
 
         clearMask();
     }
 
-    protected void generateTradeRoutes(HashMap<String, MapTerritory> filteredTerritories) {
+    protected void generateTradeRoutes() {
         HashSet<String> alreadyGenerated = new HashSet<>();
         for (String territoryName : filteredTerritories.keySet()) {
             GuildResourceContainer resources = GuildResourceManager.getResources(territoryName);
@@ -334,7 +335,7 @@ public class GuildWorldMapUI extends WorldMapUI {
             return;
         }
 
-        for (MapTerritory territory : territories.values()) {
+        for (MapTerritory territory : filteredTerritories.values()) {
             boolean hovering = territory.isBeingHovered(lastMouseX, lastMouseY);
             if (!hovering) continue;
 

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/GuildWorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/GuildWorldMapUI.java
@@ -114,17 +114,17 @@ public class GuildWorldMapUI extends WorldMapUI {
     private String getDefenseFilterText(int defenseLevel) {
         switch (defenseLevel) {
             case 1:
-                return "§aVery Low";
+                return GREEN + "Very Low";
             case 2:
-                return "§aLow";
+                return GREEN + "Low";
             case 3:
-                return "§eMedium";
+                return YELLOW + "Medium";
             case 4:
-                return "§cHigh";
+                return RED + "High";
             case 5:
-                return "§cVery High";
+                return RED + "Very High";
             default:
-                return "§7Off";
+                return GRAY + "Off";
         }
     }
 

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/MainWorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/MainWorldMapUI.java
@@ -56,32 +56,32 @@ public class MainWorldMapUI extends WorldMapUI {
             DARK_GREEN + "[>] Create a new Waypoint",
             GRAY + "Click here to create",
             GRAY + "a new waypoint."
-        ), true, () -> 1, (i, btn) -> McIf.mc().displayGuiScreen(new WaypointCreationMenu(null)));
+        ), (v) -> true, (i, btn) -> McIf.mc().displayGuiScreen(new WaypointCreationMenu(null)));
 
         addButton(MapButtonIcon.PENCIL, 0, Arrays.asList(
             GOLD + "[>] Manage Paths",
             GRAY + "List, Delete or Create",
             GRAY + "drawed lines that help you",
             GRAY + "to navigate around the world!"
-        ), true, () -> 1, (i, btn) -> McIf.mc().displayGuiScreen(new PathWaypointOverviewUI()));
+        ), (v) -> true, (i, btn) -> McIf.mc().displayGuiScreen(new PathWaypointOverviewUI()));
 
         addButton(MapButtonIcon.PIN, 1, Arrays.asList(
                 RED + "[>] Manage Waypoints",
                 GRAY + "List, Delete or Create",
                 GRAY + "all your preview set",
                 GRAY + "waypoints!"
-        ),true, () -> 1, (i, btn) -> McIf.mc().displayGuiScreen(new WaypointOverviewUI()));
+        ),(v) -> true, (i, btn) -> McIf.mc().displayGuiScreen(new WaypointOverviewUI()));
 
         addButton(MapButtonIcon.SEARCH, 2, Arrays.asList(
                 LIGHT_PURPLE + "[>] Search",
                 RED + "In Development"
-        ), true, () -> 1, (i, btn) -> {});
+        ), (v) -> true, (i, btn) -> {});
 
         addButton(MapButtonIcon.CENTER, 3, Arrays.asList(
                 AQUA + "[>] Configure Markers",
                 GRAY + "Enable or disable each",
                 GRAY + "map marker available."
-        ), true, () -> 1, (i, btn) -> McIf.mc().displayGuiScreen(new WorldMapSettingsUI()));
+        ), (v) -> true, (i, btn) -> McIf.mc().displayGuiScreen(new WorldMapSettingsUI()));
 
         addButton(MapButtonIcon.SHARE, 4, Arrays.asList(
                 BLUE + "[>] Share Location",
@@ -91,7 +91,7 @@ public class MainWorldMapUI extends WorldMapUI {
                 GRAY + "location with your party.",
                 AQUA + "Shift" + GRAY + " to share your",
                 GRAY + "pin location instead."
-        ), true, () -> 1, (i, btn) -> handleShareButton(btn == 0));
+        ), (v) -> true, (i, btn) -> handleShareButton(btn == 0));
 
         addButton(MapButtonIcon.INFO, 5, Lists.newArrayList(Arrays.asList(
                 YELLOW + "[>] Quick Guide",
@@ -101,7 +101,7 @@ public class MainWorldMapUI extends WorldMapUI {
                 GRAY + " - Double click on a pin to create a waypoint.",
                 GRAY + " - Right click on pin to remove it.",
                 GRAY + " - Right click to center on player."
-        )), true, () -> 1, (i, btn) -> {
+        )), (v) -> true, (i, btn) -> {
             easterEggClicks += 1;
 
             // Easter egg :)

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/MainWorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/MainWorldMapUI.java
@@ -56,32 +56,32 @@ public class MainWorldMapUI extends WorldMapUI {
             DARK_GREEN + "[>] Create a new Waypoint",
             GRAY + "Click here to create",
             GRAY + "a new waypoint."
-        ), true, (v) -> 1, (i, btn) -> McIf.mc().displayGuiScreen(new WaypointCreationMenu(null)));
+        ), true, () -> 1, (i, btn) -> McIf.mc().displayGuiScreen(new WaypointCreationMenu(null)));
 
         addButton(MapButtonIcon.PENCIL, 0, Arrays.asList(
             GOLD + "[>] Manage Paths",
             GRAY + "List, Delete or Create",
             GRAY + "drawed lines that help you",
             GRAY + "to navigate around the world!"
-        ), true, (v) -> 1, (i, btn) -> McIf.mc().displayGuiScreen(new PathWaypointOverviewUI()));
+        ), true, () -> 1, (i, btn) -> McIf.mc().displayGuiScreen(new PathWaypointOverviewUI()));
 
         addButton(MapButtonIcon.PIN, 1, Arrays.asList(
                 RED + "[>] Manage Waypoints",
                 GRAY + "List, Delete or Create",
                 GRAY + "all your preview set",
                 GRAY + "waypoints!"
-        ),true, (v) -> 1, (i, btn) -> McIf.mc().displayGuiScreen(new WaypointOverviewUI()));
+        ),true, () -> 1, (i, btn) -> McIf.mc().displayGuiScreen(new WaypointOverviewUI()));
 
         addButton(MapButtonIcon.SEARCH, 2, Arrays.asList(
                 LIGHT_PURPLE + "[>] Search",
                 RED + "In Development"
-        ), true, (v) -> 1, (i, btn) -> {});
+        ), true, () -> 1, (i, btn) -> {});
 
         addButton(MapButtonIcon.CENTER, 3, Arrays.asList(
                 AQUA + "[>] Configure Markers",
                 GRAY + "Enable or disable each",
                 GRAY + "map marker available."
-        ), true, (v) -> 1, (i, btn) -> McIf.mc().displayGuiScreen(new WorldMapSettingsUI()));
+        ), true, () -> 1, (i, btn) -> McIf.mc().displayGuiScreen(new WorldMapSettingsUI()));
 
         addButton(MapButtonIcon.SHARE, 4, Arrays.asList(
                 BLUE + "[>] Share Location",
@@ -91,7 +91,7 @@ public class MainWorldMapUI extends WorldMapUI {
                 GRAY + "location with your party.",
                 AQUA + "Shift" + GRAY + " to share your",
                 GRAY + "pin location instead."
-        ), true, (v) -> 1, (i, btn) -> handleShareButton(btn == 0));
+        ), true, () -> 1, (i, btn) -> handleShareButton(btn == 0));
 
         addButton(MapButtonIcon.INFO, 5, Lists.newArrayList(Arrays.asList(
                 YELLOW + "[>] Quick Guide",
@@ -101,7 +101,7 @@ public class MainWorldMapUI extends WorldMapUI {
                 GRAY + " - Double click on a pin to create a waypoint.",
                 GRAY + " - Right click on pin to remove it.",
                 GRAY + " - Right click to center on player."
-        )), true, (v) -> 1, (i, btn) -> {
+        )), true, () -> 1, (i, btn) -> {
             easterEggClicks += 1;
 
             // Easter egg :)

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/MainWorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/MainWorldMapUI.java
@@ -56,32 +56,32 @@ public class MainWorldMapUI extends WorldMapUI {
             DARK_GREEN + "[>] Create a new Waypoint",
             GRAY + "Click here to create",
             GRAY + "a new waypoint."
-        ), (v) -> true, (i, btn) -> McIf.mc().displayGuiScreen(new WaypointCreationMenu(null)));
+        ), true, (v) -> 1, (i, btn) -> McIf.mc().displayGuiScreen(new WaypointCreationMenu(null)));
 
         addButton(MapButtonIcon.PENCIL, 0, Arrays.asList(
             GOLD + "[>] Manage Paths",
             GRAY + "List, Delete or Create",
             GRAY + "drawed lines that help you",
             GRAY + "to navigate around the world!"
-        ), (v) -> true, (i, btn) -> McIf.mc().displayGuiScreen(new PathWaypointOverviewUI()));
+        ), true, (v) -> 1, (i, btn) -> McIf.mc().displayGuiScreen(new PathWaypointOverviewUI()));
 
         addButton(MapButtonIcon.PIN, 1, Arrays.asList(
                 RED + "[>] Manage Waypoints",
                 GRAY + "List, Delete or Create",
                 GRAY + "all your preview set",
                 GRAY + "waypoints!"
-        ), (v) -> true, (i, btn) -> McIf.mc().displayGuiScreen(new WaypointOverviewUI()));
+        ),true, (v) -> 1, (i, btn) -> McIf.mc().displayGuiScreen(new WaypointOverviewUI()));
 
         addButton(MapButtonIcon.SEARCH, 2, Arrays.asList(
                 LIGHT_PURPLE + "[>] Search",
                 RED + "In Development"
-        ), (v) -> true, (i, btn) -> {});
+        ), true, (v) -> 1, (i, btn) -> {});
 
         addButton(MapButtonIcon.CENTER, 3, Arrays.asList(
                 AQUA + "[>] Configure Markers",
                 GRAY + "Enable or disable each",
                 GRAY + "map marker available."
-        ), (v) -> true, (i, btn) -> McIf.mc().displayGuiScreen(new WorldMapSettingsUI()));
+        ), true, (v) -> 1, (i, btn) -> McIf.mc().displayGuiScreen(new WorldMapSettingsUI()));
 
         addButton(MapButtonIcon.SHARE, 4, Arrays.asList(
                 BLUE + "[>] Share Location",
@@ -91,7 +91,7 @@ public class MainWorldMapUI extends WorldMapUI {
                 GRAY + "location with your party.",
                 AQUA + "Shift" + GRAY + " to share your",
                 GRAY + "pin location instead."
-        ), (v) -> true, (i, btn) -> handleShareButton(btn == 0));
+        ), true, (v) -> 1, (i, btn) -> handleShareButton(btn == 0));
 
         addButton(MapButtonIcon.INFO, 5, Lists.newArrayList(Arrays.asList(
                 YELLOW + "[>] Quick Guide",
@@ -101,7 +101,7 @@ public class MainWorldMapUI extends WorldMapUI {
                 GRAY + " - Double click on a pin to create a waypoint.",
                 GRAY + " - Right click on pin to remove it.",
                 GRAY + " - Right click to center on player."
-        )), (v) -> true, (i, btn) -> {
+        )), true, (v) -> 1, (i, btn) -> {
             easterEggClicks += 1;
 
             // Easter egg :)

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/MainWorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/MainWorldMapUI.java
@@ -14,16 +14,12 @@ import com.wynntils.modules.core.managers.CompassManager;
 import com.wynntils.modules.map.MapModule;
 import com.wynntils.modules.map.configs.MapConfig;
 import com.wynntils.modules.map.instances.MapProfile;
-import com.wynntils.modules.map.overlays.enums.MapButtonType;
+import com.wynntils.modules.map.overlays.enums.MapButtonIcon;
 import com.wynntils.modules.map.overlays.objects.MapButton;
 import com.wynntils.modules.music.managers.SoundTrackManager;
 import com.wynntils.webapi.WebManager;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.audio.PositionedSoundRecord;
-import net.minecraft.client.settings.GameSettings;
-import net.minecraft.client.settings.KeyBinding;
 import net.minecraft.init.SoundEvents;
-import net.minecraftforge.fml.client.registry.ClientRegistry;
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.input.Mouse;
 
@@ -56,38 +52,38 @@ public class MainWorldMapUI extends WorldMapUI {
 
         this.mapButtons.clear();
 
-        addButton(MapButtonType.PLUS, 0, Arrays.asList(
+        addButton(MapButtonIcon.PLUS, 0, Arrays.asList(
             DARK_GREEN + "[>] Create a new Waypoint",
             GRAY + "Click here to create",
             GRAY + "a new waypoint."
         ), (v) -> true, (i, btn) -> McIf.mc().displayGuiScreen(new WaypointCreationMenu(null)));
 
-        addButton(MapButtonType.PENCIL, 0, Arrays.asList(
+        addButton(MapButtonIcon.PENCIL, 0, Arrays.asList(
             GOLD + "[>] Manage Paths",
             GRAY + "List, Delete or Create",
             GRAY + "drawed lines that help you",
             GRAY + "to navigate around the world!"
         ), (v) -> true, (i, btn) -> McIf.mc().displayGuiScreen(new PathWaypointOverviewUI()));
 
-        addButton(MapButtonType.PIN, 1, Arrays.asList(
+        addButton(MapButtonIcon.PIN, 1, Arrays.asList(
                 RED + "[>] Manage Waypoints",
                 GRAY + "List, Delete or Create",
                 GRAY + "all your preview set",
                 GRAY + "waypoints!"
         ), (v) -> true, (i, btn) -> McIf.mc().displayGuiScreen(new WaypointOverviewUI()));
 
-        addButton(MapButtonType.SEARCH, 2, Arrays.asList(
+        addButton(MapButtonIcon.SEARCH, 2, Arrays.asList(
                 LIGHT_PURPLE + "[>] Search",
                 RED + "In Development"
         ), (v) -> true, (i, btn) -> {});
 
-        addButton(MapButtonType.CENTER, 3, Arrays.asList(
+        addButton(MapButtonIcon.CENTER, 3, Arrays.asList(
                 AQUA + "[>] Configure Markers",
                 GRAY + "Enable or disable each",
                 GRAY + "map marker available."
         ), (v) -> true, (i, btn) -> McIf.mc().displayGuiScreen(new WorldMapSettingsUI()));
 
-        addButton(MapButtonType.SHARE, 4, Arrays.asList(
+        addButton(MapButtonIcon.SHARE, 4, Arrays.asList(
                 BLUE + "[>] Share Location",
                 AQUA + "Left click" + GRAY +" to share your",
                 GRAY + "location with your guild..",
@@ -97,7 +93,7 @@ public class MainWorldMapUI extends WorldMapUI {
                 GRAY + "pin location instead."
         ), (v) -> true, (i, btn) -> handleShareButton(btn == 0));
 
-        addButton(MapButtonType.INFO, 5, Lists.newArrayList(Arrays.asList(
+        addButton(MapButtonIcon.INFO, 5, Lists.newArrayList(Arrays.asList(
                 YELLOW + "[>] Quick Guide",
                 GRAY + " - CTRL to show territories",
                 GRAY + " - Left click on waypoint to place a pin.",
@@ -178,7 +174,7 @@ public class MainWorldMapUI extends WorldMapUI {
         // Map buttons
         for (MapButton button : mapButtons) {
             if (!button.isHovering(mouseX, mouseY)) continue;
-            if (button.getType().isIgnoreAction()) continue;
+            if (button.getIcon().isIgnoreAction()) continue;
 
             button.mouseClicked(mouseX, mouseY, mouseButton);
             return;

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/SeaskipperWorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/SeaskipperWorldMapUI.java
@@ -76,29 +76,29 @@ public class SeaskipperWorldMapUI extends WorldMapUI {
                 AQUA + "[>] Show territory borders",
                 GRAY + "Click here to enable/disable",
                 GRAY + "territory borders."
-        ), true, () -> showLocations ? 1 : 0, (i, btn) -> showLocations = !showLocations);
+        ), (v) -> showLocations, (i, btn) -> showLocations = !showLocations);
 
         addButton(MapButtonIcon.PLUS, 0, Arrays.asList(
                 AQUA + "[>] Show inaccessible locations",
                 GRAY + "Click here to enable/disable",
                 GRAY + "inaccessible locations."
-        ), true, () -> showInaccessibleLocations ? 1 : 0, (i, btn) -> showInaccessibleLocations = !showInaccessibleLocations);
+        ), (v) -> showInaccessibleLocations, (i, btn) -> showInaccessibleLocations = !showInaccessibleLocations);
 
         addButton(MapButtonIcon.PIN, 1, Arrays.asList(
                 LIGHT_PURPLE + "[>] Show Seaskipper routes",
                 GRAY + "Click here to enable/disable",
                 GRAY + "Seaskipper routes."
-        ), true, () -> showSeaskipperRoutes ? 1 : 0, (i, btn) -> showSeaskipperRoutes = !showSeaskipperRoutes);
+        ), (v) -> showSeaskipperRoutes, (i, btn) -> showSeaskipperRoutes = !showSeaskipperRoutes);
 
         addButton(MapButtonIcon.BOAT, 2, Arrays.asList(
                 LIGHT_PURPLE + "[>] Buy a boat",
                 GRAY + "Click here to buy a boat."
-        ), true, () -> {
+        ), (v) -> {
                 for (Slot slot : McIf.player().inventoryContainer.inventorySlots) {
-                    if (slot.getStack().getItem() == Items.BOAT) return 0;
+                    if (slot.getStack().getItem() == Items.BOAT) return false;
                 }
 
-                return 1;
+                return true;
         }, (i, btn) -> {
             if (!i.isEnabled() || boatSlot == -1) return;
             chest.handleMouseClick(chest.inventorySlots.getSlot(boatSlot), boatSlot, 0, ClickType.PICKUP);

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/SeaskipperWorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/SeaskipperWorldMapUI.java
@@ -11,7 +11,7 @@ import com.wynntils.modules.core.overlays.inventories.ChestReplacer;
 import com.wynntils.modules.map.MapModule;
 import com.wynntils.modules.map.instances.MapProfile;
 import com.wynntils.modules.map.overlays.objects.SeaskipperLocation;
-import com.wynntils.modules.map.overlays.enums.MapButtonType;
+import com.wynntils.modules.map.overlays.enums.MapButtonIcon;
 import com.wynntils.webapi.WebManager;
 import com.wynntils.webapi.profiles.SeaskipperProfile;
 import net.minecraft.client.renderer.BufferBuilder;
@@ -72,25 +72,25 @@ public class SeaskipperWorldMapUI extends WorldMapUI {
 
         this.mapButtons.clear();
 
-        addButton(MapButtonType.CENTER, 0, Arrays.asList(
+        addButton(MapButtonIcon.CENTER, 0, Arrays.asList(
                 AQUA + "[>] Show territory borders",
                 GRAY + "Click here to enable/disable",
                 GRAY + "territory borders."
         ), (v) -> showLocations, (i, btn) -> showLocations = !showLocations);
 
-        addButton(MapButtonType.PLUS, 0, Arrays.asList(
+        addButton(MapButtonIcon.PLUS, 0, Arrays.asList(
                 AQUA + "[>] Show inaccessible locations",
                 GRAY + "Click here to enable/disable",
                 GRAY + "inaccessible locations."
         ), (v) -> showInaccessibleLocations, (i, btn) -> showInaccessibleLocations = !showInaccessibleLocations);
 
-        addButton(MapButtonType.PIN, 1, Arrays.asList(
+        addButton(MapButtonIcon.PIN, 1, Arrays.asList(
                 LIGHT_PURPLE + "[>] Show Seaskipper routes",
                 GRAY + "Click here to enable/disable",
                 GRAY + "Seaskipper routes."
         ), (v) -> showSeaskipperRoutes, (i, btn) -> showSeaskipperRoutes = !showSeaskipperRoutes);
 
-        addButton(MapButtonType.BOAT, 2, Arrays.asList(
+        addButton(MapButtonIcon.BOAT, 2, Arrays.asList(
                 LIGHT_PURPLE + "[>] Buy a boat",
                 GRAY + "Click here to buy a boat."
         ), (v) -> {

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/SeaskipperWorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/SeaskipperWorldMapUI.java
@@ -76,29 +76,29 @@ public class SeaskipperWorldMapUI extends WorldMapUI {
                 AQUA + "[>] Show territory borders",
                 GRAY + "Click here to enable/disable",
                 GRAY + "territory borders."
-        ), (v) -> showLocations, (i, btn) -> showLocations = !showLocations);
+        ), true, (v) -> showLocations ? 1 : 0, (i, btn) -> showLocations = !showLocations);
 
         addButton(MapButtonIcon.PLUS, 0, Arrays.asList(
                 AQUA + "[>] Show inaccessible locations",
                 GRAY + "Click here to enable/disable",
                 GRAY + "inaccessible locations."
-        ), (v) -> showInaccessibleLocations, (i, btn) -> showInaccessibleLocations = !showInaccessibleLocations);
+        ), true, (v) -> showInaccessibleLocations ? 1 : 0, (i, btn) -> showInaccessibleLocations = !showInaccessibleLocations);
 
         addButton(MapButtonIcon.PIN, 1, Arrays.asList(
                 LIGHT_PURPLE + "[>] Show Seaskipper routes",
                 GRAY + "Click here to enable/disable",
                 GRAY + "Seaskipper routes."
-        ), (v) -> showSeaskipperRoutes, (i, btn) -> showSeaskipperRoutes = !showSeaskipperRoutes);
+        ), true, (v) -> showSeaskipperRoutes ? 1 : 0, (i, btn) -> showSeaskipperRoutes = !showSeaskipperRoutes);
 
         addButton(MapButtonIcon.BOAT, 2, Arrays.asList(
                 LIGHT_PURPLE + "[>] Buy a boat",
                 GRAY + "Click here to buy a boat."
-        ), (v) -> {
+        ), true, (v) -> {
                 for (Slot slot : McIf.player().inventoryContainer.inventorySlots) {
-                    if (slot.getStack().getItem() == Items.BOAT) return false;
+                    if (slot.getStack().getItem() == Items.BOAT) return 0;
                 }
 
-                return true;
+                return 1;
         }, (i, btn) -> {
             if (!i.isEnabled() || boatSlot == -1) return;
             chest.handleMouseClick(chest.inventorySlots.getSlot(boatSlot), boatSlot, 0, ClickType.PICKUP);

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/SeaskipperWorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/SeaskipperWorldMapUI.java
@@ -76,24 +76,24 @@ public class SeaskipperWorldMapUI extends WorldMapUI {
                 AQUA + "[>] Show territory borders",
                 GRAY + "Click here to enable/disable",
                 GRAY + "territory borders."
-        ), true, (v) -> showLocations ? 1 : 0, (i, btn) -> showLocations = !showLocations);
+        ), true, () -> showLocations ? 1 : 0, (i, btn) -> showLocations = !showLocations);
 
         addButton(MapButtonIcon.PLUS, 0, Arrays.asList(
                 AQUA + "[>] Show inaccessible locations",
                 GRAY + "Click here to enable/disable",
                 GRAY + "inaccessible locations."
-        ), true, (v) -> showInaccessibleLocations ? 1 : 0, (i, btn) -> showInaccessibleLocations = !showInaccessibleLocations);
+        ), true, () -> showInaccessibleLocations ? 1 : 0, (i, btn) -> showInaccessibleLocations = !showInaccessibleLocations);
 
         addButton(MapButtonIcon.PIN, 1, Arrays.asList(
                 LIGHT_PURPLE + "[>] Show Seaskipper routes",
                 GRAY + "Click here to enable/disable",
                 GRAY + "Seaskipper routes."
-        ), true, (v) -> showSeaskipperRoutes ? 1 : 0, (i, btn) -> showSeaskipperRoutes = !showSeaskipperRoutes);
+        ), true, () -> showSeaskipperRoutes ? 1 : 0, (i, btn) -> showSeaskipperRoutes = !showSeaskipperRoutes);
 
         addButton(MapButtonIcon.BOAT, 2, Arrays.asList(
                 LIGHT_PURPLE + "[>] Buy a boat",
                 GRAY + "Click here to buy a boat."
-        ), true, (v) -> {
+        ), true, () -> {
                 for (Slot slot : McIf.player().inventoryContainer.inventorySlots) {
                     if (slot.getStack().getItem() == Items.BOAT) return 0;
                 }

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/WorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/WorldMapUI.java
@@ -123,7 +123,7 @@ public class WorldMapUI extends GuiMovementScreen {
         Keyboard.enableRepeatEvents(true);
     }
 
-    protected void addButton(MapButtonIcon icon, int offsetX, List<String> hover, Boolean isBool, Function<Void, Integer> state, BiConsumer<MapButton, Integer> onClick) {
+    protected MapButton addButton(MapButtonIcon icon, int offsetX, List<String> hover, Boolean isBool, Function<Void, Integer> state, BiConsumer<MapButton, Integer> onClick) {
         // add the button base
         if (mapButtons.isEmpty()) {
             mapButtons.add(new MapButton(width / 2, height - 45, MapButtonIcon.BASE, null, true, (v) -> 1, null));
@@ -131,7 +131,9 @@ public class WorldMapUI extends GuiMovementScreen {
 
         int posX = mapButtons.get(0).getStartX() + 13 + (19 * (mapButtons.size() - 1)) + offsetX;
         int posY = height - 45;
-        mapButtons.add(new MapButton(posX, posY, icon, hover, isBool, state, onClick));
+        MapButton btn = new MapButton(posX, posY, icon, hover, isBool, state, onClick);
+        mapButtons.add(btn);
+        return btn;
     }
 
     protected void createIcons() {

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/WorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/WorldMapUI.java
@@ -123,15 +123,15 @@ public class WorldMapUI extends GuiMovementScreen {
         Keyboard.enableRepeatEvents(true);
     }
 
-    protected void addButton(MapButtonIcon icon, int offsetX, List<String> hover, Function<Void, Boolean> isEnabled, BiConsumer<MapButton, Integer> onClick) {
+    protected void addButton(MapButtonIcon icon, int offsetX, List<String> hover, Boolean isBool, Function<Void, Integer> state, BiConsumer<MapButton, Integer> onClick) {
         // add the button base
         if (mapButtons.isEmpty()) {
-            mapButtons.add(new MapButton(width / 2, height - 45, MapButtonIcon.BASE, null, (v) -> true, null));
+            mapButtons.add(new MapButton(width / 2, height - 45, MapButtonIcon.BASE, null, true, (v) -> 1, null));
         }
 
         int posX = mapButtons.get(0).getStartX() + 13 + (19 * (mapButtons.size() - 1)) + offsetX;
         int posY = height - 45;
-        mapButtons.add(new MapButton(posX, posY, icon, hover, isEnabled, onClick));
+        mapButtons.add(new MapButton(posX, posY, icon, hover, isBool, state, onClick));
     }
 
     protected void createIcons() {

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/WorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/WorldMapUI.java
@@ -124,15 +124,15 @@ public class WorldMapUI extends GuiMovementScreen {
         Keyboard.enableRepeatEvents(true);
     }
 
-    protected MapButton addButton(MapButtonIcon icon, int offsetX, List<String> hover, Boolean isBool, Supplier<Integer> state, BiConsumer<MapButton, Integer> onClick) {
+    protected MapButton addButton(MapButtonIcon icon, int offsetX, List<String> hover, Function<Void, Boolean> isEnabled, BiConsumer<MapButton, Integer> onClick) {
         // add the button base
         if (mapButtons.isEmpty()) {
-            mapButtons.add(new MapButton(width / 2, height - 45, MapButtonIcon.BASE, null, true, () -> 1, null));
+            mapButtons.add(new MapButton(width / 2, height - 45, MapButtonIcon.BASE, null, (v) -> true, null));
         }
 
         int posX = mapButtons.get(0).getStartX() + 13 + (19 * (mapButtons.size() - 1)) + offsetX;
         int posY = height - 45;
-        MapButton btn = new MapButton(posX, posY, icon, hover, isBool, state, onClick);
+        MapButton btn = new MapButton(posX, posY, icon, hover, isEnabled, onClick);
         mapButtons.add(btn);
         return btn;
     }

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/WorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/WorldMapUI.java
@@ -20,7 +20,7 @@ import com.wynntils.modules.map.configs.MapConfig;
 import com.wynntils.modules.map.instances.MapProfile;
 import com.wynntils.modules.map.instances.WaypointProfile;
 import com.wynntils.modules.map.managers.LootRunManager;
-import com.wynntils.modules.map.overlays.enums.MapButtonType;
+import com.wynntils.modules.map.overlays.enums.MapButtonIcon;
 import com.wynntils.modules.map.overlays.objects.*;
 import com.wynntils.modules.utilities.managers.KeyManager;
 import com.wynntils.webapi.WebManager;
@@ -123,15 +123,15 @@ public class WorldMapUI extends GuiMovementScreen {
         Keyboard.enableRepeatEvents(true);
     }
 
-    protected void addButton(MapButtonType type, int offsetX, List<String> hover, Function<Void, Boolean> isEnabled, BiConsumer<MapButton, Integer> onClick) {
+    protected void addButton(MapButtonIcon icon, int offsetX, List<String> hover, Function<Void, Boolean> isEnabled, BiConsumer<MapButton, Integer> onClick) {
         // add the button base
         if (mapButtons.isEmpty()) {
-            mapButtons.add(new MapButton(width / 2, height - 45, MapButtonType.BASE, null, (v) -> true, null));
+            mapButtons.add(new MapButton(width / 2, height - 45, MapButtonIcon.BASE, null, (v) -> true, null));
         }
 
         int posX = mapButtons.get(0).getStartX() + 13 + (19 * (mapButtons.size() - 1)) + offsetX;
         int posY = height - 45;
-        mapButtons.add(new MapButton(posX, posY, type, hover, isEnabled, onClick));
+        mapButtons.add(new MapButton(posX, posY, icon, hover, isEnabled, onClick));
     }
 
     protected void createIcons() {
@@ -407,7 +407,7 @@ public class WorldMapUI extends GuiMovementScreen {
 
         // hover lore
         for (MapButton button : mapButtons) {
-            if (button.getType().isIgnoreAction()) continue;
+            if (button.getIcon().isIgnoreAction()) continue;
             if (!button.isHovering(mouseX, mouseY)) continue;
 
             drawHoveringText(button.getHoverLore(), mouseX, mouseY);
@@ -527,7 +527,7 @@ public class WorldMapUI extends GuiMovementScreen {
 
         for (MapButton button : mapButtons) {
             if (!button.isHovering(mouseX, mouseY)) continue;
-            if (button.getType().isIgnoreAction()) continue;
+            if (button.getIcon().isIgnoreAction()) continue;
 
             button.mouseClicked(mouseX, mouseY, mouseButton);
             return;

--- a/src/main/java/com/wynntils/modules/map/overlays/ui/WorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/WorldMapUI.java
@@ -45,6 +45,7 @@ import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import static com.wynntils.modules.map.configs.MapConfig.INSTANCE;
 import static net.minecraft.client.renderer.GlStateManager.*;
@@ -123,10 +124,10 @@ public class WorldMapUI extends GuiMovementScreen {
         Keyboard.enableRepeatEvents(true);
     }
 
-    protected MapButton addButton(MapButtonIcon icon, int offsetX, List<String> hover, Boolean isBool, Function<Void, Integer> state, BiConsumer<MapButton, Integer> onClick) {
+    protected MapButton addButton(MapButtonIcon icon, int offsetX, List<String> hover, Boolean isBool, Supplier<Integer> state, BiConsumer<MapButton, Integer> onClick) {
         // add the button base
         if (mapButtons.isEmpty()) {
-            mapButtons.add(new MapButton(width / 2, height - 45, MapButtonIcon.BASE, null, true, (v) -> 1, null));
+            mapButtons.add(new MapButton(width / 2, height - 45, MapButtonIcon.BASE, null, true, () -> 1, null));
         }
 
         int posX = mapButtons.get(0).getStartX() + 13 + (19 * (mapButtons.size() - 1)) + offsetX;


### PR DESCRIPTION
Adds a button to only show a certain difficulty of guild territory defense on the guild map. Currently uses the search icon, though this can be changed to anything else.

This PR also does some refactoring and changes how MapButtons are handled. Tested in game; seems to work fine.