### PR TITLE
Fix NPE when using Prevent Trades and Duels while holding weapon feature

### DIFF
--- a/src/main/java/com/wynntils/core/utils/ItemUtils.java
+++ b/src/main/java/com/wynntils/core/utils/ItemUtils.java
@@ -23,6 +23,7 @@ import net.minecraft.util.text.TextFormatting;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -122,7 +123,7 @@ public class ItemUtils {
         for (Entry<ItemType, String[]> e : WebManager.getMaterialTypes().entrySet()) {
             for (String id : e.getValue()) {
                 if (id.matches("[A-Za-z_:]+")) {
-                    if (Item.getByNameOrId(id).equals(item.getItem())) return e.getKey();
+                    if (Objects.equals(Item.getByNameOrId(id), item.getItem())) return e.getKey();
                 } else {
                     int damageValue = 0;
 

--- a/src/main/java/com/wynntils/core/utils/ItemUtils.java
+++ b/src/main/java/com/wynntils/core/utils/ItemUtils.java
@@ -31,6 +31,7 @@ public class ItemUtils {
 
     private static final Pattern LEVEL_PATTERN = Pattern.compile("(?:Combat|Crafting|Mining|Woodcutting|Farming|Fishing) Lv\\. Min: ([0-9]+)");
     private static final Pattern LEVEL_RANGE_PATTERN = Pattern.compile("Lv\\. Range: " + TextFormatting.WHITE.toString() + "([0-9]+)-([0-9]+)");
+    private static final Pattern WEAPON_SPEED_PATTERN = Pattern.compile("§7.+ Attack Speed");
 
     public static final NBTTagCompound UNBREAKABLE = new NBTTagCompound();
 
@@ -210,4 +211,18 @@ public class ItemUtils {
         UNBREAKABLE.setBoolean("Unbreakable", true);
     }
 
+    public static boolean isWeapon(ItemStack heldItem) {
+        List<String> lore = ItemUtils.getLore(heldItem);
+
+        //If item has attack speed line, it is a weapon
+        boolean isWeapon = false;
+        for (String s : lore) {
+            if (WEAPON_SPEED_PATTERN.matcher(s).matches()) {
+                isWeapon = true;
+                break;
+            }
+        }
+
+        return isWeapon;
+    }
 }

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -81,6 +81,8 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static net.minecraft.util.text.TextFormatting.getTextWithoutFormattingCodes;
+
 public class ClientEvents implements Listener {
 
     private static GuiScreen scheduledGuiScreen = null;
@@ -274,7 +276,7 @@ public class ClientEvents implements Listener {
     public void onGUIOpen(GuiOpenEvent e) {
         // Store the original opened chest so we can check itemstacks later
         // Make sure this check is not spoofed by checking inventory size
-        if (e.getGui() instanceof ChestReplacer && TextFormatting.getTextWithoutFormattingCodes(((ChestReplacer) e.getGui()).getLowerInv().getName()).startsWith("Loot Chest")
+        if (e.getGui() instanceof ChestReplacer && getTextWithoutFormattingCodes(((ChestReplacer) e.getGui()).getLowerInv().getName()).startsWith("Loot Chest")
                 && ((ChestReplacer) e.getGui()).getLowerInv().getSizeInventory() == 27) {
             currentLootChest = ((ChestReplacer) e.getGui()).getLowerInv();
         }
@@ -580,7 +582,7 @@ public class ClientEvents implements Listener {
         if (UtilitiesConfig.INSTANCE.preventMythicChestClose || UtilitiesConfig.INSTANCE.preventFavoritedChestClose) {
             if (e.getKeyCode() == 1 || e.getKeyCode() == McIf.mc().gameSettings.keyBindInventory.getKeyCode()) {
                 IInventory inv = e.getGui().getLowerInv();
-                String invName = TextFormatting.getTextWithoutFormattingCodes(inv.getName());
+                String invName = getTextWithoutFormattingCodes(inv.getName());
                 if ((invName.startsWith("Loot Chest") || invName.contains("Daily Rewards") ||
                         invName.contains("Objective Rewards")) && inv.getSizeInventory() <= 27) {
                     for (int i = 0; i < inv.getSizeInventory(); i++) {
@@ -674,7 +676,7 @@ public class ClientEvents implements Listener {
         IInventory chestInv = e.getGui().getLowerInv();
 
         // Queue messages into game update ticker when clicking on emeralds in loot chest
-        if (TextFormatting.getTextWithoutFormattingCodes(chestInv.getName()).startsWith("Loot Chest") && OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectEmeraldPouch) {
+        if (getTextWithoutFormattingCodes(chestInv.getName()).startsWith("Loot Chest") && OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectEmeraldPouch) {
             // Check if item is actually an emerald, if we're left clicking, and make sure we're not shift clicking
             if (currentLootChest.getStackInSlot(e.getSlotId()).getDisplayName().equals("§aEmerald") && e.getMouseButton() == 0 && !GuiScreen.isShiftKeyDown()) {
                 // Find all emerald pouches in inventory
@@ -704,7 +706,7 @@ public class ClientEvents implements Listener {
 
 
         // Prevent accidental ingredient/emerald pouch clicks in loot chests
-        if (TextFormatting.getTextWithoutFormattingCodes(chestInv.getName()).startsWith("Loot Chest") && UtilitiesConfig.INSTANCE.preventOpeningPouchesChest) {
+        if (getTextWithoutFormattingCodes(chestInv.getName()).startsWith("Loot Chest") && UtilitiesConfig.INSTANCE.preventOpeningPouchesChest) {
             // Ingredient pouch
             if (e.getSlotId() - chestInv.getSizeInventory() == 4) {
                 e.setCanceled(true);
@@ -779,14 +781,14 @@ public class ClientEvents implements Listener {
         if (oldStack.isEmpty() || !newStack.isEmpty() && !oldStack.isItemEqual(newStack)) return; // invalid move
         if (!oldStack.hasDisplayName()) return; // old item is not a valid item
 
-        String oldName = TextFormatting.getTextWithoutFormattingCodes(oldStack.getDisplayName());
+        String oldName = getTextWithoutFormattingCodes(oldStack.getDisplayName());
         Matcher oldMatcher = CRAFTED_USES.matcher(oldName);
         if (!oldMatcher.matches()) return;
         int oldUses = Integer.parseInt(oldMatcher.group(1));
 
         int newUses = 0;
         if (!newStack.isEmpty()) {
-            String newName = TextFormatting.getTextWithoutFormattingCodes(StringUtils.normalizeBadString(newStack.getDisplayName()));
+            String newName = getTextWithoutFormattingCodes(StringUtils.normalizeBadString(newStack.getDisplayName()));
             Matcher newMatcher = CRAFTED_USES.matcher(newName);
             if (newMatcher.matches()) {
                 newUses = Integer.parseInt(newMatcher.group(1));
@@ -900,10 +902,9 @@ public class ClientEvents implements Listener {
         EntityPlayer ep = (EntityPlayer) clicked;
         if (ep.getTeam() == null) return; // player model npc
 
-        ItemType item = ItemUtils.getItemType(player.getHeldItemMainhand());
-        if (item == null) return; // not any type of gear
-        if (item != ItemType.WAND && item != ItemType.DAGGER && item != ItemType.BOW && item != ItemType.SPEAR && item != ItemType.RELIK)
+        if (!ItemUtils.isWeapon(player.getHeldItemMainhand()))
             return; // not a weapon
+
         e.setCanceled(true);
     }
 
@@ -1037,7 +1038,7 @@ public class ClientEvents implements Listener {
 
     @SubscribeEvent
     public void onWindowOpen(PacketEvent<SPacketOpenWindow> e){
-        if (TextFormatting.getTextWithoutFormattingCodes(e.getPacket().getWindowTitle().getUnformattedText()).startsWith("Loot Chest"))
+        if (getTextWithoutFormattingCodes(e.getPacket().getWindowTitle().getUnformattedText()).startsWith("Loot Chest"))
             lastOpenedChestWindowId = e.getPacket().getWindowId();
         if (e.getPacket().getWindowTitle().toString().contains("Daily Rewards") || e.getPacket().getWindowTitle().toString().contains("Objective Rewards"))
             lastOpenedRewardWindowId = e.getPacket().getWindowId();

--- a/src/main/java/com/wynntils/modules/utilities/managers/QuickCastManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/QuickCastManager.java
@@ -130,22 +130,13 @@ public class QuickCastManager {
         List<String> lore = ItemUtils.getLore(heldItem);
 
         //If item has attack speed line, it is a weapon
-        boolean isWeapon = false;
+        boolean isWeapon = ItemUtils.isWeapon(heldItem);
         //Check class reqs to see if the weapon can be used by current class
         boolean classReqOk = false;
         //Is the current combat level enough to use the weapon
         boolean combatLvlMinReached = false;
         //If there is a spell point requirement that is not reached, store it and print it later
         String notReachedSpellPointRequirements = null;
-
-        int i = 0;
-        for (; i < lore.size(); i++) {
-            if (WEAPON_SPEED_PATTERN.matcher(lore.get(i)).matches())
-            {
-                isWeapon = true;
-                break;
-            }
-        }
 
         if (!isWeapon)
         {
@@ -155,6 +146,7 @@ public class QuickCastManager {
             return NO_SPELL;
         }
 
+        int i = 0;
         for (; i < lore.size(); i++) {
             if (CLASS_REQ_OK_PATTERN.matcher(lore.get(i)).matches())
             {


### PR DESCRIPTION
The PR also changes how the feature detects if the currently held item is a weapon, making it much more accurate.