### PR TITLE
fix: Open on Wynnbuilder including NEW, Defective, and [%]s with decimals

### DIFF
--- a/src/main/java/com/wynntils/core/utils/Utils.java
+++ b/src/main/java/com/wynntils/core/utils/Utils.java
@@ -262,8 +262,8 @@ public class Utils {
     }
 
     public static String getRawItemName(ItemStack stack) {
-        final Pattern PERCENTAGE_PATTERN = Pattern.compile(" +\\[[0-9]+%\\]");
-        final Pattern INGREDIENT_PATTERN = Pattern.compile(" +\\[✫+\\]");
+        final Pattern PERCENTAGE_PATTERN = Pattern.compile(" +\\[\\d+(?:.\\d)*%]");
+        final Pattern INGREDIENT_PATTERN = Pattern.compile(" +\\[✫+]");
 
         String name = stack.getDisplayName();
         name = TextFormatting.getTextWithoutFormattingCodes(name);
@@ -271,6 +271,10 @@ public class Utils {
         name = INGREDIENT_PATTERN.matcher(name).replaceAll("");
         if (name.startsWith("Perfect ")) {
             name = name.substring(8);
+        } else if (name.startsWith("Defective ")) {
+            name = name.substring(10);
+        } else if (name.endsWith(" NEW")) {
+            name = name.substring(0, name.length() - 4);
         }
         name = com.wynntils.core.utils.StringUtils.normalizeBadString(name);
         return name;

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/WynnBuilderOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/WynnBuilderOverlay.java
@@ -69,6 +69,8 @@ public class WynnBuilderOverlay implements Listener {
         if (slot == null || slot.inventory == null || !slot.getHasStack()) return;
 
         ItemStack stack = slot.getStack();
+        if (ItemUtils.getStringLore(stack).contains("§3Crafted")) return; // Crafteds are not on wynnbuilder
+
         Utils.openUrl("https://wynnbuilder.github.io/item.html#" + Utils.getRawItemName(stack).replace(" ", "%20"));
         e.setCanceled(true);
     }


### PR DESCRIPTION
Fixes open to Wynnbuilder links including NEW, Defective, and [%]s with decimals. Previous check only checked for Perfect and [%]s without decimals. Just something I thought I'd backport from the beta fixes.