### PR TITLE
fix: misc bug fixes

### DIFF
--- a/src/main/java/com/wynntils/core/utils/ItemUtils.java
+++ b/src/main/java/com/wynntils/core/utils/ItemUtils.java
@@ -30,9 +30,7 @@ import java.util.regex.Pattern;
 public class ItemUtils {
 
     private static final Pattern LEVEL_PATTERN = Pattern.compile("(?:Combat|Crafting|Mining|Woodcutting|Farming|Fishing) Lv\\. Min: ([0-9]+)");
-    private static final Pattern LEVEL_RANGE_PATTERN = Pattern.compile("Lv\\. Range: " + TextFormatting.WHITE.toString() + "([0-9]+)-([0-9]+)");
-    private static final Pattern WEAPON_SPEED_PATTERN = Pattern.compile("§7.+ Attack Speed");
-
+    private static final Pattern LEVEL_RANGE_PATTERN = Pattern.compile("Lv\\. Range: " + TextFormatting.WHITE + "([0-9]+)-([0-9]+)");
     public static final NBTTagCompound UNBREAKABLE = new NBTTagCompound();
 
     /**
@@ -211,18 +209,36 @@ public class ItemUtils {
         UNBREAKABLE.setBoolean("Unbreakable", true);
     }
 
+    /**
+     * @param heldItem The ItemStack to check
+     * @return true if the item has an attack speed specification
+     */
     public static boolean isWeapon(ItemStack heldItem) {
-        List<String> lore = ItemUtils.getLore(heldItem);
+        String lore = ItemUtils.getStringLore(heldItem);
+        return lore.contains("Attack Speed") && lore.contains("§7");
+    }
 
-        //If item has attack speed line, it is a weapon
-        boolean isWeapon = false;
-        for (String s : lore) {
-            if (WEAPON_SPEED_PATTERN.matcher(s).matches()) {
-                isWeapon = true;
-                break;
-            }
-        }
+    /**
+     * @param itemStack The ItemStack to check
+     * @return true if the item is a potion, scroll, or food
+     */
+    public static boolean isConsumable(ItemStack itemStack) {
+        return itemStack.getDisplayName().matches(".+\\[\\d+/\\d+]");
+    }
 
-        return isWeapon;
+    /**
+     * @param itemStack The ItemStack to check
+     * @return true if the item is horse
+     */
+    public static boolean isHorse(ItemStack itemStack) {
+        return itemStack.getDisplayName().endsWith(" Horse") && itemStack.getItem() == Items.SADDLE;
+    }
+
+    /**
+     * @param itemStack The ItemStack to check
+     * @return true if the item is a gathering tool
+     */
+    public static boolean isGatheringTool(ItemStack itemStack) {
+        return itemStack.getDisplayName().matches("§f. Gathering .+ T\\d+");
     }
 }

