### PR TITLE
Rename "apply" to "save", remove unused config

### DIFF
--- a/src/main/java/com/wynntils/core/framework/settings/ui/SettingsUI.java
+++ b/src/main/java/com/wynntils/core/framework/settings/ui/SettingsUI.java
@@ -59,7 +59,7 @@ public class SettingsUI extends UI {
         changedSettings.forEach(c -> { try { registeredSettings.get(c).tryToLoad(); } catch (Exception e) { e.printStackTrace(); } });
         onClose();
     }, 0, 0, 17, 45);
-    public UIEButton applyButton = new UIEButton("Apply", Textures.UIs.button_a, 0.5f, 0.5f, -130, 85, -10, true, (ui, mouseButton) -> {
+    public UIEButton applyButton = new UIEButton("Save", Textures.UIs.button_a, 0.5f, 0.5f, -130, 85, -10, true, (ui, mouseButton) -> {
         changedSettings.forEach(c -> { try { registeredSettings.get(c).saveSettings(); } catch (Exception e) { e.printStackTrace(); } });
         onClose();
     }, 0, 0, 17, 45);

--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -454,13 +454,6 @@ public class UtilitiesConfig extends SettingsClass {
     public static class Market extends SettingsClass {
         public static Market INSTANCE;
 
-        @Setting(displayName = "Price Formatting", description = "Should market prices be displayed in a custom format?")
-        public boolean displayInCustomFormat = true;
-
-        @Setting(displayName = "Market Prices Format", description = "What format should market prices be displayed in?\n\n§8Brackets indicate all parameters inside must not be 0.")
-        @Setting.Features.StringParameters(parameters = {"les", "ebs", "es", "stx", "le", "eb", "e"})
-        public String customFormat = "(%stx%stx )(%le%%les% )(%eb%%ebs% )(%e%%es%)";
-
         @Setting(displayName = "Open Chat", description = "Should the chat open when the trade market asks you to type a response?")
         public boolean openChatMarket = true;
     }


### PR DESCRIPTION
Change config book apply button to "save" for clarity
Removes two unused market configs