### PR TITLE
fix: Update spell cost ID ranges

### DIFF
--- a/src/main/java/com/wynntils/modules/utilities/configs/enums/IdentificationType.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/enums/IdentificationType.java
@@ -27,21 +27,21 @@ public enum IdentificationType implements IIdentificationAnalyser {
 
         @Override
         public IdentificationResult identify(IdentificationContainer container, int current, boolean isInverted) {
-            double relative = getRelativeValue(container, current, isInverted);
+            double relative = getRelativeValue(container, current);
 
             return new IdentificationResult(getTitle(relative), relative);
         }
 
-        public double getRelativeValue(IdentificationContainer container, int current, boolean isInverted) {
+        public double getRelativeValue(IdentificationContainer container, int current) {
             if (container.isFixed() || container.getBaseValue() == 0) return current == container.getBaseValue() ? 1 : 0;
-            if (current == container.getMax()) return isInverted ? 0 : 1;
-            if (container.getMax() == container.getMin()) return isInverted ? 1 : 0 ;
+            if (current == container.getMax()) return 1;
+            if (container.getMax() == container.getMin()) return 0;
 
             int min = container.getMin();
             int max = container.getMax();
 
             double value = (current - min) / (double) (max - min);
-            return isInverted ? 1 - value : value;
+            return value;
         }
 
         String getColor(double amount) {
@@ -87,10 +87,10 @@ public enum IdentificationType implements IIdentificationAnalyser {
 
         @Override
         public IdentificationResult identify(IdentificationContainer container, int currentValue, boolean isInverted) {
-            IdentificationContainer.ReidentificationChances chances = container.getChances(currentValue, isInverted);
+            IdentificationContainer.ReidentificationChances chances = container.getChances(currentValue);
             double increasePct = chances.increase.getNumerator() * 100D / chances.increase.getDenominator();
             double decreasePct = chances.decrease.getNumerator() * 100D / chances.decrease.getDenominator();
-            double perfectPct = container.getPerfectChance(isInverted).multiplyBy(Fraction.getFraction(100, 1)).doubleValue();
+            double perfectPct = container.getPerfectChance().multiplyBy(Fraction.getFraction(100, 1)).doubleValue();
 
             String suffix = String.format(
                     AQUA + "\u21E7%.0f%% " + RED + "\u21E9%.0f%% " + GOLD + "\u2605%.1f%%",

--- a/src/main/java/com/wynntils/modules/utilities/managers/ChatItemManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/ChatItemManager.java
@@ -116,7 +116,8 @@ public class ChatItemManager {
             if (Math.abs(status.getBaseValue()) > 100) { // calculate percent
                 translatedValue = (int) Math.round((idValue * 100.0 / status.getBaseValue()) - 30);
             } else { // raw value
-                translatedValue = idValue - status.getMin();
+                // min/max must be flipped for inverted IDs to avoid negative values
+                translatedValue = status.isInverted() ? idValue - status.getMax() : idValue - status.getMin();
             }
 
             // stars
@@ -269,7 +270,8 @@ public class ChatItemManager {
                     // using bigdecimal here for precision when rounding
                     value = new BigDecimal(encodedValue + 30).movePointLeft(2).multiply(new BigDecimal(status.getBaseValue())).setScale(0, RoundingMode.HALF_UP).intValue();
                 } else {
-                    value = encodedValue + status.getMin();
+                    // min/max must be flipped for inverted IDs due to encoding
+                    value = status.isInverted() ? encodedValue + status.getMax() : encodedValue + status.getMin();
                 }
 
                 // stars

--- a/src/main/java/com/wynntils/modules/utilities/managers/ChatItemManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/ChatItemManager.java
@@ -292,7 +292,7 @@ public class ChatItemManager {
 
             // value string
             String lore;
-            if (IdentificationOrderer.INSTANCE.isInverted(id))
+            if (status.isInverted())
                 lore = (value < 0 ? GREEN.toString() : value > 0 ? RED + "+" : GRAY.toString())
                         + value + status.getType().getInGame(id);
             else

--- a/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemIdentificationOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/inventories/ItemIdentificationOverlay.java
@@ -147,7 +147,7 @@ public class ItemIdentificationOverlay implements Listener {
                 if (type == null) continue; // not a valid id
 
                 int currentValue = ids.getInteger(idName);
-                boolean isInverted = IdentificationOrderer.INSTANCE.isInverted(idName);
+                boolean isInverted = id != null ? id.isInverted() : IdentificationOrderer.INSTANCE.isInverted(idName);
 
                 // id color
                 String longName = IdentificationContainer.getAsLongName(idName);

--- a/src/main/java/com/wynntils/modules/utilities/overlays/ui/GearViewerUI.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/ui/GearViewerUI.java
@@ -280,7 +280,7 @@ public class GearViewerUI extends FakeGuiContainer {
                 IdentificationContainer idContainer = item.getStatuses().get(translatedId);
                 int value = (int) ((idContainer.isFixed()) ? idContainer.getBaseValue() : Math.round(idContainer.getBaseValue() * pct));
                 if (value == 0) value = 1; // account for mistaken rounding
-                boolean isInverted = IdentificationOrderer.INSTANCE.isInverted(translatedId);
+                boolean isInverted = idContainer.isInverted();
 
                 // determine lore name
                 String longName = IdentificationContainer.getAsLongName(translatedId);

--- a/src/main/java/com/wynntils/webapi/WebManager.java
+++ b/src/main/java/com/wynntils/webapi/WebManager.java
@@ -501,7 +501,7 @@ public class WebManager {
 
                     HashMap<String, ItemProfile> citems = new HashMap<>();
                     for (ItemProfile prof : gItems) {
-                        prof.getStatuses().values().forEach(IdentificationContainer::calculateMinMax);
+                        prof.getStatuses().forEach((n, p) -> p.calculateMinMax(n));
                         prof.addMajorIds(majorIds);
                         citems.put(prof.getDisplayName(), prof);
                     }

--- a/src/main/java/com/wynntils/webapi/profiles/item/ItemProfile.java
+++ b/src/main/java/com/wynntils/webapi/profiles/item/ItemProfile.java
@@ -343,12 +343,12 @@ public class ItemProfile {
         String lore;
 
         if (id.hasConstantValue())
-            if (IdentificationOrderer.INSTANCE.isInverted(idName))
+            if (id.isInverted())
                 lore = (baseValue < 0 ? GREEN.toString() : baseValue > 0 ? RED + "+" : GRAY.toString()) + baseValue;
             else
                 lore = (baseValue < 0 ? RED.toString() : baseValue > 0 ? GREEN + "+" : GRAY.toString()) + baseValue;
         else
-            if (IdentificationOrderer.INSTANCE.isInverted(idName))
+            if (id.isInverted())
                 lore = ((id.getMin() < 0 ? GREEN.toString() : RED + "+") + id.getMin()) +
                         ((id.getMax() < 0 ? DARK_GREEN + " to " + GREEN : DARK_RED + " to " + RED + "+") + id.getMax());
             else

--- a/src/main/java/com/wynntils/webapi/profiles/item/objects/IdentificationContainer.java
+++ b/src/main/java/com/wynntils/webapi/profiles/item/objects/IdentificationContainer.java
@@ -125,7 +125,7 @@ public class IdentificationContainer {
             );
         }
 
-        if (!isValidValue(currentValue)) {
+        if (isInvalidValue(currentValue)) {
             return new ReidentificationChances(
                 currentValue > max ? Fraction.ONE : Fraction.ZERO,
                 Fraction.ZERO,
@@ -204,9 +204,9 @@ public class IdentificationContainer {
 
     /**
      * @param currentValue Current value of this identification
-     * @return true if this is a valid value (If false, the API is probably wrong)
+     * @return true if this is an invalid value (meaning the API is probably wrong)
      */
-    public boolean isValidValue(int currentValue) {
+    public boolean isInvalidValue(int currentValue) {
         return isInverted ? (currentValue > min || currentValue < max) : (currentValue > max || currentValue < min);
     }
 


### PR DESCRIPTION
Accomplishes the same thing as the Artemis PR - updating our logic to be in line with new Wynn logic.

This isn't really merge ready because I don't have reidentification chances working on spell costs yet. Once that gets worked out, we should definitely push a stable release to make sure all users have working ID percentages.