### PR TITLE
fix: Powders & pouches not favouriting with Arabic numerals, missing T10 pouch

### DIFF
--- a/src/main/java/com/wynntils/modules/questbook/instances/EmeraldPouch.java
+++ b/src/main/java/com/wynntils/modules/questbook/instances/EmeraldPouch.java
@@ -38,7 +38,7 @@ public class EmeraldPouch {
                 totalString = "54";
                 break;
             case 1:
-                rows = 1;
+                rows = (tier == 10) ? 6 : 1;
                 totalString = "9";
                 break;
             case 2:

--- a/src/main/java/com/wynntils/modules/questbook/instances/EmeraldPouch.java
+++ b/src/main/java/com/wynntils/modules/questbook/instances/EmeraldPouch.java
@@ -85,10 +85,7 @@ public class EmeraldPouch {
         itemLore.forEach(c -> loreList.appendTag(new NBTTagString(c)));
 
         display.setTag("Lore", loreList);
-        if (UtilitiesConfig.Items.INSTANCE.romanNumeralItemTier)
-            display.setString("Name", TextFormatting.GREEN + "Emerald Pouch " + TextFormatting.DARK_GREEN + "[Tier " + Utils.StringUtils.integerToRoman(tier) + "]");  // item display name
-        else
-            display.setString("Name", TextFormatting.GREEN + "Emerald Pouch " + TextFormatting.DARK_GREEN + "[Tier " + tier + "]");
+        display.setString("Name", TextFormatting.GREEN + "Emerald Pouch " + TextFormatting.DARK_GREEN + "[Tier " + tier + "]");
 
         tag.setTag("display", display);
         tag.setBoolean("Unbreakable", true);  // this allow items like reliks to have damage

--- a/src/main/java/com/wynntils/modules/questbook/instances/EmeraldPouch.java
+++ b/src/main/java/com/wynntils/modules/questbook/instances/EmeraldPouch.java
@@ -85,7 +85,7 @@ public class EmeraldPouch {
         itemLore.forEach(c -> loreList.appendTag(new NBTTagString(c)));
 
         display.setTag("Lore", loreList);
-        display.setString("Name", TextFormatting.GREEN + "Emerald Pouch " + TextFormatting.DARK_GREEN + "[Tier " + tier + "]");
+        display.setString("Name", TextFormatting.GREEN + "Emerald Pouch " + TextFormatting.DARK_GREEN + "[Tier " + Utils.StringUtils.integerToRoman(tier) + "]");  // item display name
 
         tag.setTag("display", display);
         tag.setBoolean("Unbreakable", true);  // this allow items like reliks to have damage

--- a/src/main/java/com/wynntils/modules/questbook/instances/EmeraldPouch.java
+++ b/src/main/java/com/wynntils/modules/questbook/instances/EmeraldPouch.java
@@ -19,7 +19,7 @@ public class EmeraldPouch {
     public static List<ItemStack> generateAllItemPouchStacks() {
         List<ItemStack> pouches = new ArrayList<>();
 
-        for (int i = 1; i <= 9; i++) {
+        for (int i = 1; i <= 10; i++) {
             ItemStack pouchStack = generatePouchItemStack(i);
             pouches.add(pouchStack);
         }

--- a/src/main/java/com/wynntils/modules/questbook/instances/PowderProfile.java
+++ b/src/main/java/com/wynntils/modules/questbook/instances/PowderProfile.java
@@ -92,7 +92,7 @@ public class PowderProfile {
 
 
         display.setTag("Lore", loreList);
-        display.setString("Name", element.getLightColor() + String.valueOf(element.getSymbol()) + " " + name + " Powder " + tier);  // item display name
+        display.setString("Name", element.getLightColor() + String.valueOf(element.getSymbol()) + " " + name + " Powder " + StringUtils.integerToRoman(tier));  // item display name
 
         tag.setTag("display", display);
         tag.setBoolean("Unbreakable", true);  // this allow items like reliks to have damage

--- a/src/main/java/com/wynntils/modules/questbook/instances/PowderProfile.java
+++ b/src/main/java/com/wynntils/modules/questbook/instances/PowderProfile.java
@@ -92,10 +92,7 @@ public class PowderProfile {
 
 
         display.setTag("Lore", loreList);
-        if (UtilitiesConfig.Items.INSTANCE.romanNumeralItemTier)
-            display.setString("Name", element.getLightColor() + String.valueOf(element.getSymbol()) + " " + name + " Powder " + StringUtils.integerToRoman(tier));  // item display name
-        else
-            display.setString("Name", element.getLightColor() + String.valueOf(element.getSymbol()) + " " + name + " Powder " + tier);  // item display name
+        display.setString("Name", element.getLightColor() + String.valueOf(element.getSymbol()) + " " + name + " Powder " + tier);  // item display name
 
         tag.setTag("display", display);
         tag.setBoolean("Unbreakable", true);  // this allow items like reliks to have damage

--- a/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
+++ b/src/main/java/com/wynntils/modules/utilities/configs/UtilitiesConfig.java
@@ -337,7 +337,8 @@ public class UtilitiesConfig extends SettingsClass {
         @Setting(displayName = "Shows Item Tiers", description = "Should the tier of powders, amplifiers, and pouches be shown when pressing the show item level key?", order = 5)
         public boolean levelKeyShowsItemTiers = false;
 
-        @Setting(displayName = "Roman Numeral Item Tiers", description = "Should the tier of powders, amplifiers, and pouches be displayed using Roman numerals?", order = 6)
+        // This is only for the item specification overlays, do not use anywhere else
+        @Setting(displayName = "Roman Numeral Item Tiers", description = "Should the tier of powders, amplifiers, and pouches in specifications be displayed using Roman numerals?", order = 6)
         public boolean romanNumeralItemTier = true;
 
         @Setting(displayName = "Item Levels Outside GUIs", description = "Should the item level overlay key be enabled even when no GUI is open?", order = 7)


### PR DESCRIPTION
- Adds missing T10 pouch
- Fixes powder and pouch name changes with the Arabic numeral setting, which was originally intended for item specification overlays