### PR TITLE
fox: lootrun path chest boxes render distance

### DIFF
--- a/src/main/java/com/wynntils/modules/map/rendering/PointRenderer.java
+++ b/src/main/java/com/wynntils/modules/map/rendering/PointRenderer.java
@@ -14,7 +14,6 @@ import com.wynntils.modules.map.instances.LootRunPath;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.RenderGlobal;

--- a/src/main/java/com/wynntils/modules/map/rendering/PointRenderer.java
+++ b/src/main/java/com/wynntils/modules/map/rendering/PointRenderer.java
@@ -378,12 +378,15 @@ public class PointRenderer {
     public static void drawCube(BlockPos point, CustomColor color) {
         if (!McIf.world().isBlockLoaded(point, false)) return;
 
+        if (McIf.player().getDistanceSq(point.getX(), point.getY(), point.getZ()) > 4096f)
+            return; // only draw chest when close
+
         RenderManager renderManager = McIf.mc().getRenderManager();
 
         Location c = new Location(
-            point.getX() - renderManager.viewerPosX,
-            point.getY() - renderManager.viewerPosY,
-            point.getZ() - renderManager.viewerPosZ
+                point.getX() - renderManager.viewerPosX,
+                point.getY() - renderManager.viewerPosY,
+                point.getZ() - renderManager.viewerPosZ
         );
 
         GlStateManager.pushMatrix();


### PR DESCRIPTION
I noticed that chest boxes would also render very far away so I made it so that they no longer render in case the chest is outside of tile entity render distance (64 blocks).
This should improve performance a bit especially for big lootrun files.