### PR TITLE
feat: Mana timer bar

### DIFF
--- a/src/main/java/com/wynntils/modules/utilities/UtilitiesModule.java
+++ b/src/main/java/com/wynntils/modules/utilities/UtilitiesModule.java
@@ -62,6 +62,7 @@ public class UtilitiesModule extends Module {
         registerOverlay(new HealthBarOverlay(), Priority.NORMAL);
         registerOverlay(new HotbarOverlay(), Priority.NORMAL);
         registerOverlay(new ManaBarOverlay(), Priority.NORMAL);
+        registerOverlay(new ManaTimerOverlay(), Priority.LOW);
         registerOverlay(new ExpBarOverlay(), Priority.NORMAL);
         registerOverlay(new LevelingOverlay(), Priority.LOW);
         registerOverlay(new BubblesOverlay(), Priority.HIGHEST);
@@ -104,6 +105,7 @@ public class UtilitiesModule extends Module {
         registerSettings(OverlayConfig.Leveling.class);
         registerSettings(OverlayConfig.Exp.class);
         registerSettings(OverlayConfig.Mana.class);
+        registerSettings(OverlayConfig.ManaTimer.class);
         registerSettings(OverlayConfig.Hotbar.class);
         registerSettings(OverlayConfig.ToastsSettings.class);
         registerSettings(OverlayConfig.WarTimer.class);

--- a/src/main/java/com/wynntils/modules/utilities/configs/OverlayConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/OverlayConfig.java
@@ -142,8 +142,11 @@ public class OverlayConfig extends SettingsClass {
         @Setting(displayName = "Mana Timer Percentage", description = "Should the mana timer use percentages instead of seconds?")
         public boolean manaTimerUsePercentage = false;
 
-        @Setting(displayName = "Mana Timer Second Decimal", description = "Should the mana timer have a decimal when displaying seconds?")
-        public boolean manaTimerDecimal = true;
+        @Setting(displayName = "Mana Timer Second Decimal", description = "How many decimals should the mana timer have when displaying seconds?")
+        public ManaTimerDecimalFormats manaTimerDecimal = ManaTimerDecimalFormats.One;
+
+        @Setting(displayName = "Mana Timer Seconds Count Down", description = "Should the mana timer count down instead of up when displaying seconds?")
+        public boolean manaTimerCountDown = true;
 
         @Setting(displayName = "Mana Timer Bar Width", description = "How wide should the mana bar be in pixels?\n\n§8This will be adjusted using Minecraft's scaling.")
         @Setting.Limitations.IntLimit(min = 0, max = 81)
@@ -176,6 +179,23 @@ public class OverlayConfig extends SettingsClass {
             c,
             d
             // following the format, to add more textures, register them here with a name and create a special case in the render method
+        }
+
+        public enum ManaTimerDecimalFormats {
+            Zero("%.0f"),
+            One("%.1f"),
+            Two("%.2f");
+
+            final String decimalFormat;
+
+            ManaTimerDecimalFormats(String decimalFormat) {
+                this.decimalFormat = decimalFormat;
+            }
+
+            public String getDecimalFormat() {
+                return this.decimalFormat;
+            }
+
         }
     }
 

--- a/src/main/java/com/wynntils/modules/utilities/configs/OverlayConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/OverlayConfig.java
@@ -20,6 +20,8 @@ import com.wynntils.modules.utilities.overlays.hud.ObjectivesOverlay;
 import com.wynntils.modules.utilities.overlays.hud.ScoreboardOverlay;
 import com.wynntils.modules.utilities.overlays.hud.TerritoryFeedOverlay;
 import net.minecraft.util.text.TextFormatting;
+import java.math.RoundingMode;
+import java.text.DecimalFormat;
 
 @SettingsInfo(name = "overlays", displayPath = "Utilities/Overlays")
 public class OverlayConfig extends SettingsClass {
@@ -131,6 +133,50 @@ public class OverlayConfig extends SettingsClass {
             // following the format, to add more textures, register them here with a name and create a special case in the render method
         }
 
+    }
+
+    @SettingsInfo(name = "mana_timer_settings", displayPath = "Utilities/Overlays/Mana Timer")
+    public static class ManaTimer extends SettingsClass {
+        public static ManaTimer INSTANCE;
+
+        @Setting(displayName = "Mana Timer Percentage", description = "Should the mana timer use percentages instead of seconds?")
+        public boolean manaTimerUsePercentage = false;
+
+        @Setting(displayName = "Mana Timer Second Decimal", description = "Should the mana timer have a decimal when displaying seconds?")
+        public boolean manaTimerDecimal = true;
+
+        @Setting(displayName = "Mana Timer Bar Width", description = "How wide should the mana bar be in pixels?\n\n§8This will be adjusted using Minecraft's scaling.")
+        @Setting.Limitations.IntLimit(min = 0, max = 81)
+        public int width = 81;
+
+        @Setting(displayName = "Mana Timer Bar Orientation", description = "How orientated in degrees should the mana bar be?\n\n§8Accompanied text will be removed.")
+        public OverlayRotation overlayRotation = OverlayRotation.NORMAL;
+
+        @Setting(displayName = "Mana Timer Texture", description = "What texture should be used for the mana bar?")
+        public ManaTimerTextures manaTexture = ManaTimerTextures.a;
+
+        @Setting.Limitations.FloatLimit(min = 0f, max = 5f)
+        @Setting(displayName = "Animation Speed", description = "How fast should the animation be played?\n\n§8Set this to 0 for it to display instantly.")
+        public float animated = 1f;
+
+        @Setting(displayName = "Text Shadow", description = "What should the text shadow look like?")
+        public SmartFontRenderer.TextShadow textShadow = SmartFontRenderer.TextShadow.OUTLINE;
+
+
+        public enum ManaTimerTextures {
+            Wynn,
+            Brune,
+            Aether,
+            Skull,
+            Inverse,
+            Skyrim,
+            Rune,
+            a,
+            b,
+            c,
+            d
+            // following the format, to add more textures, register them here with a name and create a special case in the render method
+        }
     }
 
     @SettingsInfo(name = "hotbar_settings", displayPath = "Utilities/Overlays/Hotbar")

--- a/src/main/java/com/wynntils/modules/utilities/configs/OverlayConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/OverlayConfig.java
@@ -155,9 +155,9 @@ public class OverlayConfig extends SettingsClass {
         @Setting(displayName = "Mana Timer Texture", description = "What texture should be used for the mana bar?")
         public ManaTimerTextures manaTexture = ManaTimerTextures.a;
 
-        @Setting.Limitations.FloatLimit(min = 0f, max = 5f)
+        @Setting.Limitations.FloatLimit(min = 0f, max = 10f)
         @Setting(displayName = "Animation Speed", description = "How fast should the animation be played?\n\n§8Set this to 0 for it to display instantly.")
-        public float animated = 1f;
+        public float animated = 5f;
 
         @Setting(displayName = "Text Shadow", description = "What should the text shadow look like?")
         public SmartFontRenderer.TextShadow textShadow = SmartFontRenderer.TextShadow.OUTLINE;

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -33,6 +33,7 @@ import com.wynntils.modules.utilities.configs.UtilitiesConfig;
 import com.wynntils.modules.utilities.managers.*;
 import com.wynntils.modules.utilities.overlays.hud.ConsumableTimerOverlay;
 import com.wynntils.modules.utilities.overlays.hud.GameUpdateOverlay;
+import com.wynntils.modules.utilities.overlays.hud.ManaTimerOverlay;
 import com.wynntils.modules.utilities.overlays.ui.FakeGuiContainer;
 import com.wynntils.webapi.WebManager;
 import com.wynntils.webapi.profiles.player.PlayerStatsProfile;
@@ -363,6 +364,9 @@ public class ClientEvents implements Listener {
             DailyReminderManager.openedDaily();
         }
 
+        if (msg.startsWith("[!] Darkness has been enabled.")) {
+            ManaTimerOverlay.isTimeFrozen = true;
+        }
     }
 
     @SubscribeEvent
@@ -943,6 +947,7 @@ public class ClientEvents implements Listener {
     @SubscribeEvent
     public void onWorldLeave(WynnWorldEvent.Leave e) {
         ConsumableTimerOverlay.clearConsumables(true); // clear consumable list
+        ManaTimerOverlay.isTimeFrozen = false;
     }
 
     // tooltip scroller

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -364,7 +364,7 @@ public class ClientEvents implements Listener {
             DailyReminderManager.openedDaily();
         }
 
-        if (msg.startsWith("[!] Darkness has been enabled.")) {
+        if (msg.startsWith("[!] Darkness has been enabled.") || msg.startsWith("[!] Twilight has been enabled.")) {
             ManaTimerOverlay.isTimeFrozen = true;
         }
     }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/ManaTimerOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/ManaTimerOverlay.java
@@ -30,6 +30,7 @@ public class ManaTimerOverlay extends Overlay {
     public CustomColor textColor = CommonColors.LIGHT_BLUE;
 
     private static float manaTime = 0.0f;
+    public static boolean isTimeFrozen = false;
 
     @Override
     public void tick(TickEvent.ClientTickEvent event, long ticks) {
@@ -93,11 +94,14 @@ public class ManaTimerOverlay extends Overlay {
         String decimalFormat = (OverlayConfig.ManaTimer.INSTANCE.manaTimerDecimal && !OverlayConfig.ManaTimer.INSTANCE.manaTimerUsePercentage) ? "%.2f" : "%.0f";
         String displayedProgress = String.format(decimalFormat, manaTime) + suffix;
 
+        String formattedDisplayed = (isTimeFrozen) ? "Unavailable" : displayedProgress + " ✺ " + displayedMax;
+        float progress = (isTimeFrozen) ? 0.0f : flip ? -manaTime : manaTime / (float) maxProgress;
+
         if (OverlayConfig.ManaTimer.INSTANCE.overlayRotation == OverlayRotation.NORMAL) {
-            drawString(displayedProgress + " ✺ " + displayedMax, textPositionOffset.a - (81-OverlayConfig.ManaTimer.INSTANCE.width), textPositionOffset.b, cc, SmartFontRenderer.TextAlignment.MIDDLE, OverlayConfig.Mana.INSTANCE.textShadow);
+            drawString(formattedDisplayed, textPositionOffset.a - (81-OverlayConfig.ManaTimer.INSTANCE.width), textPositionOffset.b, cc, SmartFontRenderer.TextAlignment.MIDDLE, OverlayConfig.Mana.INSTANCE.textShadow);
         }
         rotate(OverlayConfig.ManaTimer.INSTANCE.overlayRotation.getDegrees());
-        drawProgressBar(Textures.Overlays.bars_mana, OverlayConfig.ManaTimer.INSTANCE.width, y1, 0, y2, 0, ty1, 81, ty2, (flip ? -manaTime : manaTime) / (float) maxProgress);
+        drawProgressBar(Textures.Overlays.bars_mana, OverlayConfig.ManaTimer.INSTANCE.width, y1, 0, y2, 0, ty1, 81, ty2, progress);
 
     }
 }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/ManaTimerOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/ManaTimerOverlay.java
@@ -17,7 +17,7 @@ import net.minecraftforge.fml.common.gameevent.TickEvent;
 
 public class ManaTimerOverlay extends Overlay {
     public ManaTimerOverlay() {
-        super("Mana Timer Bar", 81, 21, true, 0.5f, 1.0f, 10, -38, OverlayGrowFrom.BOTTOM_RIGHT);
+        super("Mana Timer Bar", 81, 21, true, 0.57f, 1.039f, 10, -38, OverlayGrowFrom.MIDDLE_LEFT);
     }
 
     @Setting(displayName = "Flip", description = "Should the filling of the bar be flipped")
@@ -87,8 +87,10 @@ public class ManaTimerOverlay extends Overlay {
 
     private void drawDefaultBar(int y1, int y2, int ty1, int ty2, CustomColor cc) {
         int maxProgress = (OverlayConfig.ManaTimer.INSTANCE.manaTimerUsePercentage) ? 100 : 5;
-        String displayedMax = (OverlayConfig.ManaTimer.INSTANCE.manaTimerUsePercentage) ? "100%" : "5s";
-        String displayedProgress = (OverlayConfig.ManaTimer.INSTANCE.manaTimerDecimal) ? String.format("%.2f", manaTime) + "s" : String.format("%.0f", manaTime) + "%";
+        char suffix = (OverlayConfig.ManaTimer.INSTANCE.manaTimerUsePercentage) ? '%' : 's';
+        String displayedMax = String.valueOf(maxProgress) + suffix;
+        String decimalFormat = (OverlayConfig.ManaTimer.INSTANCE.manaTimerDecimal && !OverlayConfig.ManaTimer.INSTANCE.manaTimerUsePercentage) ? "%.2f" : "%.0f";
+        String displayedProgress = String.format(decimalFormat, manaTime) + suffix;;
 
         if (OverlayConfig.ManaTimer.INSTANCE.overlayRotation == OverlayRotation.NORMAL) {
             drawString(displayedProgress + " ✺ " + displayedMax, textPositionOffset.a - (81-OverlayConfig.ManaTimer.INSTANCE.width), textPositionOffset.b, cc, SmartFontRenderer.TextAlignment.MIDDLE, OverlayConfig.Mana.INSTANCE.textShadow);

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/ManaTimerOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/ManaTimerOverlay.java
@@ -90,9 +90,16 @@ public class ManaTimerOverlay extends Overlay {
     private void drawDefaultBar(int y1, int y2, int ty1, int ty2, CustomColor cc) {
         int maxProgress = (OverlayConfig.ManaTimer.INSTANCE.manaTimerUsePercentage) ? 100 : 5;
         char suffix = (OverlayConfig.ManaTimer.INSTANCE.manaTimerUsePercentage) ? '%' : 's';
+
         String displayedMax = String.valueOf(maxProgress) + suffix;
-        String decimalFormat = (OverlayConfig.ManaTimer.INSTANCE.manaTimerDecimal && !OverlayConfig.ManaTimer.INSTANCE.manaTimerUsePercentage) ? "%.2f" : "%.0f";
-        String displayedProgress = String.format(decimalFormat, manaTime) + suffix;
+        String decimalFormat = (OverlayConfig.ManaTimer.INSTANCE.manaTimerUsePercentage) ?
+                OverlayConfig.ManaTimer.ManaTimerDecimalFormats.Zero.getDecimalFormat() :
+                OverlayConfig.ManaTimer.INSTANCE.manaTimerDecimal.getDecimalFormat();
+
+        String displayedProgress = (!OverlayConfig.ManaTimer.INSTANCE.manaTimerUsePercentage && OverlayConfig.ManaTimer.INSTANCE.manaTimerCountDown) ?
+                String.format(decimalFormat, 5.0f - manaTime) :
+                String.format(decimalFormat, manaTime);
+        displayedProgress += suffix;
 
         String formattedDisplayed = (isTimeFrozen) ? "Unavailable" : displayedProgress + " ✺ " + displayedMax;
         float progress = (isTimeFrozen) ? 0.0f : flip ? -manaTime : manaTime / (float) maxProgress;

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/ManaTimerOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/ManaTimerOverlay.java
@@ -33,7 +33,8 @@ public class ManaTimerOverlay extends Overlay {
 
     @Override
     public void tick(TickEvent.ClientTickEvent event, long ticks) {
-        if (!(visible = PlayerInfo.get(InventoryData.class).getTicksToNextSoulPoint() != -1 && !Reference.onLobby)) return;
+        visible = PlayerInfo.get(InventoryData.class).getTicksToNextSoulPoint() != -1;
+        if (!visible || Reference.onLobby) return;
 
         int spTicks = PlayerInfo.get(InventoryData.class).getTicksToNextSoulPoint();
         // Mana regen procs at 14599, 14499, 14399...

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/ManaTimerOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/ManaTimerOverlay.java
@@ -90,7 +90,7 @@ public class ManaTimerOverlay extends Overlay {
         char suffix = (OverlayConfig.ManaTimer.INSTANCE.manaTimerUsePercentage) ? '%' : 's';
         String displayedMax = String.valueOf(maxProgress) + suffix;
         String decimalFormat = (OverlayConfig.ManaTimer.INSTANCE.manaTimerDecimal && !OverlayConfig.ManaTimer.INSTANCE.manaTimerUsePercentage) ? "%.2f" : "%.0f";
-        String displayedProgress = String.format(decimalFormat, manaTime) + suffix;;
+        String displayedProgress = String.format(decimalFormat, manaTime) + suffix;
 
         if (OverlayConfig.ManaTimer.INSTANCE.overlayRotation == OverlayRotation.NORMAL) {
             drawString(displayedProgress + " ✺ " + displayedMax, textPositionOffset.a - (81-OverlayConfig.ManaTimer.INSTANCE.width), textPositionOffset.b, cc, SmartFontRenderer.TextAlignment.MIDDLE, OverlayConfig.Mana.INSTANCE.textShadow);

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/ManaTimerOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/ManaTimerOverlay.java
@@ -1,0 +1,100 @@
+package com.wynntils.modules.utilities.overlays.hud;
+
+import com.wynntils.Reference;
+import com.wynntils.core.framework.instances.PlayerInfo;
+import com.wynntils.core.framework.instances.data.InventoryData;
+import com.wynntils.core.framework.overlays.Overlay;
+import com.wynntils.core.framework.rendering.SmartFontRenderer;
+import com.wynntils.core.framework.rendering.colors.CommonColors;
+import com.wynntils.core.framework.rendering.colors.CustomColor;
+import com.wynntils.core.framework.rendering.textures.Textures;
+import com.wynntils.core.framework.settings.annotations.Setting;
+import com.wynntils.core.utils.objects.Pair;
+import com.wynntils.modules.core.enums.OverlayRotation;
+import com.wynntils.modules.utilities.configs.OverlayConfig;
+import net.minecraftforge.client.event.RenderGameOverlayEvent;
+import net.minecraftforge.fml.common.gameevent.TickEvent;
+
+public class ManaTimerOverlay extends Overlay {
+    public ManaTimerOverlay() {
+        super("Mana Timer Bar", 81, 21, true, 0.5f, 1.0f, 10, -38, OverlayGrowFrom.BOTTOM_RIGHT);
+    }
+
+    @Setting(displayName = "Flip", description = "Should the filling of the bar be flipped")
+    public boolean flip = false;
+
+    @Setting(displayName = "Text Position", description = "The position offset of the text")
+    public Pair<Integer, Integer> textPositionOffset = new Pair<>(40, -10);
+
+    @Setting(displayName = "Text Name", description = "The color of the text")
+    public CustomColor textColor = CommonColors.LIGHT_BLUE;
+
+    private static float manaTime = 0.0f;
+
+    @Override
+    public void tick(TickEvent.ClientTickEvent event, long ticks) {
+        if (!(visible = PlayerInfo.get(InventoryData.class).getTicksToNextSoulPoint() != -1 && !Reference.onLobby)) return;
+
+        int spTicks = PlayerInfo.get(InventoryData.class).getTicksToNextSoulPoint();
+        // Mana regen procs at 14599, 14499, 14399...
+        // and lasts until     14580, 14480, 14380...
+        // Each regen proc lasts one second but effectively needs to have the player having the MR stat at
+        // 14600, 14500, 14400... (which makes this calculation a lot easier compared to xxx99)
+        int percentUntilProc = 100 - spTicks % 100; // Each percent is a tick
+        float displayedValue = (OverlayConfig.ManaTimer.INSTANCE.manaTimerUsePercentage) ? percentUntilProc : percentUntilProc / 20.0f;
+
+        if (OverlayConfig.ManaTimer.INSTANCE.animated > 0.0f && OverlayConfig.ManaTimer.INSTANCE.animated < 10.0f) {
+            manaTime -= (OverlayConfig.ManaTimer.INSTANCE.animated * 0.1f) * (manaTime - displayedValue);
+        } else {
+            manaTime = displayedValue;
+        }
+    }
+
+    @Override
+    public void render(RenderGameOverlayEvent.Pre event) {
+        switch (OverlayConfig.ManaTimer.INSTANCE.manaTexture) {
+            case Wynn:
+                drawDefaultBar(-1, 8, 0, 17, textColor);
+                break;
+            case a: drawDefaultBar(-1, 7, 18, 33, textColor);
+                break;
+            case b: drawDefaultBar(-1, 8, 34, 51, textColor);
+                break;
+            case c: drawDefaultBar(-1, 7, 52, 67, textColor);
+                break;
+            case d: drawDefaultBar(-1, 7, 68, 83, textColor);
+                break;
+            case Brune:
+                drawDefaultBar(-1, 8, 83, 100, textColor);
+                break;
+            case Inverse:
+                drawDefaultBar(-1, 7, 100, 115, CommonColors.MAGENTA);
+                break;
+            case Aether:
+                drawDefaultBar(-1, 7, 116, 131, textColor);
+                break;
+            case Skull:
+                drawDefaultBar(-1, 8, 132, 147, textColor);
+                break;
+            case Skyrim:
+                drawDefaultBar(-1, 8, 148, 163, textColor);
+                break;
+            case Rune:
+                drawDefaultBar(-1, 8, 164, 179, textColor);
+                break;
+        }
+    }
+
+    private void drawDefaultBar(int y1, int y2, int ty1, int ty2, CustomColor cc) {
+        int maxProgress = (OverlayConfig.ManaTimer.INSTANCE.manaTimerUsePercentage) ? 100 : 5;
+        String displayedMax = (OverlayConfig.ManaTimer.INSTANCE.manaTimerUsePercentage) ? "100%" : "5s";
+        String displayedProgress = (OverlayConfig.ManaTimer.INSTANCE.manaTimerDecimal) ? String.format("%.2f", manaTime) + "s" : String.format("%.0f", manaTime) + "%";
+
+        if (OverlayConfig.ManaTimer.INSTANCE.overlayRotation == OverlayRotation.NORMAL) {
+            drawString(displayedProgress + " ✺ " + displayedMax, textPositionOffset.a - (81-OverlayConfig.ManaTimer.INSTANCE.width), textPositionOffset.b, cc, SmartFontRenderer.TextAlignment.MIDDLE, OverlayConfig.Mana.INSTANCE.textShadow);
+        }
+        rotate(OverlayConfig.ManaTimer.INSTANCE.overlayRotation.getDegrees());
+        drawProgressBar(Textures.Overlays.bars_mana, OverlayConfig.ManaTimer.INSTANCE.width, y1, 0, y2, 0, ty1, 81, ty2, (flip ? -manaTime : manaTime) / (float) maxProgress);
+
+    }
+}


### PR DESCRIPTION
Adds a bar similar to health/mana that displays time until MR cycles.
Can be toggled on/off like any standard overlay, and can also switch between seconds/percentage.
Calculates based on soul point ticks.