### PR TITLE
Beta fixes 6

### DIFF
--- a/src/main/java/com/wynntils/core/framework/rendering/colors/MinecraftChatColors.java
+++ b/src/main/java/com/wynntils/core/framework/rendering/colors/MinecraftChatColors.java
@@ -88,4 +88,30 @@ public class MinecraftChatColors extends CustomColor.SetBase {
         return new String(b);
     }
 
+    /**
+     * @param code Single character code for chat color. Eg. '4' for '§4'.
+     * @return MinecraftChatColors object from the specified chat color.
+     */
+    public static MinecraftChatColors fromColorCode(char code) {
+        switch (code) {
+            case '0': return BLACK;
+            case '1': return DARK_BLUE;
+            case '2': return DARK_GREEN;
+            case '3': return DARK_AQUA;
+            case '4': return DARK_RED;
+            case '5': return DARK_PURPLE;
+            case '6': return GOLD;
+            case '7': return GRAY;
+            case '8': return DARK_GRAY;
+            case '9': return BLUE;
+            case 'a': return GREEN;
+            case 'b': return AQUA;
+            case 'c': return RED;
+            case 'd': return LIGHT_PURPLE;
+            case 'e': return YELLOW;
+            case 'f': return WHITE;
+            default: return null;
+        }
+    }
+
 }

