### PR TITLE
Fix NPE crash when chatLine is null

### DIFF
--- a/src/main/java/com/wynntils/modules/chat/overlays/ChatOverlay.java
+++ b/src/main/java/com/wynntils/modules/chat/overlays/ChatOverlay.java
@@ -478,6 +478,7 @@ public class ChatOverlay extends GuiNewChat {
 
         TabManager.getAvailableTabs().forEach(tab -> {
             if (tab == currentTab) return;
+            tab.getCurrentMessages().removeIf(chatline -> chatline == null);
             tab.getCurrentMessages().removeIf(chatline -> chatline.getChatLineID() == id);
         });
 


### PR DESCRIPTION
Fix issue #545 after testing for days, implemented a null check in case of NullPointerExceptions