### PR TITLE
Add ding sound when creating pin on map using middle mouse click

### DIFF
--- a/src/main/java/com/wynntils/modules/map/overlays/ui/MainWorldMapUI.java
+++ b/src/main/java/com/wynntils/modules/map/overlays/ui/MainWorldMapUI.java
@@ -195,6 +195,7 @@ public class MainWorldMapUI extends WorldMapUI {
             int worldZ = getMouseWorldZ(mouseY, map);
             CompassManager.setCompassLocation(new Location(worldX, 0, worldZ));
 
+            McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.ENTITY_EXPERIENCE_ORB_PICKUP, 1f));
             resetCompassMapIcon();
             return;
         }


### PR DESCRIPTION
Previously, the "ding" sound only played when setting a pin at one of the points of interest (Cinfras, Detlas, etc) using left mouse button, but not when setting a ping using middle mouse button. This PR makes the "ding" sound also play when setting a pin anywhere using the middle mouse button.
