### PR TITLE
fix: Quest completed dialogue chat fixes

### DIFF
--- a/src/main/java/com/wynntils/modules/chat/configs/ChatConfig.java
+++ b/src/main/java/com/wynntils/modules/chat/configs/ChatConfig.java
@@ -43,7 +43,7 @@ public class ChatConfig extends SettingsClass {
     @Setting(displayName = "Filter Join Messages", description = "Should Wynncraft join messages be hidden from chat?", order = 9)
     public boolean filterJoinMessages = false;
 
-    @Setting(displayName = "Filter Event Messages", description = "Should Wynncraft join messages be hidden from chat?\n\n§8Messages starting with §6[Event] will no longer appear in chat.", order = 10)
+    @Setting(displayName = "Filter Event Messages", description = "Should Wynncraft join messages be hidden from chat?\n\n§8Messages starting with §6[Event] §8will no longer appear in chat.", order = 10)
     public boolean filterEventMessages = false;
 
     @Setting(displayName = "Filter Territory Enter", description = "Should territory enter messages be hidden from chat?\n\n§8Territory enter messages look like §7[You are now entering Detlas]§8.", order = 11)

--- a/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
+++ b/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
@@ -980,8 +980,9 @@ public class ChatManager {
                 }
             }
 
-            if (dialogueChat != null)
+            if (dialogueChat != null) {
                 ChatOverlay.getChat().printChatMessageWithOptionalDeletion(dialogueChat, WYNN_DIALOGUE_NEW_MESSAGES_ID);
+            }
 
             lastChat = chat;
             ITextComponent newComponent = new TextComponentString("");

