### PR TITLE
fix: Skillpoints redirect regex not finding every message

### DIFF
--- a/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
@@ -335,7 +335,7 @@ public class OverlayEvents implements Listener {
         }
 
         if (OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectOther) {
-            if (messageText.matches("You have \\d+ unused Skill Points and \\d+ unused Ability Points! Right-Click while holding your compass to use them")) {
+            if (messageText.matches("You have \\d+ unused Skill Point(s\\b|\\b)( and \\d+ unused Ability Point(s\\b|\\b))?! Right-Click while holding your compass to use them")) {
                 String[] res = messageText.split(" ");
                 GameUpdateOverlay.queueMessage(YELLOW + res[2] + GOLD + " skill points and " + YELLOW + res[7] + GOLD + " ability points available.");
                 e.setCanceled(true);

--- a/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/OverlayEvents.java
@@ -335,7 +335,7 @@ public class OverlayEvents implements Listener {
         }
 
         if (OverlayConfig.GameUpdate.RedirectSystemMessages.INSTANCE.redirectOther) {
-            if (messageText.matches("You have \\d+ unused Skill Point(s\\b|\\b)( and \\d+ unused Ability Point(s\\b|\\b))?! Right-Click while holding your compass to use them")) {
+            if (messageText.matches("You have \\d+ unused Skill Points?( and \\d+ unused Ability Points?)?! Right-Click while holding your compass to use them")) {
                 String[] res = messageText.split(" ");
                 GameUpdateOverlay.queueMessage(YELLOW + res[2] + GOLD + " skill points and " + YELLOW + res[7] + GOLD + " ability points available.");
                 e.setCanceled(true);


### PR DESCRIPTION
The previous regex was not finding skill points messages such as:
- "You have 1 unused Skill Point and 1 unused Ability Point! Right-Click while holding your compass to use them"
- "You have 1 unused Skill Point!  Right-Click while holding your compass to use them"
- "You have 10 unused Skill Points! Right-Click while holding your compass to use them"

