### PR TITLE
feat: Party management GUI enhancements

### DIFF
--- a/src/main/java/com/wynntils/modules/core/managers/PartyManager.java
+++ b/src/main/java/com/wynntils/modules/core/managers/PartyManager.java
@@ -20,6 +20,8 @@ public class PartyManager {
     private static final Pattern PROMOTE_PATTERN = Pattern.compile("Successfully promoted (.+) to party leader!");
 
     private static final CommandResponse listExecutor = new CommandResponse("/party list", (matcher, text) -> {
+        PlayerInfo.get(SocialData.class).resetPlayerParty();
+
         String entire = matcher.group(0);
         if (entire.contains("You must be in")) {  // clears the party
             PlayerInfo.get(SocialData.class).getPlayerParty().removeMember(McIf.player().getName());

--- a/src/main/java/com/wynntils/modules/utilities/managers/KeyManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/KeyManager.java
@@ -10,6 +10,7 @@ import com.wynntils.core.framework.enums.wynntils.WynntilsConflictContext;
 import com.wynntils.core.framework.instances.KeyHolder;
 import com.wynntils.core.framework.settings.ui.SettingsUI;
 import com.wynntils.modules.core.CoreModule;
+import com.wynntils.modules.core.managers.PartyManager;
 import com.wynntils.modules.map.overlays.MiniMapOverlay;
 import com.wynntils.modules.utilities.UtilitiesModule;
 import com.wynntils.modules.utilities.configs.UtilitiesConfig;
@@ -85,7 +86,10 @@ public class KeyManager {
 
         showLevelOverlayKey = UtilitiesModule.getModule().registerKeyBinding("Show Item Level Overlay", Keyboard.KEY_LCONTROL, "Wynntils", WynntilsConflictContext.AMBIENT, true, () -> {});
 
-        CoreModule.getModule().registerKeyBinding("Open Party Management UI", Keyboard.KEY_RBRACKET, "Wynntils", KeyConflictContext.IN_GAME, true, () -> McIf.mc().displayGuiScreen(new PartyManagementUI()));
+        CoreModule.getModule().registerKeyBinding("Open Party Management UI", Keyboard.KEY_RBRACKET, "Wynntils", KeyConflictContext.IN_GAME, true, () -> {
+            PartyManager.handlePartyList(); // Refresh list just before opening
+            McIf.mc().displayGuiScreen(new PartyManagementUI());
+        });
 
         RegisterCustomCommandKeybinds();
     }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/ui/PartyManagementUI.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/ui/PartyManagementUI.java
@@ -125,12 +125,7 @@ public class PartyManagementUI extends GuiScreen {
         updateSuggestionsList();
         // Draw details for people in suggestions
         for (String playerName : suggestedPlayers) {
-            int colour = PartyManagementColors.MEMBER.getColor(); // White - shouldn't happen, but just in case
-            if (PlayerInfo.get(SocialData.class).getFriendList().contains(playerName)) {
-                colour = PartyManagementColors.FRIEND.getColor();
-            }
-
-            fontRenderer.drawString(playerName, this.width/2 + 320, (verticalReference + 17) + 25 * suggestedPlayers.indexOf(playerName), colour);
+            fontRenderer.drawString(playerName, this.width/2 + 320, (verticalReference + 17) + 25 * suggestedPlayers.indexOf(playerName), PartyManagementColors.FRIEND.getColor());
 
             // Reset colour to white
             // This is so player heads don't have the previous self/owner colour overlaid onto them

--- a/src/main/java/com/wynntils/modules/utilities/overlays/ui/PartyManagementUI.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/ui/PartyManagementUI.java
@@ -151,7 +151,6 @@ public class PartyManagementUI extends GuiScreen {
                 // Use the default player head texture, it will automatically update when the player is visible again
                 McIf.mc().getTextureManager().bindTexture(new ResourceLocation("textures/entity/steve.png"));
             }
-
             drawScaledCustomSizeModalRect(this.width/2 + 288, (verticalReference + 14) + 25 * suggestedPlayers.indexOf(playerName), 8.0F, 8.0F, 8, 8, 12, 12, 64.0F, 64.0F);
             EntityPlayer entityPlayer = McIf.mc().world.getPlayerEntityByName(playerName);
             if (entityPlayer != null && entityPlayer.isWearing(EnumPlayerModelParts.HAT)) {
@@ -210,7 +209,6 @@ public class PartyManagementUI extends GuiScreen {
                 // Use the default player head texture, it will automatically update when the player is visible again
                 McIf.mc().getTextureManager().bindTexture(new ResourceLocation("textures/entity/steve.png"));
             }
-
             drawScaledCustomSizeModalRect(this.width/2 - 192, (verticalReference + 14) + 25 * i, 8.0F, 8.0F, 8, 8, 12, 12, 64.0F, 64.0F);
             EntityPlayer entityPlayer = McIf.mc().world.getPlayerEntityByName(rawPlayerName);
             if (entityPlayer != null && entityPlayer.isWearing(EnumPlayerModelParts.HAT)) {


### PR DESCRIPTION
- PartyManager now correctly resets the party when retrieving the new party with /party list, instead of just appending new members to an invalid party
- Party management UI refreshes party status when opening with keybind
- New buttons!
    - "Refresh Party" force refreshes the party, in case anything goes wrong. Shouldn't really be necessary, but a nice to have
    - "Kick Offline", well, kicks offline players in the party. Only accessible when there are offline players & you are party leader
- Invite players has been moved, max characters extended, and a note added for bulk inviting
- Offline players now show up as ~Strikethrough~ on the player list
- Nearby players are now added to a suggestions list on the right. Nearby being a 30 block radius. (Pretty similar to Wynncraft's friend/party highlight range)
- Self now shows up as **Bold**
- Friends and nearby now have colours
- See image
- Fixes cascading lag (move static btns to init)
- Fixes static button sound being absurdly loud
![image](https://user-images.githubusercontent.com/57310593/182287157-bda57e46-69e2-4ee4-8602-bd98780c0e43.png)


Everything should be tested pretty well since I did the testing in a dxp weekend grind party, so tons of players in various states.
Also centered the entire UI properly. Was off by 5 pixels last time.