### PR TITLE
feat: Add Lootrun Variables

### DIFF
--- a/src/main/java/com/wynntils/core/framework/instances/data/TabListData.java
+++ b/src/main/java/com/wynntils/core/framework/instances/data/TabListData.java
@@ -24,7 +24,7 @@ public class TabListData extends PlayerData {
     Buffs like "17% Frenzy" will have the 17% be considered as part of the prefix.
     This is because the 17% in Frenzy (and certain other buffs) can change, but the static scroll buffs cannot.
      */
-    private static final Pattern TAB_EFFECT_PATTERN = Pattern.compile("(.+?§7 ?(?:\\d+(?:\\.\\d+)?%)?) ?([%-+\\da-zA-Z\\s]+?) §[84a]\\((.+?)\\).*");
+    private static final Pattern TAB_EFFECT_PATTERN = Pattern.compile("(.+?§7 ?(?:\\d+(?:\\.\\d+)?%)?) ([%-+\\da-zA-Z\\s]+?) §[84]\\((.+?)\\).*");
 
     /**
      * Updates the ConsumableTimerOverlay with the effects from the tab list

--- a/src/main/java/com/wynntils/modules/map/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/map/events/ClientEvents.java
@@ -123,7 +123,7 @@ public class ClientEvents implements Listener {
         if (LootRunManager.isRecording())
             LootRunManager.addChest(lastLocation); // add chest to the current lootrun recording
 
-        if(LootRunManager.isLootrunLoaded()){
+        if (LootRunManager.isLootrunLoaded()) {
             LootRunManager.addOpenedChestToSession();
             LootRunManager.addOpenedChestToLatestLootrun();
         }

--- a/src/main/java/com/wynntils/modules/map/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/map/events/ClientEvents.java
@@ -126,7 +126,6 @@ public class ClientEvents implements Listener {
         if(LootRunManager.isLootrunLoaded()){
             if(LootRunManager.isCheckALootrunChest(lastLocation)){
                 LootRunManager.addOpenedChestToSession();
-                LootRunManager.addOpenedChestToLatestLootrun();
             }
         }
 

--- a/src/main/java/com/wynntils/modules/map/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/map/events/ClientEvents.java
@@ -124,8 +124,10 @@ public class ClientEvents implements Listener {
             LootRunManager.addChest(lastLocation); // add chest to the current lootrun recording
 
         if(LootRunManager.isLootrunLoaded()){
-            LootRunManager.addOpenedChestToSession();
-            LootRunManager.addOpenedChestToLatestLootrun();
+            if(LootRunManager.isCheckALootrunChest(lastLocation)){
+                LootRunManager.addOpenedChestToSession();
+                LootRunManager.addOpenedChestToLatestLootrun();
+            }
         }
 
         String tier = e.getGui().getLowerInv().getName().replace("Loot Chest ", "");

--- a/src/main/java/com/wynntils/modules/map/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/map/events/ClientEvents.java
@@ -123,6 +123,11 @@ public class ClientEvents implements Listener {
         if (LootRunManager.isRecording())
             LootRunManager.addChest(lastLocation); // add chest to the current lootrun recording
 
+        if(LootRunManager.isLootrunLoaded()){
+            LootRunManager.addOpenedChestToSession();
+            LootRunManager.addOpenedChestToLatestLootrun();
+        }
+
         String tier = e.getGui().getLowerInv().getName().replace("Loot Chest ", "");
         if (!MapConfig.Waypoints.INSTANCE.chestTiers.isTierAboveThis(tier)) return;
 

--- a/src/main/java/com/wynntils/modules/map/managers/LootRunManager.java
+++ b/src/main/java/com/wynntils/modules/map/managers/LootRunManager.java
@@ -19,6 +19,7 @@ import com.wynntils.modules.map.overlays.objects.MapIcon;
 import com.wynntils.modules.map.overlays.objects.MapPathWaypointIcon;
 import com.wynntils.modules.map.rendering.PointRenderer;
 
+import jdk.nashorn.internal.ir.Block;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3i;
 import org.apache.commons.lang3.ArrayUtils;
@@ -43,10 +44,10 @@ public class LootRunManager {
     private static LootRunPath recordingPath = null;
     private static LootRunPath lastRecorded = null;
     private final static List<PathWaypointProfile> mapPath = new ArrayList<>();
-    private static int sessionLootruns = 0;
-    private static int sessionLootrunChests = 0;
+    private static int sessionLootrunsAmount = 0;
+    private static int sessionLootrunChestsAmount = 0;
     private static boolean isLootrunLoaded = false;
-    private static int latestLootrunOpenedChests = 0;
+
 
     private final static List<CustomColor> pathColors = Arrays.asList(
         CommonColors.BLUE,
@@ -164,7 +165,6 @@ public class LootRunManager {
         activePaths.clear();
         recordingPath = null;
         isLootrunLoaded = false;
-        latestLootrunOpenedChests = 0;
         updateMapPath();
     }
 
@@ -362,24 +362,23 @@ public class LootRunManager {
             latestLootrun = null;
         activePaths.remove(name);
         updateMapPath();
-        isLootrunLoaded = false;
         return true;
     }
 
     public static int getSessionLootruns() {
-        return sessionLootruns;
+        return sessionLootrunsAmount;
     }
 
     public static int getSessionLootrunChests() {
-        return sessionLootrunChests;
+        return sessionLootrunChestsAmount;
     }
 
     public static void addLootruntoSession() {
-        sessionLootruns += 1;
+        sessionLootrunsAmount += 1;
     }
 
     public static void addOpenedChestToSession() {
-        sessionLootrunChests += 1;
+        sessionLootrunChestsAmount += 1;
     }
 
     public static boolean isLootrunLoaded() {
@@ -388,6 +387,32 @@ public class LootRunManager {
 
     public static String getLatestLootrunName() {
         return latestLootrunName;
+    }
+
+    public static boolean isCheckALootrunChest(BlockPos pos) {
+        for (LootRunPath path : activePaths.values()) {
+            if (path.getChests().contains(pos)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static String getLootrunNames() {
+        if (activePaths.size() > 0) {
+            String s = "";
+            for (String key : activePaths.keySet()) {
+                if (key != activePaths.keySet().toArray()[activePaths.keySet().toArray().length - 1]) {
+                    s = s + key + ", ";
+
+                }
+                else {
+                    s = s + key;
+                }
+            }
+            return s;
+        }
+        return "§c§l✖§r";
     }
 
     public static int getLootrunChests() {
@@ -402,21 +427,6 @@ public class LootRunManager {
             return latestLootrun.getPoints().size();
         }
         return 0;
-    }
-
-    public static boolean isCheckALootrunChest(BlockPos pos) {
-        if(latestLootrun.getChests().contains(pos)) {
-            return true;
-        }
-        return false;
-    }
-
-    public static int getLatestLootrunOpenedChests() {
-        return latestLootrunOpenedChests;
-    }
-
-    public static void addOpenedChestToLatestLootrun() {
-        latestLootrunOpenedChests += 1;
     }
 
     private static class LootRunPathIntermediary {

--- a/src/main/java/com/wynntils/modules/map/managers/LootRunManager.java
+++ b/src/main/java/com/wynntils/modules/map/managers/LootRunManager.java
@@ -404,6 +404,13 @@ public class LootRunManager {
         return 0;
     }
 
+    public static boolean isCheckALootrunChest(BlockPos pos) {
+        if(latestLootrun.getChests().contains(pos)) {
+            return true;
+        }
+        return false;
+    }
+
     public static int getLatestLootrunOpenedChests() {
         return latestLootrunOpenedChests;
     }

--- a/src/main/java/com/wynntils/modules/map/managers/LootRunManager.java
+++ b/src/main/java/com/wynntils/modules/map/managers/LootRunManager.java
@@ -43,6 +43,10 @@ public class LootRunManager {
     private static LootRunPath recordingPath = null;
     private static LootRunPath lastRecorded = null;
     private final static List<PathWaypointProfile> mapPath = new ArrayList<>();
+    private static int sessionLootruns = 0;
+    private static int sessionLootrunChests = 0;
+    private static boolean isLootrunLoaded = false;
+    private static int latestLootrunOpenedChests = 0;
 
     private final static List<CustomColor> pathColors = Arrays.asList(
         CommonColors.BLUE,
@@ -102,7 +106,8 @@ public class LootRunManager {
             reader.close();
             latestLootrun = path;
             latestLootrunName = lootRunName;
-
+            addLootruntoSession();
+            isLootrunLoaded = true;
             return Optional.of(path);
         } catch (Exception ex) {
             ex.printStackTrace();
@@ -158,6 +163,8 @@ public class LootRunManager {
     public static void clear() {
         activePaths.clear();
         recordingPath = null;
+        isLootrunLoaded = false;
+        latestLootrunOpenedChests = 0;
         updateMapPath();
     }
 
@@ -355,7 +362,54 @@ public class LootRunManager {
             latestLootrun = null;
         activePaths.remove(name);
         updateMapPath();
+        isLootrunLoaded = false;
         return true;
+    }
+
+    public static int getSessionLootruns() {
+        return sessionLootruns;
+    }
+
+    public static int getSessionLootrunChests() {
+        return sessionLootrunChests;
+    }
+
+    public static void addLootruntoSession() {
+        sessionLootruns += 1;
+    }
+
+    public static void addOpenedChestToSession() {
+        sessionLootrunChests += 1;
+    }
+
+    public static boolean isLootrunLoaded() {
+        return isLootrunLoaded;
+    }
+
+    public static String getLatestLootrunName() {
+        return latestLootrunName;
+    }
+
+    public static int getLootrunChests() {
+       if(latestLootrun != null) {
+           return latestLootrun.getChests().size();
+       }
+       return 0;
+    }
+
+    public static int getLootrunPoints() {
+        if(latestLootrun != null) {
+            return latestLootrun.getPoints().size();
+        }
+        return 0;
+    }
+
+    public static int getLatestLootrunOpenedChests() {
+        return latestLootrunOpenedChests;
+    }
+
+    public static void addOpenedChestToLatestLootrun() {
+        latestLootrunOpenedChests += 1;
     }
 
     private static class LootRunPathIntermediary {
@@ -399,5 +453,4 @@ public class LootRunManager {
             return o;
         }
     }
-
 }

--- a/src/main/java/com/wynntils/modules/utilities/instances/DynamicTimerContainer.java
+++ b/src/main/java/com/wynntils/modules/utilities/instances/DynamicTimerContainer.java
@@ -6,22 +6,22 @@ package com.wynntils.modules.utilities.instances;
 
 public class DynamicTimerContainer extends TimerContainer {
 
-    private long expirationTime; // The timestamp when the timer expires
+    private long expirationTime; // The time remaining for the consumable in seconds
 
-    public DynamicTimerContainer(String name, long expirationTime, boolean persistent) {
+    public DynamicTimerContainer(String name, long timeRemaining, boolean persistent) {
         super(name, persistent);
-        this.expirationTime = expirationTime;
+        this.expirationTime = timeRemaining;
     }
 
     /**
-     * @return The timestamp when the timer expires
+     * @return The time remaining for the consumable in seconds
      */
     public long getExpirationTime() {
         return expirationTime;
     }
 
     /**
-     * @param expirationTime The new timestamp for when the timer expires
+     * @param expirationTime The new time remaining for the consumable in seconds
      */
     public void setExpirationTime(long expirationTime) {
         this.expirationTime = expirationTime;

--- a/src/main/java/com/wynntils/modules/utilities/instances/InfoFormatter.java
+++ b/src/main/java/com/wynntils/modules/utilities/instances/InfoFormatter.java
@@ -511,7 +511,7 @@ public class InfoFormatter {
 
         // Lootrun name
         registerFormatter((input) ->
-                        LootRunManager.getLatestLootrunName(),
+                        LootRunManager.getLootrunNames(),
                 "lname", "lootrun_name");
 
         // Session Lootruns
@@ -533,11 +533,6 @@ public class InfoFormatter {
         registerFormatter((input) ->
                         String.valueOf(LootRunManager.getLootrunPoints()),
                 "lp", "lootrun_points");
-
-        // Current Lootrun Opened Chests
-        registerFormatter((input) ->
-                        String.valueOf(LootRunManager.getLatestLootrunOpenedChests()),
-                "loc", "lootrun_opened_chests");
     }
 
     private void registerFormatter(InfoModule formatter, String... vars) {

--- a/src/main/java/com/wynntils/modules/utilities/instances/InfoFormatter.java
+++ b/src/main/java/com/wynntils/modules/utilities/instances/InfoFormatter.java
@@ -17,6 +17,7 @@ import com.wynntils.core.utils.objects.Location;
 import com.wynntils.core.utils.reference.EmeraldSymbols;
 import com.wynntils.modules.core.managers.CompassManager;
 import com.wynntils.modules.core.managers.PingManager;
+import com.wynntils.modules.map.managers.LootRunManager;
 import com.wynntils.modules.utilities.configs.UtilitiesConfig;
 import com.wynntils.modules.utilities.interfaces.InfoModule;
 import com.wynntils.modules.utilities.managers.*;
@@ -507,6 +508,36 @@ public class InfoFormatter {
         registerFormatter((input) ->
                         !UtilitiesConfig.INSTANCE.enableDryStreak ? "-" : String.valueOf(UtilitiesConfig.INSTANCE.dryStreakBoxes),
                 "dry_boxes", "dry_streak_boxes");
+
+        // Lootrun name
+        registerFormatter((input) ->
+                        LootRunManager.getLatestLootrunName(),
+                "lname", "lootrun_name");
+
+        // Session Lootruns
+        registerFormatter((input) ->
+                        String.valueOf(LootRunManager.getSessionLootruns()),
+                "sl", "session_lootruns");
+
+        // Session Opened Lootrun Chests
+        registerFormatter((input) ->
+                        String.valueOf(LootRunManager.getSessionLootrunChests()),
+                "slc", "session_lootrun_chests");
+
+        // Current Lootrun Chest Amount
+        registerFormatter((input) ->
+                        String.valueOf(LootRunManager.getLootrunChests()),
+                "lc", "lootrun_chests");
+
+        // Current Lootrun Points Amount
+        registerFormatter((input) ->
+                        String.valueOf(LootRunManager.getLootrunPoints()),
+                "lp", "lootrun_points");
+
+        // Current Lootrun Opened Chests
+        registerFormatter((input) ->
+                        String.valueOf(LootRunManager.getLatestLootrunOpenedChests()),
+                "loc", "lootrun_opened_chests");
     }
 
     private void registerFormatter(InfoModule formatter, String... vars) {

--- a/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
@@ -7,7 +7,6 @@ package com.wynntils.modules.utilities.overlays;
 import com.wynntils.McIf;
 import com.wynntils.Reference;
 import com.wynntils.core.events.custom.*;
-import com.wynntils.core.framework.enums.ClassType;
 import com.wynntils.core.framework.enums.professions.ProfessionType;
 import com.wynntils.core.framework.instances.PlayerInfo;
 import com.wynntils.core.framework.instances.data.CharacterData;
@@ -21,10 +20,8 @@ import com.wynntils.modules.utilities.managers.MountHorseManager;
 import com.wynntils.modules.utilities.overlays.hud.*;
 import com.wynntils.webapi.WebManager;
 import com.wynntils.webapi.profiles.item.enums.ItemTier;
-import net.minecraft.init.MobEffects;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.network.play.server.*;
-import net.minecraft.potion.Potion;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.client.event.ClientChatReceivedEvent;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
@@ -770,36 +767,6 @@ public class OverlayEvents implements Listener {
     @SubscribeEvent
     public void onPlayerDeath(GameEvent.PlayerDeath e) {
         ConsumableTimerOverlay.clearTimers(false);
-    }
-
-    @SubscribeEvent
-    public void onEffectApplied(PacketEvent<SPacketEntityEffect> e) {
-        if (!Reference.onWorld || !OverlayConfig.ConsumableTimer.INSTANCE.showEffects) return;
-
-        SPacketEntityEffect packet = e.getPacket();
-        if (packet.getEntityId() != McIf.player().getEntityId()) return;
-
-        Potion potion = Potion.getPotionById(packet.getEffectId());
-
-        // normal weapons get the WITHER effect, Weathered (the mythic) gets INVISIBILITY instead
-        if ((potion == MobEffects.WITHER || potion == MobEffects.INVISIBILITY) && PlayerInfo.get(CharacterData.class).getCurrentClass() == ClassType.ASSASSIN) {
-            ConsumableTimerOverlay.addDynamicTimer("Vanish", 5, false);
-        }
-    }
-
-    @SubscribeEvent
-    public void onEffectRemoved(PacketEvent<SPacketRemoveEntityEffect> e) {
-        if (!Reference.onWorld || !OverlayConfig.ConsumableTimer.INSTANCE.showEffects) return;
-
-        SPacketRemoveEntityEffect packet = e.getPacket();
-        if (packet.getEntity(McIf.world()) != McIf.player()) return;
-
-        Potion potion = packet.getPotion();
-
-        // When removing Vanish from assassin
-        if ((potion == MobEffects.WITHER || potion == MobEffects.INVISIBILITY) && PlayerInfo.get(CharacterData.class).getCurrentClass() == ClassType.ASSASSIN) {
-            ConsumableTimerOverlay.removeTimer("Vanish");
-        }
     }
 
     @SubscribeEvent


### PR DESCRIPTION
**Info Variables Changes**
- Added the %slc% and %session_lootrun_chests% variables (The amount of opened chests in a lootrun in the playing session)
- Added the %lname% and %lootrun_name% variables (The name of the current lootrun)
- Added the %sl% and %session_lootruns% variables (The amount of lootruns done in the playing session)
- Added the %lc% and %lootrun_chests% variables (The amount of chests loaded in the current lootrun)
- Added the %lp% and %lootrun_points% variables (The amount of points loaded in the current lootrun)
- Added the %loc% and %lootrun_opened_chests% variables (The amount of opened chest during the current lootrun)