### PR TITLE
feat: Add glowing totems

### DIFF
--- a/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
@@ -20,10 +20,12 @@ import com.wynntils.modules.utilities.managers.MountHorseManager;
 import com.wynntils.modules.utilities.overlays.hud.*;
 import com.wynntils.webapi.WebManager;
 import com.wynntils.webapi.profiles.item.enums.ItemTier;
+import net.minecraft.entity.item.EntityArmorStand;
 import net.minecraft.init.MobEffects;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.network.play.server.*;
 import net.minecraft.potion.Potion;
+import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.client.event.ClientChatReceivedEvent;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
@@ -34,6 +36,7 @@ import org.apache.commons.lang3.StringUtils;
 import java.text.DecimalFormat;
 import java.util.Arrays;
 import java.util.EnumMap;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -853,6 +856,13 @@ public class OverlayEvents implements Listener {
         ConsumableTimerOverlay.removeBasicTimer(totemName);
         totemName = "Totem " + e.getLocation();
         ConsumableTimerOverlay.addBasicTimer(totemName, e.getTime());
+
+        // Glowing totems
+        List<EntityArmorStand> possibleTotems = McIf.mc().world.getEntitiesWithinAABB(EntityArmorStand.class,
+                new AxisAlignedBB(e.getLocation().getX(), e.getLocation().getY(), e.getLocation().getZ(), e.getLocation().getX(), e.getLocation().getY(), e.getLocation().getZ()));
+        possibleTotems.forEach(entityArmorStand -> {
+            if (entityArmorStand.getDisplayName().getUnformattedText().equals("Armor Stand")) entityArmorStand.setGlowing(true);
+        });
     }
 
     @SubscribeEvent


### PR DESCRIPTION
This is in OverlayEvents so it can piggyback off the consumable timer setting for the totem, though it can be (easily) moved to TotemTracker if needed.

Also no, we can't use the existing totem "entity" in TotemTracker. That thing is just the nametag, not the actual totem.

For future reference, legality of this is confirmed in https://discord.com/channels/394189072635133952/405350459126317065/1009605568618582076.