### PR TITLE
Fix DungeonKeyManager crash involving old dungeon keys

### DIFF
--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemSpecificationOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemSpecificationOverlay.java
@@ -93,11 +93,14 @@ public class ItemSpecificationOverlay implements Listener {
             }
 
             if (UtilitiesConfig.Items.INSTANCE.keySpecification && DungeonKeyManager.isDungeonKey(stack)) {
-                specificationChars = DungeonKeyManager.getDungeonKey(stack).getAcronym();
-                if (DungeonKeyManager.isCorrupted(stack)) {
-                    color = MinecraftChatColors.DARK_RED;
-                } else {
-                    color = MinecraftChatColors.GOLD;
+                DungeonKeyManager.DungeonKey dungeonKey = DungeonKeyManager.getDungeonKey(stack);
+                if (dungeonKey != null) {
+                    specificationChars = dungeonKey.getAcronym();
+                    if (DungeonKeyManager.isCorrupted(stack)) {
+                        color = MinecraftChatColors.DARK_RED;
+                    } else {
+                        color = MinecraftChatColors.GOLD;
+                    }
                 }
             }
 


### PR DESCRIPTION
Related logs: https://hst.sh/yuzohanuda

Signed-off-by: kristofbolyai <bolyai.bolyai@gmail.com>