### PR TITLE
fix: Devauth does not load JVM args

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,6 @@ minecraft {
         client {
             workingDirectory project.file('run')
 
-            property("devauth.configDir", project.file(".devauth").absolutePath)
-
             property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
             property 'forge.logging.console.level', 'debug'
 


### PR DESCRIPTION
This line in build.gradle overrides any JVM args, such as `-Ddevauth.account=alt`. 
Also, I feel like since Minecraft accounts can be used across multiple projects, storing them in the Wynntils directory isn't very useful.