--- a/src/main/java/com/wynntils/modules/map/commands/CommandLootRun.java
+++ b/src/main/java/com/wynntils/modules/map/commands/CommandLootRun.java
@@ -71,7 +71,7 @@ public class CommandLootRun extends CommandBase implements IClientCommand {
                 if (args.length < 2) {
                     throw new WrongUsageException("/lootrun load [name]");
                 }
-                String name = args[1];
+                String name = getNameWithSpaces(args);
                 boolean result = LootRunManager.loadFromFile(name);
 
                 String message;
@@ -97,7 +97,8 @@ public class CommandLootRun extends CommandBase implements IClientCommand {
                 if (args.length < 2) {
                     throw new WrongUsageException("/lootrun save [name]");
                 }
-                String name = args[1];
+                // Iterate through remaining args to allow for spaces in name
+                String name = getNameWithSpaces(args);
                 if (LootRunManager.hasLootrun(name)) {
                     throw new CommandException("A lootrun file with this name already exists!");
                 }
@@ -124,7 +125,7 @@ public class CommandLootRun extends CommandBase implements IClientCommand {
                 if (args.length < 2) {
                     throw new WrongUsageException("/lootrun delete [name]");
                 }
-                String name = args[1];
+                String name = getNameWithSpaces(args);
 
                 boolean result = LootRunManager.delete(name);
 
@@ -273,7 +274,7 @@ public class CommandLootRun extends CommandBase implements IClientCommand {
                 if (args.length < 4) {
                     pos = new BlockPos((int) McIf.player().posX, (int) McIf.player().posY, (int) McIf.player().posZ - 1);
                 } else {
-                    int x = 0, y = 0, z = 0;
+                    int x, y, z;
                     try {
                         x = Integer.parseInt(args[1]);
                         y = Integer.parseInt(args[2]);
@@ -352,6 +353,18 @@ public class CommandLootRun extends CommandBase implements IClientCommand {
             default:
                 throw new WrongUsageException("/" + getUsage(sender));
         }
+    }
+
+    private String getNameWithSpaces(String[] args) {
+        // Iterate through remaining args to allow for spaces in names
+        StringBuilder nameBuilder = new StringBuilder();
+        for (int i = 1; i < args.length; i++) {
+            nameBuilder.append(args[i]);
+            if (i < args.length - 1) {
+                nameBuilder.append(" ");
+            }
+        }
+        return nameBuilder.toString();
     }
 
     @Override

--- a/src/main/java/com/wynntils/modules/map/commands/CommandLootRun.java
+++ b/src/main/java/com/wynntils/modules/map/commands/CommandLootRun.java
@@ -97,7 +97,6 @@ public class CommandLootRun extends CommandBase implements IClientCommand {
                 if (args.length < 2) {
                     throw new WrongUsageException("/lootrun save [name]");
                 }
-                // Iterate through remaining args to allow for spaces in name
                 String name = getNameWithSpaces(args);
                 if (LootRunManager.hasLootrun(name)) {
                     throw new CommandException("A lootrun file with this name already exists!");

--- a/src/main/java/com/wynntils/modules/map/managers/LootRunManager.java
+++ b/src/main/java/com/wynntils/modules/map/managers/LootRunManager.java
@@ -149,6 +149,12 @@ public class LootRunManager {
         updateMapPath();
     }
 
+    public static void clearOnlyLoaded() {
+        activePath = null;
+        activePathName = null;
+        updateMapPath();
+    }
+
     public static LootRunPath getActivePath() {
         return activePath;
     }

--- a/src/main/java/com/wynntils/modules/questbook/overlays/ui/LootRunPage.java
+++ b/src/main/java/com/wynntils/modules/questbook/overlays/ui/LootRunPage.java
@@ -320,7 +320,8 @@ public class LootRunPage extends QuestBookListPage<String> {
         if (mouseButton == 0) { //left click means either load or unload
             if (isTracked) {
                 if (LootRunManager.getActivePath() != null) {
-                    LootRunManager.clear();
+                    // Clear only loaded so recordings are not cleared
+                    LootRunManager.clearOnlyLoaded();
                 }
             } else {
                 boolean result = LootRunManager.loadFromFile(selectedEntry);

--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -123,7 +123,7 @@ public class UtilitiesConfig extends SettingsClass {
     @Setting(displayName = "Show Leaderboard Badges", description = "Should leaderboard players have badges above their heads?", order = 22)
     public boolean renderLeaderboardBadges = true;
 
-    @Setting(displayName = "Prevent Trades & Duels", description = "Should trade and duel requests be disabled while holding an item?", order = 20)
+    @Setting(displayName = "Prevent Trades & Duels", description = "Should trade and duel requests be disabled while holding an item?\n\n§8Items blocked include weapons, all consumables, horses, compass, and quest book", order = 20)
     public boolean preventTradesDuels = false;
 
     @Setting(displayName = "Bulk Buy on Shift-Click", description = "Should the option to buy scrolls and potions in bulk while holding shift be available?", order = 14)

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -955,8 +955,15 @@ public class ClientEvents implements Listener {
         EntityPlayer ep = (EntityPlayer) clicked;
         if (ep.getTeam() == null) return; // player model npc
 
-        if (!ItemUtils.isWeapon(player.getHeldItemMainhand()))
-            return; // not a weapon
+        ItemStack heldItem = player.getHeldItemMainhand();
+        if (heldItem.isEmpty()) return;
+
+        if (!ItemUtils.isWeapon(heldItem) &&
+            !ItemUtils.isConsumable(heldItem) && // Potions, scrolls, food, etc.
+            !ItemUtils.isHorse(heldItem) &&
+            !ItemUtils.isGatheringTool(heldItem) &&
+            !heldItem.getDisplayName().equals("§bCharacter Info") &&
+            !heldItem.getDisplayName().equals("§dQuest Book")) return;
 
         e.setCanceled(true);
     }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/ui/PartyManagementUI.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/ui/PartyManagementUI.java
@@ -10,12 +10,16 @@ import com.wynntils.core.framework.instances.data.SocialData;
 import com.wynntils.core.framework.rendering.ScreenRenderer;
 import com.wynntils.core.utils.Utils;
 import com.wynntils.core.utils.objects.Pair;
-import net.minecraft.client.gui.*;
+import net.minecraft.client.gui.GuiButton;
+import net.minecraft.client.gui.GuiLabel;
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.gui.GuiTextField;
 import net.minecraft.client.network.NetHandlerPlayClient;
 import net.minecraft.client.network.NetworkPlayerInfo;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EnumPlayerModelParts;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.text.TextFormatting;
 import org.lwjgl.input.Keyboard;
 
@@ -100,7 +104,14 @@ public class PartyManagementUI extends GuiScreen {
 
             // Player heads
             NetworkPlayerInfo networkPlayerInfo = netHandlerPlayClient.getPlayerInfo(playerName);
-            McIf.mc().getTextureManager().bindTexture(networkPlayerInfo.getLocationSkin());
+            if (networkPlayerInfo != null) {
+                McIf.mc().getTextureManager().bindTexture(networkPlayerInfo.getLocationSkin());
+            } else {
+                // If networkPlayerInfo is null, either the player is offline or invisible due to /switch bug
+                // Use the default player head texture, it will automatically update when the player is visible again
+                McIf.mc().getTextureManager().bindTexture(new ResourceLocation("textures/entity/steve.png"));
+            }
+
             drawScaledCustomSizeModalRect(this.width/2 - 197, (verticalReference + 14) + 25 * i, 8.0F, 8.0F, 8, 8, 12, 12, 64.0F, 64.0F);
             EntityPlayer entityPlayer = McIf.mc().world.getPlayerEntityByName(playerName);
             if (entityPlayer != null && entityPlayer.isWearing(EnumPlayerModelParts.HAT)) {

--- a/src/main/java/com/wynntils/webapi/profiles/player/PlayerStatsProfile.java
+++ b/src/main/java/com/wynntils/webapi/profiles/player/PlayerStatsProfile.java
@@ -439,7 +439,9 @@ public class PlayerStatsProfile {
             }
 
             JsonObject globalStats = playerProfile.get("global").getAsJsonObject();
-            int chestsFound = globalStats.get("chestsFound").getAsInt();
+            // Chest stats in API are gone, set to 0 for now
+            // int chestsFound = globalStats.get("chestsFound").getAsInt();
+            int chestsFound = 0;
             long blocksWalked = globalStats.get("blocksWalked").getAsLong();
             int itemsIdentified = globalStats.get("itemsIdentified").getAsInt();
             int mobsKilled = globalStats.get("mobsKilled").getAsInt();


### PR DESCRIPTION
- /lootrun command now accepts spaces for `save`, `load`, and `delete`
- Lootrun GUI in quest book will not unload recordings anymore
- Fix party management UI crashing when HERO or CHAMPIONs use /switch and become invisible
- Fix api chest count npe
- Trade/duel blocker blocks items such as potions, tools, horses, etc instead of just weapons