### PR TITLE
feat: Added variables for lootruning (Reverted Files)

### DIFF
--- a/src/main/java/com/wynntils/modules/map/managers/LootRunManager.java
+++ b/src/main/java/com/wynntils/modules/map/managers/LootRunManager.java
@@ -19,7 +19,6 @@ import com.wynntils.modules.map.overlays.objects.MapIcon;
 import com.wynntils.modules.map.overlays.objects.MapPathWaypointIcon;
 import com.wynntils.modules.map.rendering.PointRenderer;
 
-import jdk.nashorn.internal.ir.Block;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3i;
 import org.apache.commons.lang3.ArrayUtils;

--- a/src/main/java/com/wynntils/modules/map/managers/LootRunManager.java
+++ b/src/main/java/com/wynntils/modules/map/managers/LootRunManager.java
@@ -19,6 +19,7 @@ import com.wynntils.modules.map.overlays.objects.MapIcon;
 import com.wynntils.modules.map.overlays.objects.MapPathWaypointIcon;
 import com.wynntils.modules.map.rendering.PointRenderer;
 
+import jdk.nashorn.internal.ir.Block;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3i;
 import org.apache.commons.lang3.ArrayUtils;
@@ -43,6 +44,10 @@ public class LootRunManager {
     private static LootRunPath recordingPath = null;
     private static LootRunPath lastRecorded = null;
     private final static List<PathWaypointProfile> mapPath = new ArrayList<>();
+    private static int sessionLootrunsAmount = 0;
+    private static int sessionLootrunChestsAmount = 0;
+    private static boolean isLootrunLoaded = false;
+
 
     private final static List<CustomColor> pathColors = Arrays.asList(
         CommonColors.BLUE,
@@ -102,7 +107,8 @@ public class LootRunManager {
             reader.close();
             latestLootrun = path;
             latestLootrunName = lootRunName;
-
+            addLootruntoSession();
+            isLootrunLoaded = true;
             return Optional.of(path);
         } catch (Exception ex) {
             ex.printStackTrace();
@@ -158,6 +164,7 @@ public class LootRunManager {
     public static void clear() {
         activePaths.clear();
         recordingPath = null;
+        isLootrunLoaded = false;
         updateMapPath();
     }
 
@@ -358,6 +365,70 @@ public class LootRunManager {
         return true;
     }
 
+    public static int getSessionLootruns() {
+        return sessionLootrunsAmount;
+    }
+
+    public static int getSessionLootrunChests() {
+        return sessionLootrunChestsAmount;
+    }
+
+    public static void addLootruntoSession() {
+        sessionLootrunsAmount += 1;
+    }
+
+    public static void addOpenedChestToSession() {
+        sessionLootrunChestsAmount += 1;
+    }
+
+    public static boolean isLootrunLoaded() {
+        return isLootrunLoaded;
+    }
+
+    public static String getLatestLootrunName() {
+        return latestLootrunName;
+    }
+
+    public static boolean isCheckALootrunChest(BlockPos pos) {
+        for (LootRunPath path : activePaths.values()) {
+            if (path.getChests().contains(pos)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static String getLootrunNames() {
+        if (activePaths.size() > 0) {
+            String s = "";
+            for (String key : activePaths.keySet()) {
+                if (key != activePaths.keySet().toArray()[activePaths.keySet().toArray().length - 1]) {
+                    s = s + key + ", ";
+
+                }
+                else {
+                    s = s + key;
+                }
+            }
+            return s;
+        }
+        return "§c§l✖§r";
+    }
+
+    public static int getLootrunChests() {
+       if(latestLootrun != null) {
+           return latestLootrun.getChests().size();
+       }
+       return 0;
+    }
+
+    public static int getLootrunPoints() {
+        if(latestLootrun != null) {
+            return latestLootrun.getPoints().size();
+        }
+        return 0;
+    }
+
     private static class LootRunPathIntermediary {
         public List<Location> points;
         public List<BlockPos> chests;
@@ -399,5 +470,4 @@ public class LootRunManager {
             return o;
         }
     }
-
 }

--- a/src/main/java/com/wynntils/modules/utilities/instances/InfoFormatter.java
+++ b/src/main/java/com/wynntils/modules/utilities/instances/InfoFormatter.java
@@ -661,4 +661,5 @@ public class InfoFormatter {
         cache.put("horsetier", Integer.toString(horse.getTier()));
         cache.put("horselevelmax", Integer.toString(horse.getMaxLevel()));
     }
+    
 }

--- a/src/main/java/com/wynntils/modules/utilities/instances/InfoFormatter.java
+++ b/src/main/java/com/wynntils/modules/utilities/instances/InfoFormatter.java
@@ -17,6 +17,7 @@ import com.wynntils.core.utils.objects.Location;
 import com.wynntils.core.utils.reference.EmeraldSymbols;
 import com.wynntils.modules.core.managers.CompassManager;
 import com.wynntils.modules.core.managers.PingManager;
+import com.wynntils.modules.map.managers.LootRunManager;
 import com.wynntils.modules.utilities.configs.UtilitiesConfig;
 import com.wynntils.modules.utilities.interfaces.InfoModule;
 import com.wynntils.modules.utilities.managers.*;
@@ -507,6 +508,31 @@ public class InfoFormatter {
         registerFormatter((input) ->
                         !UtilitiesConfig.INSTANCE.enableDryStreak ? "-" : String.valueOf(UtilitiesConfig.INSTANCE.dryStreakBoxes),
                 "dry_boxes", "dry_streak_boxes");
+
+        // Lootrun name
+        registerFormatter((input) ->
+                        LootRunManager.getLootrunNames(),
+                "lname", "lootrun_name");
+
+        // Session Lootruns
+        registerFormatter((input) ->
+                        String.valueOf(LootRunManager.getSessionLootruns()),
+                "sl", "session_lootruns");
+
+        // Session Opened Lootrun Chests
+        registerFormatter((input) ->
+                        String.valueOf(LootRunManager.getSessionLootrunChests()),
+                "slc", "session_lootrun_chests");
+
+        // Current Lootrun Chest Amount
+        registerFormatter((input) ->
+                        String.valueOf(LootRunManager.getLootrunChests()),
+                "lc", "lootrun_chests");
+
+        // Current Lootrun Points Amount
+        registerFormatter((input) ->
+                        String.valueOf(LootRunManager.getLootrunPoints()),
+                "lp", "lootrun_points");
     }
 
     private void registerFormatter(InfoModule formatter, String... vars) {
@@ -636,4 +662,3 @@ public class InfoFormatter {
         cache.put("horselevelmax", Integer.toString(horse.getMaxLevel()));
     }
 }
-


### PR DESCRIPTION

**Info Variables Changes**

  -  Added the %slc% and %session_lootrun_chests% variables (The amount of opened chests in a lootrun in the playing session)
  -  Added the %lname% and %lootrun_name% variables (The name of the current lootrun)
  -  Added the %sl% and %session_lootruns% variables (The amount of lootruns done in the playing session)
  -  Added the %lc% and %lootrun_chests% variables (The amount of chests loaded in the current lootrun)
  -  Added the %lp% and %lootrun_points% variables (The amount of points loaded in the current lootrun)
  -  Added the %loc% and %lootrun_opened_chests% variables (The amount of opened chest during the current lootrun)

(I reverted the unecessary files from the last pr)