--- a/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
+++ b/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
@@ -143,7 +143,7 @@ public class ChatManager {
 
                     if (QuestManager.getCurrentDiscoveries().isEmpty() && !discoveriesLoaded) {
                         QuestManager.updateAnalysis(EnumSet.of(AnalysePosition.DISCOVERIES, AnalysePosition.SECRET_DISCOVERIES), true, true);
-                        return new Pair<ITextComponent, Pair<Supplier<Boolean>, Function<ITextComponent, ITextComponent>>>(original, new Pair<>(ChatManager::getDiscoveriesLoaded, s -> ChatManager.processRealMessage(s).a));
+                        return new Pair<>(original, new Pair<>(ChatManager::getDiscoveriesLoaded, s -> ChatManager.processRealMessage(s).a));
                     }
 
                     translateWynnic = QuestManager.getCurrentDiscoveries().stream()

--- a/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
+++ b/src/main/java/com/wynntils/modules/chat/managers/ChatManager.java
@@ -905,13 +905,11 @@ public class ChatManager {
             int max = Math.max(0, siblings.size() - newMessageCount);
             for (int i = max; i < siblings.size(); i++) {
                 ITextComponent line = siblings.get(i).createCopy();
-                // Remove new line if present
-                if (i != siblings.size() - 1 && !line.getSiblings().isEmpty()) {
-                    line.getSiblings().remove(line.getSiblings().size() - 1);
-                }
+                line.getSiblings().removeIf(sibling -> sibling.getFormattedText().contains("\n")); // Remove new line if present
 
-                line = ForgeEventFactory.onClientChat(ChatType.SYSTEM, line);
-                if (line != null) {
+                line = ForgeEventFactory.onClientChat(ChatType.SYSTEM, line); // This just returns line, it doesn't actually alter it
+                if (line != null && !line.getFormattedText().equals("") && !line.getFormattedText().contains("\n")) { // Don't print extra newlines
+
                     ChatOverlay.getChat().printChatMessage(line);
                 }
             }
@@ -963,7 +961,8 @@ public class ChatManager {
             // If dialogue is the exact same as previously then most likely a message was received
             // The second check is for the colors changing on the shift prompt
             if (dialogue.equals(last) && dialogue.get(dialogue.size() - 1).getSiblings().equals(last.get(last.size() - 1).getSiblings())) {
-                newMessageCount++;
+                newMessageCount += 2; // 2 because this needs to account for the new lines
+                // new lines are ignored later in the processing logic but they are still present here and need to be fed to the processor
 
                 // most recent message
                 ITextComponent newMessage = siblings.get(siblings.size() - lineCount - 1);

--- a/src/main/java/com/wynntils/modules/chat/overlays/ChatOverlay.java
+++ b/src/main/java/com/wynntils/modules/chat/overlays/ChatOverlay.java
@@ -144,10 +144,6 @@ public class ChatOverlay extends GuiNewChat {
         LOGGER.info("[CHAT] " + McIf.getUnformattedText(chatComponent).replaceAll("\r", "\\\\r").replaceAll("\n", "\\\\n"));
     }
 
-    public void printUnloggedChatMessage(ITextComponent chatComponent) {
-        printUnloggedChatMessage(chatComponent, 0);
-    }
-
     public void printUnloggedChatMessage(ITextComponent chatComponent, int chatLineId) {
         setChatLine(chatComponent, chatLineId, McIf.mc().ingameGUI.getUpdateCounter(), false, true);
     }

--- a/src/main/java/com/wynntils/modules/chat/overlays/ChatOverlay.java
+++ b/src/main/java/com/wynntils/modules/chat/overlays/ChatOverlay.java
@@ -156,7 +156,7 @@ public class ChatOverlay extends GuiNewChat {
             chatComponent = dialogue.b;
             chatLineId = WYNN_DIALOGUE_ID;
 
-            if (dialogue.b == null) {
+            if (chatComponent == null) {
                 deleteChatLine(chatLineId);
                 return;
             }

--- a/src/main/java/com/wynntils/modules/chat/overlays/ChatOverlay.java
+++ b/src/main/java/com/wynntils/modules/chat/overlays/ChatOverlay.java
@@ -390,12 +390,6 @@ public class ChatOverlay extends GuiNewChat {
         }
     }
 
-
-    public void updateLine(ChatTab tab, int id, Function<ITextComponent, ITextComponent> change) {
-        updateLines(tab, new HashMap<Integer, Pair<Supplier<Boolean>, Function<ITextComponent, ITextComponent>>>()
-            {{ put(id, new Pair<>(() -> true, change)); }});
-    }
-
     public void refreshChat() {
         resetScroll();
     }

--- a/src/main/java/com/wynntils/modules/chat/overlays/ChatOverlay.java
+++ b/src/main/java/com/wynntils/modules/chat/overlays/ChatOverlay.java
@@ -148,6 +148,15 @@ public class ChatOverlay extends GuiNewChat {
         setChatLine(chatComponent, chatLineId, McIf.mc().ingameGUI.getUpdateCounter(), false, true);
     }
 
+    /**
+     * Sets the chat to be chatComponent at chatLineId by deleting the previous value and adding the new one.
+     * Adds the line if the specified ID is 0.
+     * @param chatComponent The ITextComponent we are setting the value to be
+     * @param chatLineId The chat line ID we are replacing
+     * @param updateCounter Passed directly into {@link ChatOverlay#addLine}
+     * @param displayOnly Passed directly into {@link ChatOverlay#addLine}
+     * @param noEvent Skips posting a new ChatEvent when true
+     */
     private void setChatLine(ITextComponent chatComponent, int chatLineId, int updateCounter, boolean displayOnly, boolean noEvent) {
         chatComponent = chatComponent.createCopy();
 

--- a/src/main/java/com/wynntils/modules/questbook/managers/QuestManager.java
+++ b/src/main/java/com/wynntils/modules/questbook/managers/QuestManager.java
@@ -102,7 +102,7 @@ public class QuestManager {
             return;
         }
 
-        sendMessage(GRAY + "[Analysing quest book...]");
+        sendQuestBookMessage(GRAY + "[Analysing quest book...]");
         hasInterrupted = false;
 
         List<ItemStack> gatheredQuests = new ArrayList<>();
@@ -314,7 +314,7 @@ public class QuestManager {
             if (!gatheredDiscoveries.isEmpty()) parseDiscoveries(gatheredDiscoveries);
 
             FrameworkManager.getEventBus().post(new QuestBookUpdateEvent.Full());
-            sendMessage(GRAY + "[Quest book analyzed]");
+            sendQuestBookMessage(GRAY + "[Quest book analyzed]");
             WynntilsSound.QUESTBOOK_UPDATE.play(0.5f, 1f);
         });
 
@@ -550,10 +550,10 @@ public class QuestManager {
 
     private static void interrupt() {
         hasInterrupted = true;
-        sendMessage(RED + "[Quest book analysis failed, manually open your book to try again]");
+        sendQuestBookMessage(RED + "[Quest book analysis failed, manually open your book to try again]");
     }
 
-    private static void sendMessage(String msg) {
+    private static void sendQuestBookMessage(String msg) {
         // Can be called from nio thread by FakeInventory
         McIf.mc().addScheduledTask(() ->
             ChatOverlay.getChat().printChatMessageWithOptionalDeletion(new TextComponentString(msg), MESSAGE_ID)


### PR DESCRIPTION
Fixes the quest completed dialogue looking like this: https://cdn.discordapp.com/attachments/709413517907722300/977665607896031304/unknown.png

Works by doubling the number of new lines processed when that quest completed bit comes up. Also adds ignores to empty and \n lines. Tested on the starting quest and the lava springs quest.