### PR TITLE
Make /detection output proper CSV format

### DIFF
--- a/src/main/java/com/wynntils/modules/map/commands/CommandDetection.java
+++ b/src/main/java/com/wynntils/modules/map/commands/CommandDetection.java
@@ -95,7 +95,7 @@ public class CommandDetection extends CommandBase implements IClientCommand {
 
     private void printInstance(PrintStream ps, String type, String name, String formattedName, Location key) {
         // Write a CSV line
-        ps.println(type + ", " + name + ", " + formattedName + ", " + (int) Math.floor(key.x) + ", " + (int) Math.floor(key.y) + ", " + (int) Math.floor(key.z));
+        ps.println(type + ",\"" + name + "\",\"" + formattedName + "\"," + (int) Math.floor(key.x) + "," + (int) Math.floor(key.y) + "," + (int) Math.floor(key.z));
     }
 
 }


### PR DESCRIPTION
Names should be quoted, and there should be no space between fields.