### PR TITLE
fix: emerald pouch message in chest not being sent

### DIFF
--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -746,7 +746,7 @@ public class ClientEvents implements Listener {
 
         // Queue messages into game update ticker when clicking on emeralds in loot chest
         if (getTextWithoutFormattingCodes(chestInv.getName()).startsWith("Loot Chest") && OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectEmeraldPouch) {
-            // Check if item is actually an emerald, if we're left clicking, and make sure we're not shift clicking
+            // Check if item is actually an emerald, if we're left clicking, and if we're shift clicking
             if (currentLootChest.getStackInSlot(e.getSlotId()).getDisplayName().equals("§aEmerald") && e.getMouseButton() == 0 && GuiScreen.isShiftKeyDown()) {
                 // Find all emerald pouches in inventory
                 NonNullList<Integer> availableCapacities = NonNullList.create();

--- a/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/events/ClientEvents.java
@@ -747,7 +747,7 @@ public class ClientEvents implements Listener {
         // Queue messages into game update ticker when clicking on emeralds in loot chest
         if (getTextWithoutFormattingCodes(chestInv.getName()).startsWith("Loot Chest") && OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectEmeraldPouch) {
             // Check if item is actually an emerald, if we're left clicking, and make sure we're not shift clicking
-            if (currentLootChest.getStackInSlot(e.getSlotId()).getDisplayName().equals("§aEmerald") && e.getMouseButton() == 0 && !GuiScreen.isShiftKeyDown()) {
+            if (currentLootChest.getStackInSlot(e.getSlotId()).getDisplayName().equals("§aEmerald") && e.getMouseButton() == 0 && GuiScreen.isShiftKeyDown()) {
                 // Find all emerald pouches in inventory
                 NonNullList<Integer> availableCapacities = NonNullList.create();
                 for (int i = 0; i < e.getGui().getUpperInv().getSizeInventory(); i++) {


### PR DESCRIPTION
Reverses the shift-key check since you hold shift to move emeralds to pouch now