### PR TITLE
FIX: Mounting horse when sprinting uses stamina

### DIFF
--- a/src/main/java/com/wynntils/modules/utilities/managers/MountHorseManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/MountHorseManager.java
@@ -139,6 +139,7 @@ public class MountHorseManager {
         }
 
         player.inventory.currentItem = 8; // swap to soul points to avoid any right-click conflicts
+        McIf.player().setSprinting(false);
         playerController.interactWithEntity(player, playersHorse, EnumHand.MAIN_HAND);
         player.inventory.currentItem = prev;
         return MountHorseStatus.SUCCESS;

--- a/src/main/java/com/wynntils/modules/utilities/managers/MountHorseManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/MountHorseManager.java
@@ -122,7 +122,8 @@ public class MountHorseManager {
                 return MountHorseStatus.NO_HORSE;
             }
 
-            player.inventory.currentItem = horse.getInventorySlot();
+            
+            .inventory.currentItem = horse.getInventorySlot();
             playerController.processRightClick(player, player.world, EnumHand.MAIN_HAND);
             player.inventory.currentItem = prev;
             if (far) {
@@ -139,7 +140,7 @@ public class MountHorseManager {
         }
 
         player.inventory.currentItem = 8; // swap to soul points to avoid any right-click conflicts
-        McIf.player().setSprinting(false);
+        player.setSprinting(false);
         playerController.interactWithEntity(player, playersHorse, EnumHand.MAIN_HAND);
         player.inventory.currentItem = prev;
         return MountHorseStatus.SUCCESS;


### PR DESCRIPTION
Currently, whenever you sprint and mount your horse, your stamina bar will keep running out until you remount it while not sprinting. This one-liner fixes that by stopping the sprinting of the player. I've tried restoring the sprint status after mounting but then the stamina bar runs out again, maybe there needs to be a little wait time? Not sure how you'd like me to implement that though as that may be confusing for the end user, so I'll just leave it like this for now