### PR TITLE
fix: mythic detection & /guild list spam

### DIFF
--- a/src/main/java/com/wynntils/modules/core/events/ServerEvents.java
+++ b/src/main/java/com/wynntils/modules/core/events/ServerEvents.java
@@ -172,7 +172,7 @@ public class ServerEvents implements Listener {
             waitingForGuildList = false;
             e.setCanceled(true);
         }
-        if (messageText.startsWith("#") && messageText.contains(" XP -")) {
+        if (messageText.startsWith("#") && messageText.contains(" XP")) {
             if (waitingForGuildList) e.setCanceled(true);
 
             String[] splitMessage = messageText.split(" ");

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -4,7 +4,6 @@
 
 package com.wynntils.modules.utilities.events;
 
-import com.google.common.eventbus.Subscribe;
 import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.*;
@@ -87,7 +86,8 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
 import java.util.*;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;import java.util.stream.Collectors;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static com.wynntils.core.framework.instances.PlayerInfo.get;
 import static net.minecraft.util.text.TextFormatting.getTextWithoutFormattingCodes;

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -1146,6 +1146,8 @@ public class ClientEvents implements Listener {
         // Only run at first time we get items, don't care about updating
         if (e.getPacket().getWindowId() == lastProcessedOpenedChest) return;
 
+        // Wynncraft sends you two packets when opening the chest. The first is empty, the second one has the actual items.
+        // By returning here, we only process the second packet, whilst still only handling each chest once.
         List<ItemStack> actualItems = e.getPacket().getItemStacks().subList(0, 27).stream().filter(item -> !item.isEmpty() && item.hasDisplayName() && item.getItem() != Items.AIR).collect(Collectors.toList());
         if (actualItems.size() == 0) return;
 

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -1146,7 +1146,7 @@ public class ClientEvents implements Listener {
         // Only run at first time we get items, don't care about updating
         if (e.getPacket().getWindowId() == lastProcessedOpenedChest) return;
 
-        List<ItemStack> actualItems = e.getPacket().getItemStacks().subList(0, 27).stream().filter(item -> !item.isEmpty() && item.hasDisplayName() && !item.getDisplayName().equalsIgnoreCase("AIR")).collect(Collectors.toList());
+        List<ItemStack> actualItems = e.getPacket().getItemStacks().subList(0, 27).stream().filter(item -> !item.isEmpty() && item.hasDisplayName() && item.getItem() != Items.AIR).collect(Collectors.toList());
         if (actualItems.size() == 0) return;
 
         lastProcessedOpenedChest = e.getPacket().getWindowId();

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -87,7 +87,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
 import java.util.*;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.util.regex.Pattern;import java.util.stream.Collectors;
 
 import static com.wynntils.core.framework.instances.PlayerInfo.get;
 import static net.minecraft.util.text.TextFormatting.getTextWithoutFormattingCodes;
@@ -1146,6 +1146,9 @@ public class ClientEvents implements Listener {
         // Only run at first time we get items, don't care about updating
         if (e.getPacket().getWindowId() == lastProcessedOpenedChest) return;
 
+        List<ItemStack> actualItems = e.getPacket().getItemStacks().subList(0, 27).stream().filter(item -> !item.isEmpty() && item.hasDisplayName() && !item.getDisplayName().equalsIgnoreCase("AIR")).collect(Collectors.toList());
+        if (actualItems.size() == 0) return;
+
         lastProcessedOpenedChest = e.getPacket().getWindowId();
 
         // Dry streak counter and sound sfx
@@ -1171,7 +1174,6 @@ public class ClientEvents implements Listener {
                     }
                 }
 
-
                 if (UtilitiesConfig.INSTANCE.enableDryStreak && UtilitiesConfig.INSTANCE.dryStreakEndedMessage) {
                     ITextComponent textComponent = new TextComponentString(UtilitiesConfig.INSTANCE.dryStreakCount + " long dry streak broken! Mythic found! Found boxes since last mythic: " + UtilitiesConfig.INSTANCE.dryStreakBoxes);
                     textComponent.getStyle()
@@ -1191,28 +1193,6 @@ public class ClientEvents implements Listener {
                 UtilitiesConfig.INSTANCE.dryStreakCount += 1;
 
             UtilitiesConfig.INSTANCE.saveSettings(UtilitiesModule.getModule());
-            return;
-        }
-
-        // Mythic found sfx for daily rewards and objective rewards
-        if (!MusicConfig.SoundEffects.INSTANCE.mythicFound) return;
-
-        // Size should be at least 27, checked for it earlier
-        int size = 27;
-        for (int i = 0; i < size; i++) {
-            ItemStack stack = e.getPacket().getItemStacks().get(i);
-            if (stack.isEmpty() || !stack.hasDisplayName()) continue;
-            if (!stack.getDisplayName().contains(TextFormatting.DARK_PURPLE.toString())) continue;
-            if (!stack.getDisplayName().contains("Unidentified")) continue;
-
-            try {
-                SoundTrackManager.findTrack(WebManager.getMusicLocations().getEntryTrack("mythicFound"),
-                        true, false, false, false, true, false, true);
-            } catch (Exception exception) {
-                exception.printStackTrace();
-            }
-
-            break;
         }
     }
 


### PR DESCRIPTION
Fixes mythics in chests not being detected by Wynntils
Removes the `/guild list` spam 


The problem with the mythic's not being detected, was that Wynn sends two item change packets. One with empty items, one with the actual items. This PR makes Wynntils ignore the first, empty, packet and only handle the second, actual, packet. Before, Wynntils would only check the first packet, and then ignore the second, as the `lastProcessedChestID` was the same as the ID of the second packet