### PR TITLE
Feat: Add reverse option to ingredient pouch sorting

### DIFF
--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -148,7 +148,7 @@ public class UtilitiesConfig extends SettingsClass {
     @Setting(displayName = "Show consumable charges in hotbar", description = "Should potion, food, and scroll charges be shown in the hotbar?", order = 28)
     public boolean showConsumableChargesHotbar = true;
 
-    @Setting(displayName = "Sort Ingredient Pouch Method", description = "How should the ingredient pouch overview be sorted?\n\n§8Click on the ingredient pouch to refresh.", order = 30)
+    @Setting(displayName = "Sort Ingredient Pouch Method", description = "How should the ingredient pouch overview be sorted?\n\n§8Click on the ingredient pouch to refresh.", order = 33)
     public IngPouchSortType sortIngredientPouch = IngPouchSortType.Rarity;
 
     @Setting(upload = false)

--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -151,6 +151,9 @@ public class UtilitiesConfig extends SettingsClass {
     @Setting(displayName = "Sort Ingredient Pouch Method", description = "How should the ingredient pouch overview be sorted?\n\n§8Click on the ingredient pouch to refresh.", order = 33)
     public IngPouchSortType sortIngredientPouch = IngPouchSortType.Rarity;
 
+    @Setting(displayName = "Reverse Ingredient Pouch Order", description = "Should the ingredient pouch sort order be reversed?\n\n§8Click on the ingredient pouch to refresh.", order = 34)
+    public boolean sortIngredientPouchReverse = false;
+
     @Setting(upload = false)
     public String lastServerResourcePack = "";
 

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -1229,11 +1229,11 @@ public class ClientEvents implements Listener {
                 sortedIngredients = new LinkedHashMap<>();
                 List<Map.Entry<String, Pair<Integer, Integer>>> sortedQtyList = new ArrayList<>(items.entrySet());
 
-                // sort based on the pair's first value (qty), reversed for descending
-                sortedQtyList.sort(Comparator.comparing((Map.Entry<String, Pair<Integer, Integer>> o) -> (o.getValue().a)).reversed());
+                // sort based on the pair's first value (qty), sorted ascending
+                sortedQtyList.sort(Comparator.comparing(o -> (o.getValue().a)));
 
-                if (UtilitiesConfig.INSTANCE.sortIngredientPouchReverse) {
-                    // reverse sortedQtyList
+                if (!UtilitiesConfig.INSTANCE.sortIngredientPouchReverse) {
+                    // reverse sortedQtyList for descending if sortIngredientPouchReverse is false
                     Collections.reverse(sortedQtyList);
                 }
 
@@ -1246,11 +1246,11 @@ public class ClientEvents implements Listener {
                 sortedIngredients = new LinkedHashMap<>();
                 List<Map.Entry<String, Pair<Integer, Integer>>> sortedRarityList = new ArrayList<>(items.entrySet());
 
-                // sort based on rarity, reversed for descending (3* -> 0*)
-                sortedRarityList.sort(Comparator.comparing((Map.Entry<String, Pair<Integer, Integer>> o) -> (o.getValue().b)).reversed());
+                // sort based on rarity, sorting ascending (0* -> 3*)
+                sortedRarityList.sort(Comparator.comparing(o -> (o.getValue().b)));
 
-                if (UtilitiesConfig.INSTANCE.sortIngredientPouchReverse) {
-                    // reverse sortedRarityList
+                if (!UtilitiesConfig.INSTANCE.sortIngredientPouchReverse) {
+                    // reverse sortedRarityList for descending (3* -> 0*) if sortIngredientPouchReverse is false
                     Collections.reverse(sortedRarityList);
                 }
 

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -1229,13 +1229,13 @@ public class ClientEvents implements Listener {
                 sortedIngredients = new LinkedHashMap<>();
                 List<Map.Entry<String, Pair<Integer, Integer>>> sortedQtyList = new ArrayList<>(items.entrySet());
 
-                // sort based on the pair's first value (qty), sorted ascending
-                sortedQtyList.sort(Comparator.comparing(o -> (o.getValue().a)));
+                // Define default and reverse comparators
+                Comparator<Map.Entry<String, Pair<Integer, Integer>>> sortQtyComparator = UtilitiesConfig.INSTANCE.sortIngredientPouchReverse ?
+                        Comparator.comparing(o -> (o.getValue().a)) : // Sort based on qty, sorted ascending
+                        Comparator.comparing((Map.Entry<String, Pair<Integer, Integer>> o) -> (o.getValue().a)).reversed(); // Sort based on qty, sorted descending
 
-                if (!UtilitiesConfig.INSTANCE.sortIngredientPouchReverse) {
-                    // reverse sortedQtyList for descending if sortIngredientPouchReverse is false
-                    Collections.reverse(sortedQtyList);
-                }
+                // Sort using comparator
+                sortedQtyList.sort(sortQtyComparator);
 
                 for (Map.Entry<String, Pair<Integer, Integer>> ingredient : sortedQtyList) {
                     sortedIngredients.put(ingredient.getKey(), ingredient.getValue());
@@ -1246,13 +1246,13 @@ public class ClientEvents implements Listener {
                 sortedIngredients = new LinkedHashMap<>();
                 List<Map.Entry<String, Pair<Integer, Integer>>> sortedRarityList = new ArrayList<>(items.entrySet());
 
-                // sort based on rarity, sorting ascending (0* -> 3*)
-                sortedRarityList.sort(Comparator.comparing(o -> (o.getValue().b)));
+                // Define default and reverse comparators
+                Comparator<Map.Entry<String, Pair<Integer, Integer>>> sortRarityComparator = UtilitiesConfig.INSTANCE.sortIngredientPouchReverse ?
+                        Comparator.comparing(o -> (o.getValue().b)) : // Sort based on rarity, sorted ascending (0* -> 3*)
+                        Comparator.comparing((Map.Entry<String, Pair<Integer, Integer>> o) -> (o.getValue().b)).reversed(); // Sort based on rarity, sorted descending (3* -> 0*)
 
-                if (!UtilitiesConfig.INSTANCE.sortIngredientPouchReverse) {
-                    // reverse sortedRarityList for descending (3* -> 0*) if sortIngredientPouchReverse is false
-                    Collections.reverse(sortedRarityList);
-                }
+                // Sort using comparator
+                sortedRarityList.sort(sortRarityComparator);
 
                 for (Map.Entry<String, Pair<Integer, Integer>> ingredient : sortedRarityList) {
                     sortedIngredients.put(ingredient.getKey(), ingredient.getValue());

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -1217,13 +1217,26 @@ public class ClientEvents implements Listener {
         Map<String, Pair<Integer, Integer>> sortedIngredients;
         switch (UtilitiesConfig.INSTANCE.sortIngredientPouch) {
             case Alphabetical:
-                sortedIngredients = new TreeMap<>(items); // TreeMap will sort it for us
+                if (UtilitiesConfig.INSTANCE.sortIngredientPouchReverse) {
+                    // Use TreeMap with reverseOrder to sort reverse-alphabetically
+                    sortedIngredients = new TreeMap<>(Collections.reverseOrder());
+                    sortedIngredients.putAll(items);
+                } else {
+                    sortedIngredients = new TreeMap<>(items); // TreeMap will sort it for us
+                }
                 break;
             case Quantity:
                 sortedIngredients = new LinkedHashMap<>();
                 List<Map.Entry<String, Pair<Integer, Integer>>> sortedQtyList = new ArrayList<>(items.entrySet());
-                // sort based on the pair's first value (qty), reversed for descending
-                sortedQtyList.sort(Comparator.comparing((Map.Entry<String, Pair<Integer, Integer>> o) -> (o.getValue().a)).reversed());
+
+                if (UtilitiesConfig.INSTANCE.sortIngredientPouchReverse) {
+                    // sort based on the pair's first value (qty), sorted ascending
+                    sortedQtyList.sort(Comparator.comparing((Map.Entry<String, Pair<Integer, Integer>> o) -> (o.getValue().a)));
+                } else {
+                    // sort based on the pair's first value (qty), reversed for descending
+                    sortedQtyList.sort(Comparator.comparing((Map.Entry<String, Pair<Integer, Integer>> o) -> (o.getValue().a)).reversed());
+                }
+
                 for (Map.Entry<String, Pair<Integer, Integer>> ingredient : sortedQtyList) {
                     sortedIngredients.put(ingredient.getKey(), ingredient.getValue());
                 }
@@ -1232,8 +1245,15 @@ public class ClientEvents implements Listener {
             default:
                 sortedIngredients = new LinkedHashMap<>();
                 List<Map.Entry<String, Pair<Integer, Integer>>> sortedRarityList = new ArrayList<>(items.entrySet());
-                // sort based on rarity, reversed for descending (3* -> 0*)
-                sortedRarityList.sort(Comparator.comparing((Map.Entry<String, Pair<Integer, Integer>> o) -> (o.getValue().b)).reversed());
+
+                if (UtilitiesConfig.INSTANCE.sortIngredientPouchReverse) {
+                    // sort based on rarity, sorted ascending (0* -> 3*)
+                    sortedRarityList.sort(Comparator.comparing((Map.Entry<String, Pair<Integer, Integer>> o) -> (o.getValue().b)));
+                } else {
+                    // sort based on rarity, reversed for descending (3* -> 0*)
+                    sortedRarityList.sort(Comparator.comparing((Map.Entry<String, Pair<Integer, Integer>> o) -> (o.getValue().b)).reversed());
+                }
+
                 for (Map.Entry<String, Pair<Integer, Integer>> ingredient : sortedRarityList) {
                     sortedIngredients.put(ingredient.getKey(), ingredient.getValue());
                 }

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -1229,12 +1229,12 @@ public class ClientEvents implements Listener {
                 sortedIngredients = new LinkedHashMap<>();
                 List<Map.Entry<String, Pair<Integer, Integer>>> sortedQtyList = new ArrayList<>(items.entrySet());
 
+                // sort based on the pair's first value (qty), reversed for descending
+                sortedQtyList.sort(Comparator.comparing((Map.Entry<String, Pair<Integer, Integer>> o) -> (o.getValue().a)).reversed());
+
                 if (UtilitiesConfig.INSTANCE.sortIngredientPouchReverse) {
-                    // sort based on the pair's first value (qty), sorted ascending
-                    sortedQtyList.sort(Comparator.comparing((Map.Entry<String, Pair<Integer, Integer>> o) -> (o.getValue().a)));
-                } else {
-                    // sort based on the pair's first value (qty), reversed for descending
-                    sortedQtyList.sort(Comparator.comparing((Map.Entry<String, Pair<Integer, Integer>> o) -> (o.getValue().a)).reversed());
+                    // reverse sortedQtyList
+                    Collections.reverse(sortedQtyList);
                 }
 
                 for (Map.Entry<String, Pair<Integer, Integer>> ingredient : sortedQtyList) {
@@ -1246,12 +1246,12 @@ public class ClientEvents implements Listener {
                 sortedIngredients = new LinkedHashMap<>();
                 List<Map.Entry<String, Pair<Integer, Integer>>> sortedRarityList = new ArrayList<>(items.entrySet());
 
+                // sort based on rarity, reversed for descending (3* -> 0*)
+                sortedRarityList.sort(Comparator.comparing((Map.Entry<String, Pair<Integer, Integer>> o) -> (o.getValue().b)).reversed());
+
                 if (UtilitiesConfig.INSTANCE.sortIngredientPouchReverse) {
-                    // sort based on rarity, sorted ascending (0* -> 3*)
-                    sortedRarityList.sort(Comparator.comparing((Map.Entry<String, Pair<Integer, Integer>> o) -> (o.getValue().b)));
-                } else {
-                    // sort based on rarity, reversed for descending (3* -> 0*)
-                    sortedRarityList.sort(Comparator.comparing((Map.Entry<String, Pair<Integer, Integer>> o) -> (o.getValue().b)).reversed());
+                    // reverse sortedRarityList
+                    Collections.reverse(sortedRarityList);
                 }
 
                 for (Map.Entry<String, Pair<Integer, Integer>> ingredient : sortedRarityList) {


### PR DESCRIPTION
Adds option in utilities configuration to reverse the sort order for the ingredient pouch hover tooltip. Sort logic updated to add reverse sorting for all three sort methods. Tested with normal ingredients. Also resolves utilities config pane sort order bug ("sort method" order was already used above resulting in out-of-order items).