--- a/src/main/java/com/wynntils/core/utils/Utils.java
+++ b/src/main/java/com/wynntils/core/utils/Utils.java
@@ -265,8 +265,8 @@ public class Utils {
     }
 
     public static String getRawItemName(ItemStack stack) {
-        final Pattern PERCENTAGE_PATTERN = Pattern.compile(" +\\[[0-9]+%\\]");
-        final Pattern INGREDIENT_PATTERN = Pattern.compile(" +\\[✫+\\]");
+        final Pattern PERCENTAGE_PATTERN = Pattern.compile(" +\\[\\d+(?:.\\d)*%]");
+        final Pattern INGREDIENT_PATTERN = Pattern.compile(" +\\[✫+]");
 
         String name = stack.getDisplayName();
         name = TextFormatting.getTextWithoutFormattingCodes(name);
@@ -274,6 +274,10 @@ public class Utils {
         name = INGREDIENT_PATTERN.matcher(name).replaceAll("");
         if (name.startsWith("Perfect ")) {
             name = name.substring(8);
+        } else if (name.startsWith("Defective ")) {
+            name = name.substring(10);
+        } else if (name.endsWith(" NEW")) {
+            name = name.substring(0, name.length() - 4);
         }
         name = com.wynntils.core.utils.StringUtils.normalizeBadString(name);
         return name;

--- a/src/main/java/com/wynntils/modules/map/managers/LootRunManager.java
+++ b/src/main/java/com/wynntils/modules/map/managers/LootRunManager.java
@@ -18,7 +18,6 @@ import com.wynntils.modules.map.overlays.objects.MapIcon;
 import com.wynntils.modules.map.overlays.objects.MapPathWaypointIcon;
 import com.wynntils.modules.map.rendering.PointRenderer;
 
-import net.minecraft.client.renderer.EntityRenderer;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3i;
 

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -678,14 +678,15 @@ public class ClientEvents implements Listener {
     @SubscribeEvent
     public void clickOnInventory(GuiOverlapEvent.InventoryOverlap.HandleMouseClick e) {
         if (!Reference.onWorld) return;
+        if (e.getGui().getSlotUnderMouse() == null) return;
 
         // Dungeon key middle click functionality
-        if (e.getMouseButton() == 2 && e.getGui().getSlotUnderMouse() != null && e.getGui().getSlotUnderMouse().getHasStack()) {
+        if (e.getMouseButton() == 2 && e.getGui().getSlotUnderMouse().getHasStack()) {
             ItemStack is = e.getGui().getSlotUnderMouse().getStack();
             handleDungeonKeyMClick(is);
         }
 
-        if (UtilitiesConfig.INSTANCE.preventSlotClicking && e.getGui().getSlotUnderMouse() != null && e.getGui().getSlotUnderMouse().inventory instanceof InventoryPlayer) {
+        if (UtilitiesConfig.INSTANCE.preventSlotClicking && e.getGui().getSlotUnderMouse().inventory instanceof InventoryPlayer) {
             if ((!EmeraldPouchManager.isEmeraldPouch(e.getGui().getSlotUnderMouse().getStack()) || e.getMouseButton() == 0) && checkDropState(e.getGui().getSlotUnderMouse().getSlotIndex())) {
                 e.setCanceled(true);
                 return;

--- a/src/main/java/com/wynntils/modules/utilities/managers/ChatItemManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/ChatItemManager.java
@@ -286,7 +286,7 @@ public class ChatItemManager {
                 if (requiredClass != null) {
                     longName = spell.forOtherClass(requiredClass).getName() + " Spell Cost";
                 } else {
-                    longName = spell.forOtherClass(PlayerInfo.get(CharacterData.class).getCurrentClass()).getGenericAndSpecificName() + " Cost";
+                    longName = spell.forOtherClass(PlayerInfo.get(CharacterData.class).getCurrentClass()).getName() + " Cost";
                 }
             }
 

--- a/src/main/java/com/wynntils/modules/utilities/managers/KeyManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/KeyManager.java
@@ -64,10 +64,10 @@ public class KeyManager {
 
         zoomOutKey = CoreModule.getModule().registerKeyBinding("Zoom Out", Keyboard.KEY_MINUS, "Wynntils", KeyConflictContext.IN_GAME, false, () -> MiniMapOverlay.zoomBy(-1));
 
-        CoreModule.getModule().registerKeyBinding("Cast 1st Spell", Keyboard.KEY_Z, "Wynntils", KeyConflictContext.IN_GAME, true, QuickCastManager::castFirstSpell);
-        CoreModule.getModule().registerKeyBinding("Cast 2nd Spell", Keyboard.KEY_X, "Wynntils", KeyConflictContext.IN_GAME, true, QuickCastManager::castSecondSpell);
-        CoreModule.getModule().registerKeyBinding("Cast 3rd Spell", Keyboard.KEY_C, "Wynntils", KeyConflictContext.IN_GAME, true, QuickCastManager::castThirdSpell);
-        CoreModule.getModule().registerKeyBinding("Cast 4th Spell", Keyboard.KEY_V, "Wynntils", KeyConflictContext.IN_GAME, true, QuickCastManager::castFourthSpell);
+        CoreModule.getModule().registerKeyBinding("Cast R-L-R Spell", Keyboard.KEY_Z, "Wynntils", KeyConflictContext.IN_GAME, true, QuickCastManager::castFirstSpell);
+        CoreModule.getModule().registerKeyBinding("Cast R-R-R Spell", Keyboard.KEY_X, "Wynntils", KeyConflictContext.IN_GAME, true, QuickCastManager::castSecondSpell);
+        CoreModule.getModule().registerKeyBinding("Cast R-L-L Spell", Keyboard.KEY_C, "Wynntils", KeyConflictContext.IN_GAME, true, QuickCastManager::castThirdSpell);
+        CoreModule.getModule().registerKeyBinding("Cast R-R-L Spell", Keyboard.KEY_V, "Wynntils", KeyConflictContext.IN_GAME, true, QuickCastManager::castFourthSpell);
 
         CoreModule.getModule().registerKeyBinding("Mount Horse", Keyboard.KEY_Y, "Wynntils", KeyConflictContext.IN_GAME, true, MountHorseManager::mountHorseAndShowMessage);
 

--- a/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
@@ -781,7 +781,7 @@ public class OverlayEvents implements Listener {
             timerName = "Speed boost";
         }
         // if the effect is invisibility timer is "Vanish"
-        else if (potion == MobEffects.INVISIBILITY && effect.getDuration() < 200) {
+        else if (potion == MobEffects.WITHER && effect.getDuration() < 200) {
             timerName = "Vanish";
             isVanished = true;
         }
@@ -836,9 +836,11 @@ public class OverlayEvents implements Listener {
                 }, 5);
             }
             // When removing invisibility from assassin
-            else if (potion == MobEffects.INVISIBILITY) {
+            else if (potion == MobEffects.WITHER) {
                 isVanished = false; // So it won't skip
                 ConsumableTimerOverlay.removeBasicTimer("Vanish");
+                // Bit of a delay until Wynn starts the cooldown timer; we need to copy it
+                new Delay(() -> ConsumableTimerOverlay.addBasicTimer("Vanish Cooldown", 5), 9);
             }
         });
     }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
@@ -825,17 +825,15 @@ public class OverlayEvents implements Listener {
                 // Remove old speed boost timer
                 ConsumableTimerOverlay.removeBasicTimer("Speed boost");
 
-                // Check if we still have speed, in which case, we just refreshed the timer
-                for (PotionEffect pe : McIf.player().getActivePotionEffects()) {
-                    if (pe.getPotion().getName().equals("effect.moveSpeed")) {
-                        // New timer must wait, then retrieve the new duration from the player's active effects
-                        // Cannot use pe.getPotion().getDuration() directly as it contains the previous duration
-                        new Delay(() ->
-                                // getDuration() / 20 because getDuration() returns the duration in ticks, not seconds
-                                ConsumableTimerOverlay.addBasicTimer("Speed boost", McIf.player().getActivePotionEffect(pe.getPotion()).getDuration() / 20), 5);
-                        return;
+                new Delay(() -> {
+                    for (PotionEffect pe : McIf.player().getActivePotionEffects()) {
+                        if (pe.getPotion().getName().equals("effect.moveSpeed")) {
+                            // pe.getDuration() is in ticks, so we divide by 20 to get seconds
+                            ConsumableTimerOverlay.addBasicTimer("Speed boost", pe.getDuration() / 20);
+                            return;
+                        }
                     }
-                }
+                }, 1);
             }
             // When removing invisibility from assassin
             else if (potion == MobEffects.INVISIBILITY) {

--- a/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
@@ -24,6 +24,7 @@ import net.minecraft.init.MobEffects;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.network.play.server.*;
 import net.minecraft.potion.Potion;
+import net.minecraft.potion.PotionEffect;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.client.event.ClientChatReceivedEvent;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
@@ -821,7 +822,20 @@ public class OverlayEvents implements Listener {
 
             // When removing speed boost from (archer)
             if (potion == MobEffects.SPEED) {
+                // Remove old speed boost timer
                 ConsumableTimerOverlay.removeBasicTimer("Speed boost");
+
+                // Check if we still have speed, in which case, we just refreshed the timer
+                for (PotionEffect pe : McIf.player().getActivePotionEffects()) {
+                    if (pe.getPotion().getName().equals("effect.moveSpeed")) {
+                        // New timer must wait, then retrieve the new duration from the player's active effects
+                        // Cannot use pe.getPotion().getDuration() directly as it contains the previous duration
+                        new Delay(() ->
+                                // getDuration() / 20 because getDuration() returns the duration in ticks, not seconds
+                                ConsumableTimerOverlay.addBasicTimer("Speed boost", McIf.player().getActivePotionEffect(pe.getPotion()).getDuration() / 20), 5);
+                        return;
+                    }
+                }
             }
             // When removing invisibility from assassin
             else if (potion == MobEffects.INVISIBILITY) {

--- a/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
@@ -833,7 +833,7 @@ public class OverlayEvents implements Listener {
                             return;
                         }
                     }
-                }, 1);
+                }, 5);
             }
             // When removing invisibility from assassin
             else if (potion == MobEffects.INVISIBILITY) {

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/IngredientFilterOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/IngredientFilterOverlay.java
@@ -8,6 +8,7 @@ import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.GuiOverlapEvent;
 import com.wynntils.core.framework.interfaces.Listener;
+import com.wynntils.core.utils.Utils;
 import com.wynntils.modules.utilities.configs.UtilitiesConfig;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
@@ -24,10 +25,18 @@ public class IngredientFilterOverlay implements Listener {
     public void initGui(GuiOverlapEvent.ChestOverlap.InitGui e) {
         if (!Reference.onWorld || !UtilitiesConfig.Items.INSTANCE.filterEnabled) return;
 
+        int buttonXOffset = -20;
+        int buttonYOffset = 15;
+
+        // Character info page extends beyond normal inventory bounds; move it down
+        if (Utils.isCharacterInfoPage(e.getGui())) {
+            buttonYOffset += 105;
+        }
+
         e.getButtonList().add(
                 new GuiButton(11,
-                        (e.getGui().width - e.getGui().getXSize()) / 2 - 20,
-                        (e.getGui().height - e.getGui().getYSize()) / 2 + 15,
+                        (e.getGui().width - e.getGui().getXSize()) / 2 + buttonXOffset,
+                        (e.getGui().height - e.getGui().getYSize()) / 2 + buttonYOffset,
                         18, 18,
                         RarityColorOverlay.getProfessionFilter()
                 )

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemIdentificationOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemIdentificationOverlay.java
@@ -157,7 +157,16 @@ public class ItemIdentificationOverlay implements Listener {
                     if (requiredClass != null) {
                         longName = spell.forOtherClass(requiredClass).getName() + " Spell Cost";
                     } else {
-                        longName = spell.forOtherClass(PlayerInfo.get(CharacterData.class).getCurrentClass()).getGenericAndSpecificName() + " Cost";
+                        longName = spell.forOtherClass(PlayerInfo.get(CharacterData.class).getCurrentClass()).getName() + " Cost";
+                    }
+                }
+
+                { // Manually change some lore labels to be consistent with vanilla in 2.0
+                    // See override on line 451, this file
+                    if (longName.equals("Main Attack Neutral Damage")) {
+                        longName = "Main Attack Damage";
+                    } else if (longName.equals("Neutral Spell Damage")) {
+                        longName = "Spell Damage";
                     }
                 }
 

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemSpecificationOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemSpecificationOverlay.java
@@ -4,6 +4,7 @@
 
 package com.wynntils.modules.utilities.overlays.inventories;
 
+import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.GuiOverlapEvent;
 import com.wynntils.core.framework.enums.Powder;
@@ -25,6 +26,8 @@ import com.wynntils.webapi.profiles.item.enums.ItemType;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.RenderHelper;
+import net.minecraft.client.renderer.block.model.ModelResourceLocation;
+import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.init.Items;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
@@ -63,6 +66,7 @@ public class ItemSpecificationOverlay implements Listener {
             String specificationChars = null;
             CustomColor color = null;
             int xOffset = 2;
+            int yOffset = 1;
             float scale = 1f;
 
             if (UtilitiesConfig.Items.INSTANCE.unidentifiedSpecification) {
@@ -189,14 +193,18 @@ public class ItemSpecificationOverlay implements Listener {
                 }
             }
 
-            // Specification numbers for archetypes
+            // Specification numbers for archetypes; only draws when >0 on that archetype
             if (stack.getDisplayName().contains("Archetype") && stack.getDisplayName().contains("§l") && stack.getItem() == Items.STONE_AXE) {
                 Matcher archetypeMatcher = ARCHETYPE_UNLOCKED_PATTERN.matcher(ItemUtils.getStringLore(stack));
                 if (archetypeMatcher.find()) {
-                    specificationChars = archetypeMatcher.group(1);
-                    color = MinecraftChatColors.fromColorCode(stack.getDisplayName().charAt(1));
-                    xOffset = -1;
-                    scale = UtilitiesConfig.Items.INSTANCE.specificationTierSize;
+                    int archetypeAmount = Integer.parseInt(archetypeMatcher.group(1));
+                    if (archetypeAmount > 0) {
+                        specificationChars = archetypeMatcher.group(1);
+                        color = MinecraftChatColors.fromColorCode(stack.getDisplayName().charAt(1));
+                        xOffset = 5;
+                        yOffset = 5;
+                        scale = UtilitiesConfig.Items.INSTANCE.specificationTierSize;
+                    }
                 }
             }
 
@@ -208,7 +216,8 @@ public class ItemSpecificationOverlay implements Listener {
                 // Make a modifiable copy
                 color = new CustomColor(color);
                 color.setA(0.8f);
-                renderer.drawString(specificationChars, (s.xPos + xOffset) / scale, (s.yPos + 1) / scale, color, SmartFontRenderer.TextAlignment.LEFT_RIGHT, SmartFontRenderer.TextShadow.OUTLINE);
+                //renderer.drawRect(Textures.UIs.box, s.xPos, s.yPos, 0, 0, 18,18); // TODO remove debug
+                renderer.drawString(specificationChars, (s.xPos + xOffset) / scale, (s.yPos + yOffset) / scale, color, SmartFontRenderer.TextAlignment.LEFT_RIGHT, SmartFontRenderer.TextShadow.OUTLINE);
                 ScreenRenderer.endGL();
             }
         }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemSpecificationOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemSpecificationOverlay.java
@@ -202,7 +202,7 @@ public class ItemSpecificationOverlay implements Listener {
                         specificationChars = archetypeMatcher.group(1);
                         color = MinecraftChatColors.fromColorCode(stack.getDisplayName().charAt(1));
                         xOffset = 5;
-                        yOffset = 5;
+                        yOffset = -10;
                     }
                 }
             }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemSpecificationOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemSpecificationOverlay.java
@@ -16,6 +16,7 @@ import com.wynntils.core.framework.rendering.colors.MinecraftChatColors;
 import com.wynntils.core.framework.rendering.textures.Textures;
 import com.wynntils.core.utils.ItemUtils;
 import com.wynntils.core.utils.StringUtils;
+import com.wynntils.core.utils.Utils;
 import com.wynntils.modules.utilities.configs.UtilitiesConfig;
 import com.wynntils.modules.utilities.managers.CorkianAmplifierManager;
 import com.wynntils.modules.utilities.managers.DungeonKeyManager;
@@ -39,6 +40,7 @@ public class ItemSpecificationOverlay implements Listener {
 
     private final ScreenRenderer renderer = new ScreenRenderer();
     private final Pattern ARCHETYPE_UNLOCKED_PATTERN = Pattern.compile("§7Unlocked Abilities: §f(\\d+)§7/\\d+");
+    private final Pattern SKILL_CRYSTAL_PATTERN = Pattern.compile("§7You have §a(\\d+)§7 skill points§7to be distributed§eShift-Click to reset");
 
     private void renderOverlay(GuiContainer gui) {
         if (!Reference.onWorld) return;
@@ -174,6 +176,16 @@ public class ItemSpecificationOverlay implements Listener {
                     color = MinecraftChatColors.GREEN;
                     xOffset = -1;
                     scale = UtilitiesConfig.Items.INSTANCE.specificationTierSize;
+                }
+            }
+
+            // Specification numbers for skill points remaining
+            if (Utils.isCharacterInfoPage(gui) && stack.getDisplayName().equals("§2§lSkill Crystal")) {
+                Matcher skillPointMatcher = SKILL_CRYSTAL_PATTERN.matcher(ItemUtils.getStringLore(stack));
+                if (skillPointMatcher.find()) {
+                    specificationChars = skillPointMatcher.group(1);
+                    color = MinecraftChatColors.GREEN;
+                    xOffset = 1;
                 }
             }
 

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemSpecificationOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemSpecificationOverlay.java
@@ -210,7 +210,7 @@ public class ItemSpecificationOverlay implements Listener {
                     if (archetypeAmount > 0) {
                         specificationChars = archetypeMatcher.group(1);
                         color = MinecraftChatColors.fromColorCode(stack.getDisplayName().charAt(1));
-                        xOffset = 5;
+                        xOffset = specificationChars.length() > 1 ? 2 : 5; // Alignment for 2-digit numbers
                         yOffset = -10;
                     }
                 }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemSpecificationOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemSpecificationOverlay.java
@@ -41,7 +41,7 @@ public class ItemSpecificationOverlay implements Listener {
     private final ScreenRenderer renderer = new ScreenRenderer();
     private final Pattern ARCHETYPE_UNLOCKED_PATTERN = Pattern.compile("§7Unlocked Abilities: §f(\\d+)§7/\\d+");
     private final Pattern SKILL_CRYSTAL_PATTERN = Pattern.compile("§7You have §a(\\d+)§7 skill points§7to be distributed§eShift-Click to reset");
-    private final Pattern ABILITY_POINT_PATTERN = Pattern.compile("§7Ability Points are used§7to unlock new abilities§b✦ Available Points: §f(\\d+)§7/\\d+");
+    private final Pattern ABILITY_POINT_PATTERN = Pattern.compile("✦ (?:Available|Unused) Points: §f(\\d+)§");
 
     private void renderOverlay(GuiContainer gui) {
         if (!Reference.onWorld) return;
@@ -192,7 +192,8 @@ public class ItemSpecificationOverlay implements Listener {
             }
 
             // Specification numbers for ability points remaining
-            if (Utils.isAbilityTreePage(gui) && stack.getDisplayName().equals("§3§lAbility Points")) {
+            // Works on both character info page and ability tree page
+            if ((Utils.isAbilityTreePage(gui) || Utils.isCharacterInfoPage(gui)) && stack.getDisplayName().contains("§lAbility ")) {
                 Matcher abilityPointMatcher = ABILITY_POINT_PATTERN.matcher(ItemUtils.getStringLore(stack));
                 if (abilityPointMatcher.find()) {
                     specificationChars = abilityPointMatcher.group(1);

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemSpecificationOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemSpecificationOverlay.java
@@ -4,7 +4,6 @@
 
 package com.wynntils.modules.utilities.overlays.inventories;
 
-import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.GuiOverlapEvent;
 import com.wynntils.core.framework.enums.Powder;
@@ -26,8 +25,6 @@ import com.wynntils.webapi.profiles.item.enums.ItemType;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.RenderHelper;
-import net.minecraft.client.renderer.block.model.ModelResourceLocation;
-import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.init.Items;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
@@ -44,6 +41,7 @@ public class ItemSpecificationOverlay implements Listener {
     private final ScreenRenderer renderer = new ScreenRenderer();
     private final Pattern ARCHETYPE_UNLOCKED_PATTERN = Pattern.compile("§7Unlocked Abilities: §f(\\d+)§7/\\d+");
     private final Pattern SKILL_CRYSTAL_PATTERN = Pattern.compile("§7You have §a(\\d+)§7 skill points§7to be distributed§eShift-Click to reset");
+    private final Pattern ABILITY_POINT_PATTERN = Pattern.compile("§7Ability Points are used§7to unlock new abilities§b✦ Available Points: §f(\\d+)§7/\\d+");
 
     private void renderOverlay(GuiContainer gui) {
         if (!Reference.onWorld) return;
@@ -189,6 +187,16 @@ public class ItemSpecificationOverlay implements Listener {
                 if (skillPointMatcher.find()) {
                     specificationChars = skillPointMatcher.group(1);
                     color = MinecraftChatColors.GREEN;
+                    xOffset = 1;
+                }
+            }
+
+            // Specification numbers for ability points remaining
+            if (Utils.isAbilityTreePage(gui) && stack.getDisplayName().equals("§3§lAbility Points")) {
+                Matcher abilityPointMatcher = ABILITY_POINT_PATTERN.matcher(ItemUtils.getStringLore(stack));
+                if (abilityPointMatcher.find()) {
+                    specificationChars = abilityPointMatcher.group(1);
+                    color = MinecraftChatColors.AQUA;
                     xOffset = 1;
                 }
             }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemSpecificationOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemSpecificationOverlay.java
@@ -24,6 +24,7 @@ import com.wynntils.webapi.profiles.item.enums.ItemType;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.RenderHelper;
+import net.minecraft.init.Items;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
@@ -37,6 +38,7 @@ import java.util.regex.Pattern;
 public class ItemSpecificationOverlay implements Listener {
 
     private final ScreenRenderer renderer = new ScreenRenderer();
+    private final Pattern ARCHETYPE_UNLOCKED_PATTERN = Pattern.compile("§7Unlocked Abilities: §f(\\d+)§7/\\d+");
 
     private void renderOverlay(GuiContainer gui) {
         if (!Reference.onWorld) return;
@@ -170,6 +172,17 @@ public class ItemSpecificationOverlay implements Listener {
                         specificationChars = ItemLevelOverlay.romanToArabic(EmeraldPouchManager.getPouchTier(stack));
                     }
                     color = MinecraftChatColors.GREEN;
+                    xOffset = -1;
+                    scale = UtilitiesConfig.Items.INSTANCE.specificationTierSize;
+                }
+            }
+
+            // Specification numbers for archetypes
+            if (stack.getDisplayName().contains("Archetype") && stack.getDisplayName().contains("§l") && stack.getItem() == Items.STONE_AXE) {
+                Matcher archetypeMatcher = ARCHETYPE_UNLOCKED_PATTERN.matcher(ItemUtils.getStringLore(stack));
+                if (archetypeMatcher.find()) {
+                    specificationChars = archetypeMatcher.group(1);
+                    color = MinecraftChatColors.fromColorCode(stack.getDisplayName().charAt(1));
                     xOffset = -1;
                     scale = UtilitiesConfig.Items.INSTANCE.specificationTierSize;
                 }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemSpecificationOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemSpecificationOverlay.java
@@ -215,7 +215,6 @@ public class ItemSpecificationOverlay implements Listener {
                 // Make a modifiable copy
                 color = new CustomColor(color);
                 color.setA(0.8f);
-                //renderer.drawRect(Textures.UIs.box, s.xPos, s.yPos, 0, 0, 18,18); // TODO remove debug
                 renderer.drawString(specificationChars, (s.xPos + xOffset) / scale, (s.yPos + yOffset) / scale, color, SmartFontRenderer.TextAlignment.LEFT_RIGHT, SmartFontRenderer.TextShadow.OUTLINE);
                 ScreenRenderer.endGL();
             }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemSpecificationOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemSpecificationOverlay.java
@@ -203,7 +203,6 @@ public class ItemSpecificationOverlay implements Listener {
                         color = MinecraftChatColors.fromColorCode(stack.getDisplayName().charAt(1));
                         xOffset = 5;
                         yOffset = 5;
-                        scale = UtilitiesConfig.Items.INSTANCE.specificationTierSize;
                     }
                 }
             }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/SkillPointOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/SkillPointOverlay.java
@@ -390,13 +390,12 @@ public class SkillPointOverlay implements Listener {
         ItemStack stack = e.getStack();
         if (stack.isEmpty() || !stack.hasDisplayName()) return; // display name also checks for tag compound
 
-        String lore = TextFormatting.getTextWithoutFormattingCodes(ItemUtils.getStringLore(stack));
         String name = TextFormatting.getTextWithoutFormattingCodes(stack.getDisplayName());
         String value = e.getOverlayText();
 
         if (!name.contains("Upgrade")) return; // Skill Points
 
-        Matcher spm = SKILLPOINT_PATTERN.matcher(lore);
+        Matcher spm = SKILLPOINT_PATTERN.matcher(ItemUtils.getStringLore(stack));
         if (!spm.find()) return;
 
         SkillPoint skillPoint = SkillPoint.findSkillPoint(name);

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/SkillPointOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/SkillPointOverlay.java
@@ -129,14 +129,18 @@ public class SkillPointOverlay implements Listener {
         ItemStack save = new ItemStack(Items.WRITABLE_BOOK);
         save.setStackDisplayName(TextFormatting.GOLD + "[>] Save current loadout");
         ItemUtils.replaceLore(save, (waitingForSkillPointData) ?
-                Arrays.asList(TextFormatting.GRAY + "Allows you to save this loadout with a name.", TextFormatting.RED + "Waiting for skill point data...") :
+                Arrays.asList(TextFormatting.GRAY + "Allows you to save this loadout with a name.",
+                        TextFormatting.RED + "Waiting for skill point data...",
+                        TextFormatting.GRAY + "Click on your player head if this is not loading.") :
                 Collections.singletonList(TextFormatting.GRAY + "Allows you to save this loadout with a name."));
         e.getGui().inventorySlots.getSlot(SAVE_SLOT).putStack(save);
 
         ItemStack load = new ItemStack(Items.ENCHANTED_BOOK);
         load.setStackDisplayName(TextFormatting.GOLD + "[>] Load loadout");
         ItemUtils.replaceLore(load, (waitingForSkillPointData) ?
-                Arrays.asList(TextFormatting.GRAY + "Allows you to load one of your saved loadouts.", TextFormatting.RED + "Waiting for skill point data...") :
+                Arrays.asList(TextFormatting.GRAY + "Allows you to load one of your saved loadouts.",
+                        TextFormatting.RED + "Waiting for skill point data...",
+                        TextFormatting.GRAY + "Click on your player head if this is not loading.") :
                 Collections.singletonList(TextFormatting.GRAY + "Allows you to load one of your saved loadouts."));
         e.getGui().inventorySlots.getSlot(LOAD_SLOT).putStack(load);
 

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/WynnBuilderOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/WynnBuilderOverlay.java
@@ -67,6 +67,8 @@ public class WynnBuilderOverlay implements Listener {
         if (slot == null || slot.inventory == null || !slot.getHasStack()) return;
 
         ItemStack stack = slot.getStack();
+        if (ItemUtils.getStringLore(stack).contains("§3Crafted")) return; // Crafteds are not on wynnbuilder
+
         Utils.openUrl("https://wynnbuilder.github.io/item.html#" + Utils.getRawItemName(stack).replace(" ", "%20"));
         e.setCanceled(true);
     }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/ui/GearViewerUI.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/ui/GearViewerUI.java
@@ -290,7 +290,7 @@ public class GearViewerUI extends FakeGuiContainer {
                     if (requiredClass != null) {
                         longName = spell.forOtherClass(requiredClass).getName() + " Spell Cost";
                     } else {
-                        longName = spell.forOtherClass(PlayerInfo.get(CharacterData.class).getCurrentClass()).getGenericAndSpecificName() + " Cost";
+                        longName = spell.forOtherClass(PlayerInfo.get(CharacterData.class).getCurrentClass()).getName() + " Cost";
                     }
                 }
 

--- a/src/main/java/com/wynntils/modules/visual/overlays/OverlayEvents.java
+++ b/src/main/java/com/wynntils/modules/visual/overlays/OverlayEvents.java
@@ -21,9 +21,7 @@ public class OverlayEvents implements Listener {
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void initClassMenu(GuiOverlapEvent.ChestOverlap.InitGui e) {
         if (!VisualConfig.CustomSelector.INSTANCE.characterSelector) return;
-        // item slot check required as compass menu will relay "Select a Character" just before updating
-        if (!e.getGui().getLowerInv().getName().contains("Select a Character")
-                || e.getGui().getLowerInv().getStackInSlot(2).getDisplayName().toLowerCase().contains("character")) return;
+        if (!e.getGui().getLowerInv().getName().contains("Select a Character")) return;
 
         WindowedResolution res = new WindowedResolution(480, 254);
         fakeCharacterSelector = new CharacterSelectorUI(null, e.getGui(), res.getScaleFactor());
@@ -32,9 +30,8 @@ public class OverlayEvents implements Listener {
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void closeCharacterMenu(GuiOverlapEvent.ChestOverlap.GuiClosed e) {
-        if (!e.getGui().getLowerInv().getName().contains("Select a Character")
-            || e.getGui().getLowerInv().getStackInSlot(2).getDisplayName().toLowerCase().contains("character")) return;
-
+        if (!VisualConfig.CustomSelector.INSTANCE.characterSelector) return;
+        // Literally impossible to have a character selector open after any inventory close; might as well clear it every time
         fakeCharacterSelector = null;
     }
 


### PR DESCRIPTION
- Fixes archer speed timer
- Fixes ingredient filter button position in character info page
- Fixes custom character selector appearing incorrectly
- Add specification nums for remaining SP
- Add specification nums for remaining AP (works in both ability tree page and char info page)
- Add specification nums for # of archetype upgrades selected
- Remove mentions of spell numbers (eg. 1st spell, 2nd spell). Spell numbers are no longer used in-game. (They are still used internally)
- Fix assassin vanish timer(s)
- Fix middle click to open items on wynnbuilder
- Fix skill point overlay not showing up