### PR TITLE
fix: regex for life/mana steal

### DIFF
--- a/src/main/java/com/wynntils/core/framework/instances/data/TabListData.java
+++ b/src/main/java/com/wynntils/core/framework/instances/data/TabListData.java
@@ -49,7 +49,7 @@ public class TabListData extends PlayerData {
             Matcher m = TAB_EFFECT_PATTERN.matcher(effect);
             if (!m.find()) continue;
 
-            // See comment at TAB_EFFECT_PATTERN definition for the what the group numbers are
+            // See comment at TAB_EFFECT_PATTERN definition for what the group numbers are
             ConsumableTimerOverlay.addStaticTimer(m.group(1), m.group(2), m.group(3), false);
         }
     }

--- a/src/main/java/com/wynntils/core/framework/instances/data/TabListData.java
+++ b/src/main/java/com/wynntils/core/framework/instances/data/TabListData.java
@@ -23,8 +23,10 @@ public class TabListData extends PlayerData {
     Note: Buffs like "+190 Main Attack Damage" will have the +190 be considered as part of the name.
     Buffs like "17% Frenzy" will have the 17% be considered as part of the prefix.
     This is because the 17% in Frenzy (and certain other buffs) can change, but the static scroll buffs cannot.
+
+    https://regexr.com/729qc
      */
-    private static final Pattern TAB_EFFECT_PATTERN = Pattern.compile("(.+?§7 ?(?:\\d+(?:\\.\\d+)?%)?) ?([%-+\\da-zA-Z\\s]+?) §[84a]\\((.+?)\\).*");
+    private static final Pattern TAB_EFFECT_PATTERN = Pattern.compile("(.+?§7 ?(?:\\d+(?:\\.\\d+)?%)?) ?([%\\-+\\/\\da-zA-Z\\s]+?) §[84a]\\((.+?)\\).*");
 
     /**
      * Updates the ConsumableTimerOverlay with the effects from the tab list


### PR DESCRIPTION
Fixes effects with a `/` in them not parsing.