### PR TITLE
fix: always sell all button

### DIFF
--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -489,6 +489,9 @@ public class UtilitiesConfig extends SettingsClass {
 
         @Setting(displayName = "Automatically Open Chat", description = "Should the chat open when the trade market asks you to type a response?")
         public boolean openChatMarket = true;
+
+        @Setting(displayName = "Add Sell all button", description = "Should a sell all button be added to the market gui?")
+        public boolean showSellAllButton = true;
     }
 
     @SettingsInfo(name = "bank", displayPath = "Utilities/Bank")

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/TradeMarketOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/TradeMarketOverlay.java
@@ -4,6 +4,7 @@ import com.mojang.realmsclient.gui.ChatFormatting;
 import com.wynntils.McIf;
 import com.wynntils.core.events.custom.GuiOverlapEvent;
 import com.wynntils.core.framework.interfaces.Listener;
+import com.wynntils.modules.utilities.configs.UtilitiesConfig;
 import net.minecraft.inventory.ClickType;
 import net.minecraft.inventory.InventoryBasic;
 import net.minecraft.item.ItemStack;
@@ -22,6 +23,7 @@ public class TradeMarketOverlay implements Listener {
 
     @SubscribeEvent
     public void onGuiUpdate(GuiOverlapEvent.ChestOverlap.DrawScreen e) {
+        if (!UtilitiesConfig.Market.INSTANCE.showSellAllButton) return;
         InventoryBasic inventory = (InventoryBasic) e.getGui().getLowerInv();
         if (!inventory.getName().startsWith("What would you like to sell?")) {
             shouldSend = false;

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/TradeMarketOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/TradeMarketOverlay.java
@@ -33,7 +33,6 @@ public class TradeMarketOverlay implements Listener {
         ItemStack itemStack = new ItemStack(buildNBT(inventory));
 
         inventory.setInventorySlotContents(20, itemStack);
-        shouldSend = true;
     }
 
     @SubscribeEvent


### PR DESCRIPTION
Fixes Wynntils always putting in the max amount of items to sell, even if the user selected a custom amount.
Also adds a settings option to disable/enable the sell all button.
I feel so stupid for not seeing this earlier :/