### PR TITLE
Prevent closing chests with emeralds, amount of chest close preventions

### DIFF
--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -57,7 +57,7 @@ public class UtilitiesConfig extends SettingsClass {
     @Setting.Limitations.IntLimit(min = 0, max = 64)
     public int preventEmeraldChestClose = 0;
 
-    @Setting(displayName = "Favorited Item Close Times", description = "How often should Wynntils prevent you from closing a chest with favorite items in it?\n\n§8Setting it to 0 will make you unable to close a chest with favorite items in", order = 4)
+    @Setting(displayName = "Favorited Item Close Times", description = "How many times should you click to force close a chest with favorite items in it?\n\n§8Setting this to 0 will disable this feature.", order = 4)
     @Setting.Limitations.IntLimit(min = 0, max = 15)
     public int preventFavoritedChestClosingAmount = 0;
 

--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -54,7 +54,7 @@ public class UtilitiesConfig extends SettingsClass {
     public boolean preventFavoritedChestClose = true;
 
     @Setting(displayName = "Emerald Chest Closing", description = "How many emeralds should there be in a chest (in one stack) for Wynntils to prevent you from closing it?\n\n§8Set to 0 to disable this completely.", order = 4)
-    @Setting.Limitations.IntLimit(min = 0, max = 64)
+    @Setting.Limitations.IntLimit(min = 0, max = 32)
     public int preventEmeraldChestClose = 0;
 
     @Setting(displayName = "Favorited Item Close Times", description = "How many times should you click to force close a chest with favorite items in it?\n\n§8Setting this to 0 will disable this feature.", order = 4)

--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -50,14 +50,14 @@ public class UtilitiesConfig extends SettingsClass {
     @Setting(displayName = "Mythic Chest Closing", description = "Should the closing of loot chests be prevented when they contain mythics?", order = 3)
     public boolean preventMythicChestClose = true;
 
-    @Setting(displayName = "Favorite Item Chest Closing", description = "How often should Wynntils prevent you from closing a chest with favorite items in it?\n\n§8Setting it to 0 will make you unable to close a chest with favorite items in", order = 4)
+    @Setting(displayName = "Favorited Item Chest Closing", description = "Should the closing of loot chests be prevented when they contain favorited items?", order = 4)
     public boolean preventFavoritedChestClose = true;
 
     @Setting(displayName = "Emerald Chest Closing", description = "How many emeralds should there be in a chest (in one stack) for Wynntils to prevent you from closing it?\n\n§8Set to 0 to disable this completely", order = 4)
     @Setting.Limitations.IntLimit(min = 0, max = 64)
     public int preventEmeraldChestClose = 0;
 
-    @Setting(displayName = "Favorite Item Close Times", description = "After how many chest closes with favorite items do you want to forcefully close the chest?", order = 4)
+    @Setting(displayName = "Favorite Item Close Times", description = "How often should Wynntils prevent you from closing a chest with favorite items in it?\n\n§8Setting it to 0 will make you unable to close a chest with favorite items in", order = 4)
     @Setting.Limitations.IntLimit(min = 0, max = 10)
     public int preventFavoritedChestCloseTimes = 0;
 

--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -50,7 +50,7 @@ public class UtilitiesConfig extends SettingsClass {
     @Setting(displayName = "Mythic Chest Closing", description = "Should the closing of loot chests be prevented when they contain mythics?", order = 3)
     public boolean preventMythicChestClose = true;
 
-    @Setting(displayName = "Favorite Item Chest Closing", description = "How often should Wynntils prevent you from closing a chest with favorite items in it?\n\n§8Setting it to 0 will make you unable to close a chest with favorite items in, no matter how often you try", order = 4)
+    @Setting(displayName = "Favorite Item Chest Closing", description = "How often should Wynntils prevent you from closing a chest with favorite items in it?\n\n§8Setting it to 0 will make you unable to close a chest with favorite items in", order = 4)
     public boolean preventFavoritedChestClose = true;
 
     @Setting(displayName = "Emerald Chest Closing", description = "How many emeralds should there be in a chest (in one stack) for Wynntils to prevent you from closing it?\n\n§8Set to 0 to disable this completely", order = 4)

--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -53,7 +53,7 @@ public class UtilitiesConfig extends SettingsClass {
     @Setting(displayName = "Favorite Item Chest Closing", description = "How often should Wynntils prevent you from closing a chest with favorite items in it?\n\n§8Setting it to 0 will make you unable to close a chest with favorite items in, no matter how often you try", order = 4)
     public boolean preventFavoritedChestClose = true;
 
-    @Setting(displayName = "Emerald Chest Closing", description = "How many emeralds should there be in a chest for Wynntils to prevent you from closing it?\n\n§8Set to 0 to disable this completely", order = 4)
+    @Setting(displayName = "Emerald Chest Closing", description = "How many emeralds should there be in a chest (in one stack) for Wynntils to prevent you from closing it?\n\n§8Set to 0 to disable this completely", order = 4)
     @Setting.Limitations.IntLimit(min = 0, max = 64)
     public int preventEmeraldChestClose = 0;
 

--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -50,10 +50,10 @@ public class UtilitiesConfig extends SettingsClass {
     @Setting(displayName = "Mythic Chest Closing", description = "Should the closing of loot chests be prevented when they contain mythics?", order = 3)
     public boolean preventMythicChestClose = true;
 
-    @Setting(displayName = "Favorited Item Chest Closing", description = "Should the closing of loot chests be prevented when they contain favorited items?", order = 4)
+    @Setting(displayName = "Favorite Item Chest Closing", description = "How often should Wynntils prevent you from closing a chest with favorite items in it?\n\n§8Setting it to 0 will make you unable to close a chest with favorite items in, no matter how often you try", order = 4)
     public boolean preventFavoritedChestClose = true;
 
-    @Setting(displayName = "Emerald Chest Closing", description = "Should the closing of loot chests be prevented when they contain emeralds?", order = 4)
+    @Setting(displayName = "Emerald Chest Closing", description = "How many emeralds should there be in a chest for Wynntils to prevent you from closing it?\n\n§8Set to 0 to disable this completely", order = 4)
     @Setting.Limitations.IntLimit(min = 0, max = 64)
     public int preventEmeraldChestClose = 0;
 

--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -58,7 +58,7 @@ public class UtilitiesConfig extends SettingsClass {
     public int preventEmeraldChestClose = 0;
 
     @Setting(displayName = "Favorited Item Close Times", description = "How many times should you click to force close a chest with favorite items in it?\n\n§8Setting this to 0 will disable this feature.", order = 4)
-    @Setting.Limitations.IntLimit(min = 0, max = 15)
+    @Setting.Limitations.IntLimit(min = 0, max = 10)
     public int preventFavoritedChestClosingAmount = 0;
 
     @Setting(displayName = "Clicking on Pouches in Chests", description = "Should opening ingredient and emerald pouches be blocked when opening loot chests?", order = 6)

--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -57,9 +57,9 @@ public class UtilitiesConfig extends SettingsClass {
     @Setting.Limitations.IntLimit(min = 0, max = 64)
     public int preventEmeraldChestClose = 0;
 
-    @Setting(displayName = "Favorite Item Close Times", description = "How often should Wynntils prevent you from closing a chest with favorite items in it?\n\n§8Setting it to 0 will make you unable to close a chest with favorite items in", order = 4)
-    @Setting.Limitations.IntLimit(min = 0, max = 10)
-    public int preventFavoritedChestCloseTimes = 0;
+    @Setting(displayName = "Favorited Item Close Times", description = "How often should Wynntils prevent you from closing a chest with favorite items in it?\n\n§8Setting it to 0 will make you unable to close a chest with favorite items in", order = 4)
+    @Setting.Limitations.IntLimit(min = 0, max = 15)
+    public int preventFavoritedChestClosingAmount = 0;
 
     @Setting(displayName = "Clicking on Pouches in Chests", description = "Should opening ingredient and emerald pouches be blocked when opening loot chests?", order = 6)
     public boolean preventOpeningPouchesChest = true;

--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -53,6 +53,14 @@ public class UtilitiesConfig extends SettingsClass {
     @Setting(displayName = "Favorited Item Chest Closing", description = "Should the closing of loot chests be prevented when they contain favorited items?", order = 4)
     public boolean preventFavoritedChestClose = true;
 
+    @Setting(displayName = "Emerald Chest Closing", description = "Should the closing of loot chests be prevented when they contain emeralds?", order = 4)
+    @Setting.Limitations.IntLimit(min = 0, max = 64)
+    public int preventEmeraldChestClose = 0;
+
+    @Setting(displayName = "Favorite Item Close Times", description = "After how many chest closes with favorite items do you want to forcefully close the chest?", order = 4)
+    @Setting.Limitations.IntLimit(min = 0, max = 10)
+    public int preventFavoritedChestCloseTimes = 0;
+
     @Setting(displayName = "Clicking on Pouches in Chests", description = "Should opening ingredient and emerald pouches be blocked when opening loot chests?", order = 6)
     public boolean preventOpeningPouchesChest = true;
 

--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -53,7 +53,7 @@ public class UtilitiesConfig extends SettingsClass {
     @Setting(displayName = "Favorited Item Chest Closing", description = "Should the closing of loot chests be prevented when they contain favorited items?", order = 4)
     public boolean preventFavoritedChestClose = true;
 
-    @Setting(displayName = "Emerald Chest Closing", description = "How many emeralds should there be in a chest (in one stack) for Wynntils to prevent you from closing it?\n\n§8Set to 0 to disable this completely", order = 4)
+    @Setting(displayName = "Emerald Chest Closing", description = "How many emeralds should there be in a chest (in one stack) for Wynntils to prevent you from closing it?\n\n§8Set to 0 to disable this completely.", order = 4)
     @Setting.Limitations.IntLimit(min = 0, max = 64)
     public int preventEmeraldChestClose = 0;
 

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -122,7 +122,7 @@ public class ClientEvents implements Listener {
     private static int lastProcessedOpenedChest = -1;
     private int lastOpenedChestWindowId = -1;
     private int lastOpenedRewardWindowId = -1;
-    private int timesClosed = 1;
+    private int timesClosed = 0;
 
 
     @SubscribeEvent
@@ -595,8 +595,8 @@ public class ClientEvents implements Listener {
         if (UtilitiesConfig.INSTANCE.preventMythicChestClose || UtilitiesConfig.INSTANCE.preventFavoritedChestClose) {
             boolean preventedClose = false;
             if (e.getKeyCode() == 1 || e.getKeyCode() == McIf.mc().gameSettings.keyBindInventory.getKeyCode()) {
-                if (UtilitiesConfig.INSTANCE.preventFavoritedChestClosingAmount != 0 && timesClosed >= UtilitiesConfig.INSTANCE.preventFavoritedChestClosingAmount) {
-                    timesClosed = 1;
+                if (UtilitiesConfig.INSTANCE.preventFavoritedChestClosingAmount != 0 && timesClosed + 1 >= UtilitiesConfig.INSTANCE.preventFavoritedChestClosingAmount) {
+                    timesClosed = 0;
                     return;
                 }
 
@@ -616,7 +616,7 @@ public class ClientEvents implements Listener {
                                 stack.getTagCompound().getBoolean("wynntilsFavorite")) {
                             text = new TextComponentString("You cannot close this loot chest while there is a favorited item, ingredient, emerald pouch, emerald or powder in it!"
                             + (UtilitiesConfig.INSTANCE.preventFavoritedChestClosingAmount != 0 ? " Try closing this chest " +
-                                    (UtilitiesConfig.INSTANCE.preventFavoritedChestClosingAmount -timesClosed) + " more times to forcefully close!" : ""));
+                                    (UtilitiesConfig.INSTANCE.preventFavoritedChestClosingAmount - timesClosed - 1) + " more times to forcefully close!" : ""));
                         } else {
                             continue;
                         }
@@ -625,15 +625,11 @@ public class ClientEvents implements Listener {
                         McIf.player().sendMessage(text);
                         McIf.mc().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.BLOCK_NOTE_BASS, 1f));
                         e.setCanceled(true);
-                        preventedClose = true;
-                        break;
+                        timesClosed++;
+                        return;
                     }
                 }
-                if (!preventedClose) {
-                    timesClosed = 1;
-                } else {
-                    timesClosed++;
-                }
+                timesClosed = 0;
                 return;
             }
         }

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -595,7 +595,7 @@ public class ClientEvents implements Listener {
         if (UtilitiesConfig.INSTANCE.preventMythicChestClose || UtilitiesConfig.INSTANCE.preventFavoritedChestClose) {
             boolean preventedClose = false;
             if (e.getKeyCode() == 1 || e.getKeyCode() == McIf.mc().gameSettings.keyBindInventory.getKeyCode()) {
-                if(UtilitiesConfig.INSTANCE.preventFavoritedChestCloseTimes != 0 && timesClosed >= UtilitiesConfig.INSTANCE.preventFavoritedChestCloseTimes) {
+                if (UtilitiesConfig.INSTANCE.preventFavoritedChestCloseTimes != 0 && timesClosed >= UtilitiesConfig.INSTANCE.preventFavoritedChestCloseTimes) {
                     timesClosed = 1;
                     return;
                 }

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -595,7 +595,7 @@ public class ClientEvents implements Listener {
         if (UtilitiesConfig.INSTANCE.preventMythicChestClose || UtilitiesConfig.INSTANCE.preventFavoritedChestClose) {
             boolean preventedClose = false;
             if (e.getKeyCode() == 1 || e.getKeyCode() == McIf.mc().gameSettings.keyBindInventory.getKeyCode()) {
-                if (UtilitiesConfig.INSTANCE.preventFavoritedChestCloseTimes != 0 && timesClosed >= UtilitiesConfig.INSTANCE.preventFavoritedChestCloseTimes) {
+                if (UtilitiesConfig.INSTANCE.preventFavoritedChestClosingAmount != 0 && timesClosed >= UtilitiesConfig.INSTANCE.preventFavoritedChestClosingAmount) {
                     timesClosed = 1;
                     return;
                 }
@@ -615,8 +615,8 @@ public class ClientEvents implements Listener {
                         } else if (UtilitiesConfig.INSTANCE.preventFavoritedChestClose && stack.hasTagCompound() &&
                                 stack.getTagCompound().getBoolean("wynntilsFavorite")) {
                             text = new TextComponentString("You cannot close this loot chest while there is a favorited item, ingredient, emerald pouch, emerald or powder in it!"
-                            + (UtilitiesConfig.INSTANCE.preventFavoritedChestCloseTimes != 0 ? " Try closing this chest " +
-                                    (UtilitiesConfig.INSTANCE.preventFavoritedChestCloseTimes-timesClosed) + " more times to forcefully close!" : ""));
+                            + (UtilitiesConfig.INSTANCE.preventFavoritedChestClosingAmount != 0 ? " Try closing this chest " +
+                                    (UtilitiesConfig.INSTANCE.preventFavoritedChestClosingAmount -timesClosed) + " more times to forcefully close!" : ""));
                         } else {
                             continue;
                         }

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -122,6 +122,7 @@ public class ClientEvents implements Listener {
     private static int lastProcessedOpenedChest = -1;
     private int lastOpenedChestWindowId = -1;
     private int lastOpenedRewardWindowId = -1;
+    private int timesClosed = 1;
 
 
     @SubscribeEvent
@@ -587,8 +588,6 @@ public class ClientEvents implements Listener {
         }
     }
 
-
-    int timesClosed = 1;
     @SubscribeEvent
     public void keyPressOnChest(GuiOverlapEvent.ChestOverlap.KeyTyped e) {
         if (!Reference.onWorld) return;
@@ -630,9 +629,9 @@ public class ClientEvents implements Listener {
                         break;
                     }
                 }
-                if(!preventedClose){
+                if (!preventedClose) {
                     timesClosed = 1;
-                }else{
+                } else {
                     timesClosed++;
                 }
                 return;

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/FavoriteItemsOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/FavoriteItemsOverlay.java
@@ -85,7 +85,7 @@ public class FavoriteItemsOverlay implements Listener {
             }
 
             if (stack.getItem() == Items.EMERALD && stack.getDisplayName().contains("Emerald")) {
-                if(UtilitiesConfig.INSTANCE.preventEmeraldChestClose != 0 && stack.getCount() >= UtilitiesConfig.INSTANCE.preventEmeraldChestClose) {
+                if (UtilitiesConfig.INSTANCE.preventEmeraldChestClose != 0 && stack.getCount() >= UtilitiesConfig.INSTANCE.preventEmeraldChestClose) {
                     nbt.setBoolean("wynntilsFavorite", true);
                     continue;
                 }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/FavoriteItemsOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/FavoriteItemsOverlay.java
@@ -84,6 +84,13 @@ public class FavoriteItemsOverlay implements Listener {
                 continue;
             }
 
+            if (stack.getItem() == Items.EMERALD && stack.getDisplayName().contains("Emerald")) {
+                if(UtilitiesConfig.INSTANCE.preventEmeraldChestClose != 0 && stack.getCount() >= UtilitiesConfig.INSTANCE.preventEmeraldChestClose) {
+                    nbt.setBoolean("wynntilsFavorite", true);
+                    continue;
+                }
+            }
+
             if (!itemName.contains("Unidentified")) {
                 nbt.setBoolean("wynntilsFavorite", false);
                 continue; // don't care about identified items


### PR DESCRIPTION
Implement [Favoriting emeralds and option for closing chest with favorite items](https://feedback.wynntils.com/posts/33/favoriting-emeralds-and-option-for-closing-chest-with-favorite-items)

You can set an amount of emeralds (per stack) there have to be for the emeralds to be marked as a favorite item and therefore preventing you from closing this chest.
You can set an amount of times Wynntils should prevent you from closing the chests. If its set to X, then you have to try and close the chest X times before Wynntils actually lets you close it.
