### PR TITLE
fix: Fix various ability bar bugs

### DIFF
--- a/src/main/java/com/wynntils/core/framework/instances/data/BossBarData.java
+++ b/src/main/java/com/wynntils/core/framework/instances/data/BossBarData.java
@@ -142,7 +142,12 @@ public class BossBarData extends PlayerData {
         if (packet.getOperation() != SPacketUpdateBossInfo.Operation.UPDATE_PCT) return;
 
         int bloodPool = get(CharacterData.class).getCurrentBloodPool();
-        if (packet.getPercent() != 0) { // This is only sent initially, don't attempt to div by zero
+        // Only update the max blood pool if the blood pool is 1
+        // The max blood pool being 1 means the ADD packet was just received
+        // This max should only be set one time
+        // If done multiple times, the bar's maximum fluctuates between for example, 28-32, where it should be 30
+
+        if (packet.getPercent() != 0 && get(CharacterData.class).getMaxBloodPool() == 1) {
             int maxBloodPool = Integer.parseInt(maxBloodPoolFormat.format(bloodPool / packet.getPercent()));
             get(CharacterData.class).setMaxBloodPool(maxBloodPool);
         }

--- a/src/main/java/com/wynntils/core/framework/instances/data/BossBarData.java
+++ b/src/main/java/com/wynntils/core/framework/instances/data/BossBarData.java
@@ -5,6 +5,7 @@ import net.minecraft.network.play.server.SPacketUpdateBossInfo;
 
 import java.math.RoundingMode;
 import java.text.DecimalFormat;
+import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -14,67 +15,152 @@ public class BossBarData extends PlayerData {
     private static final DecimalFormat maxBloodPoolFormat = new DecimalFormat("#0");
 
     public static final Pattern BLOOD_POOL_PATTERN = Pattern.compile("§cBlood Pool §4\\[§c(\\d+)%§4]§r");
+    public static UUID BLOOD_POOL_UUID;
+
     public static final Pattern MANA_BANK_PATTERN = Pattern.compile("§bMana Bank §3\\[(\\d+)/(\\d+)§3]§r");
-    public static final Pattern AWAKENED_PROGRESS_PATTERN = Pattern.compile("§fAwakening §7\\[§f(\\d+)/200§7]§r");
-    public static final Pattern CORRUPTED_PROGRESS_PATTERN = Pattern.compile("§cCorrupted §4\\[§c(\\d+)%§4]§r");
+    public static UUID MANA_BANK_UUID;
+
+    public static final Pattern AWAKENING_PATTERN = Pattern.compile("§fAwakening §7\\[§f(\\d+)/200§7]§r");
+    public static UUID AWAKENING_UUID;
+
+    public static final Pattern CORRUPTED_PATTERN = Pattern.compile("§cCorrupted §4\\[§c(\\d+)%§4]§r");
+    public static UUID CORRUPTED_UUID;
+
     public static final Pattern FOCUS_PATTERN = Pattern.compile("§eFocus §6\\[§e(\\d+)/(\\d+)§6]§r");
+    public static UUID FOCUS_UUID;
 
     public BossBarData() {
         maxBloodPoolFormat.setRoundingMode(RoundingMode.DOWN);
     }
 
-    public void updateBossbarStats(SPacketUpdateBossInfo packet) {
-        // (!) Do not remove .getName() check, Intellij is wrong about it
-        if (packet == null || packet.getName() == null) return;
+    public void processAddPacket(SPacketUpdateBossInfo packet) {
+        String title = packet.getName().getFormattedText();
+        // This is a new bar being added, set the UUID field
+        // .contains checks are okay since the title is not a user input
 
-        updateBloodPool(packet);
-        updateAwakenedBar(packet);
-        updateManaBankBar(packet);
-        updateFocusBar(packet);
-        updateCorruptedBar(packet);
+        if (title.contains("Blood Pool")) {
+            BLOOD_POOL_UUID = packet.getUniqueId();
+            // ADD packets do not contain percent data, leave it as 1 for now to show the bar
+            // The percent packet will update it later
+            // This is a problem exclusive to the Blood Pool bar
+            get(CharacterData.class).setMaxBloodPool(1);
+
+        } else if (title.contains("Mana Bank")) {
+            MANA_BANK_UUID = packet.getUniqueId();
+
+        } else if (title.contains("Awakening")) {
+            AWAKENING_UUID = packet.getUniqueId();
+
+        } else if (title.contains("Corrupted")) {
+            CORRUPTED_UUID = packet.getUniqueId();
+
+        } else if (title.contains("Focus")) {
+            FOCUS_UUID = packet.getUniqueId();
+        }
+    }
+
+    public void processNamePacket(SPacketUpdateBossInfo packet) {
+        if (packet.getOperation() != SPacketUpdateBossInfo.Operation.UPDATE_NAME && packet.getOperation() != SPacketUpdateBossInfo.Operation.ADD) return;
+        UUID uuid = packet.getUniqueId();
+
+        if (uuid.equals(BLOOD_POOL_UUID)) {
+            updateBloodPool(packet);
+        } else if (uuid.equals(MANA_BANK_UUID)) {
+            updateManaBank(packet);
+        } else if (uuid.equals(AWAKENING_UUID)) {
+            updateAwakened(packet);
+        } else if (uuid.equals(CORRUPTED_UUID)) {
+            updateCorrupted(packet);
+        } else if (uuid.equals(FOCUS_UUID)) {
+            updateFocus(packet);
+        }
+    }
+
+    public void processPctPacket(SPacketUpdateBossInfo packet) {
+        UUID uuid = packet.getUniqueId();
+
+        if (uuid.equals(BLOOD_POOL_UUID)) {
+            updateBloodPoolFromPct(packet);
+        }
+    }
+
+    /**
+     * Clears the given bossbar's stats back to -1
+     * Also removes any related visible bars from the user
+     * @param packet the packet of the bossbar to clear
+     */
+    public void processRemovePacket(SPacketUpdateBossInfo packet) {
+        UUID uuid = packet.getUniqueId();
+
+        if (uuid.equals(BLOOD_POOL_UUID)) {
+            BLOOD_POOL_UUID = null;
+            get(CharacterData.class).setBloodPool(-1);
+            get(CharacterData.class).setMaxBloodPool(-1);
+
+        } else if (uuid.equals(MANA_BANK_UUID)) {
+            MANA_BANK_UUID = null;
+            get(CharacterData.class).setManaBank(-1);
+            get(CharacterData.class).setMaxManaBank(-1);
+
+        } else if (uuid.equals(AWAKENING_UUID)) {
+            AWAKENING_UUID = null;
+            get(CharacterData.class).setAwakenedProgress(-1);
+
+        } else if (uuid.equals(CORRUPTED_UUID)) {
+            CORRUPTED_UUID = null;
+            get(CharacterData.class).setCorruptedProgressPercent(-1);
+
+        } else if (uuid.equals(FOCUS_UUID)) {
+            FOCUS_UUID = null;
+            get(CharacterData.class).setFocus(-1);
+            get(CharacterData.class).setMaxFocus(-1);
+        }
     }
 
     private void updateBloodPool(SPacketUpdateBossInfo packet) {
         Matcher m = BLOOD_POOL_PATTERN.matcher(packet.getName().getFormattedText());
         if (!m.matches()) return;
 
-        int bloodPool = Integer.parseInt(m.group(1));
-        get(CharacterData.class).setBloodPool(bloodPool);
+        get(CharacterData.class).setBloodPool(Integer.parseInt(m.group(1)));
+    }
+
+    private void updateBloodPoolFromPct(SPacketUpdateBossInfo packet) {
+        if (packet.getOperation() != SPacketUpdateBossInfo.Operation.UPDATE_PCT) return;
+
+        int bloodPool = get(CharacterData.class).getCurrentBloodPool();
         if (packet.getPercent() != 0) { // This is only sent initially, don't attempt to div by zero
             int maxBloodPool = Integer.parseInt(maxBloodPoolFormat.format(bloodPool / packet.getPercent()));
             get(CharacterData.class).setMaxBloodPool(maxBloodPool);
         }
     }
 
-    private void updateManaBankBar(SPacketUpdateBossInfo packet) {
+    private void updateManaBank(SPacketUpdateBossInfo packet) {
         Matcher m = MANA_BANK_PATTERN.matcher(packet.getName().getFormattedText());
         if (!m.matches()) return;
+
         get(CharacterData.class).setManaBank(Integer.parseInt(m.group(1)));
         get(CharacterData.class).setMaxManaBank(Integer.parseInt(m.group(2)));
     }
 
-    private void updateAwakenedBar(SPacketUpdateBossInfo packet) {
-        Matcher m = AWAKENED_PROGRESS_PATTERN.matcher(packet.getName().getFormattedText());
+    private void updateAwakened(SPacketUpdateBossInfo packet) {
+        Matcher m = AWAKENING_PATTERN.matcher(packet.getName().getFormattedText());
         if (!m.matches()) return;
-        int awakeningProgress = Integer.parseInt(m.group(1));
-        get(CharacterData.class).setAwakenedProgress(awakeningProgress);
+
+        get(CharacterData.class).setAwakenedProgress(Integer.parseInt(m.group(1)));
     }
 
-    private void updateCorruptedBar(SPacketUpdateBossInfo packet) {
-        Matcher m = CORRUPTED_PROGRESS_PATTERN.matcher(packet.getName().getFormattedText());
+    private void updateCorrupted(SPacketUpdateBossInfo packet) {
+        Matcher m = CORRUPTED_PATTERN.matcher(packet.getName().getFormattedText());
         if (!m.matches()) return;
-        int corruptedProgress = Integer.parseInt(m.group(1));
-        get(CharacterData.class).setCorruptedProgressPercent(corruptedProgress);
+
+        get(CharacterData.class).setCorruptedProgressPercent(Integer.parseInt(m.group(1)));
     }
 
-    private void updateFocusBar(SPacketUpdateBossInfo packet) {
+    private void updateFocus(SPacketUpdateBossInfo packet) {
         Matcher m = FOCUS_PATTERN.matcher(packet.getName().getFormattedText());
         if (!m.matches()) return;
 
-        int focusProgress = Integer.parseInt(m.group(1));
-        int maxFocus = Integer.parseInt(m.group(2));
-
-        get(CharacterData.class).setFocus(focusProgress);
-        get(CharacterData.class).setMaxFocus(maxFocus);
+        get(CharacterData.class).setFocus(Integer.parseInt(m.group(1)));
+        get(CharacterData.class).setMaxFocus(Integer.parseInt(m.group(2)));
     }
 }

--- a/src/main/java/com/wynntils/core/framework/instances/data/BossBarData.java
+++ b/src/main/java/com/wynntils/core/framework/instances/data/BossBarData.java
@@ -34,28 +34,42 @@ public class BossBarData extends PlayerData {
     }
 
     public void processAddPacket(SPacketUpdateBossInfo packet) {
-        String title = packet.getName().getFormattedText();
         // This is a new bar being added, set the UUID field
-        // .contains checks are okay since the title is not a user input
+        String title = packet.getName().getFormattedText();
 
-        if (title.contains("Blood Pool")) {
+        // Using regex because it is possible a guild name could contain the same text as the boss bar
+        Matcher bloodPoolMatcher = BLOOD_POOL_PATTERN.matcher(title);
+        if (bloodPoolMatcher.matches()) {
             BLOOD_POOL_UUID = packet.getUniqueId();
             // ADD packets do not contain percent data, leave it as 1 for now to show the bar
             // The percent packet will update it later
             // This is a problem exclusive to the Blood Pool bar
             get(CharacterData.class).setMaxBloodPool(1);
+            return;
+        }
 
-        } else if (title.contains("Mana Bank")) {
+        Matcher manaBankMatcher = MANA_BANK_PATTERN.matcher(title);
+        if (manaBankMatcher.matches()) {
             MANA_BANK_UUID = packet.getUniqueId();
+            return;
+        }
 
-        } else if (title.contains("Awakening")) {
+        Matcher awakeningMatcher = AWAKENING_PATTERN.matcher(title);
+        if (awakeningMatcher.matches()) {
             AWAKENING_UUID = packet.getUniqueId();
+            return;
+        }
 
-        } else if (title.contains("Corrupted")) {
+        Matcher corruptedMatcher = CORRUPTED_PATTERN.matcher(title);
+        if (corruptedMatcher.matches()) {
             CORRUPTED_UUID = packet.getUniqueId();
+            return;
+        }
 
-        } else if (title.contains("Focus")) {
+        Matcher focusMatcher = FOCUS_PATTERN.matcher(title);
+        if (focusMatcher.matches()) {
             FOCUS_UUID = packet.getUniqueId();
+            return;
         }
     }
 

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/CorruptedBarOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/CorruptedBarOverlay.java
@@ -82,7 +82,7 @@ public class CorruptedBarOverlay extends Overlay {
         }
 
         rotate(OverlayConfig.CorruptedBar.INSTANCE.overlayRotation.getDegrees());
-        drawProgressBar(Textures.Overlays.bars_health, -OverlayConfig.CorruptedBar.INSTANCE.width, y1, 0, y2, 0, ty1, 81, ty2, (flip ? -corruptedPercent : corruptedPercent) / (float) get(CharacterData.class).getCorruptedProgressPercent());
+        drawProgressBar(Textures.Overlays.bars_health, -OverlayConfig.CorruptedBar.INSTANCE.width, y1, 0, y2, 0, ty1, 81, ty2, (flip ? -corruptedPercent : corruptedPercent) / (float) maxCorruptedPercent);
     }
 
 }


### PR DESCRIPTION
Fixes #596:
- Corrupted bar previously did not render properly
- Bars did not disappear when the vanilla Wynn one disappeared
- Bars did not differentiate between packet types