### PR TITLE
feat: Add Leveling and Lootrunning Placeholders to Wynntils

### DIFF
--- a/src/main/java/com/wynntils/core/utils/StringUtils.java
+++ b/src/main/java/com/wynntils/core/utils/StringUtils.java
@@ -10,6 +10,7 @@ import com.wynntils.core.framework.rendering.ScreenRenderer;
 import com.wynntils.core.framework.rendering.SmartFontRenderer;
 import com.wynntils.core.framework.rendering.colors.CustomColor;
 import com.wynntils.core.utils.helpers.MD5Verification;
+import com.wynntils.modules.utilities.managers.LevelingManager;
 
 import java.nio.charset.StandardCharsets;
 import java.text.DecimalFormat;
@@ -45,7 +46,15 @@ public class StringUtils {
                 .trim();
     }
 
-    public static String durationIntegerToShortString(int count) {
+    public static String parseGrindTime(int count) {
+        if(count == 0) {
+            if(LevelingManager.getXpPerMinute() == 0) {
+                return "∞";
+            }
+            else {
+                return "Less than a minute";
+            }
+        }
         if (count < 60) {
             return count + "s";
         } else if (count > 86400) {

--- a/src/main/java/com/wynntils/core/utils/StringUtils.java
+++ b/src/main/java/com/wynntils/core/utils/StringUtils.java
@@ -45,6 +45,18 @@ public class StringUtils {
                 .trim();
     }
 
+    public static String durationIntegerToShortString(int count) {
+        if (count < 60) {
+            return count + "s";
+        } else if (count > 86400) {
+            return count / 86400 + "d";
+        } else if (count > 3600) {
+            return count / 3600 + "h";
+        } else {
+            return count / 60 + "m";
+        }
+    }
+
     public static String firstCharToUpper(String[] array) {
         StringBuilder result = new StringBuilder();
 

--- a/src/main/java/com/wynntils/modules/map/events/ClientEvents.java
+++ b/src/main/java/com/wynntils/modules/map/events/ClientEvents.java
@@ -15,6 +15,7 @@ import com.wynntils.modules.core.managers.CompassManager;
 import com.wynntils.modules.map.MapModule;
 import com.wynntils.modules.map.configs.MapConfig;
 import com.wynntils.modules.map.instances.LabelDetector;
+import com.wynntils.modules.map.instances.LootRunPath;
 import com.wynntils.modules.map.instances.WaypointProfile;
 import com.wynntils.modules.map.managers.BeaconManager;
 import com.wynntils.modules.map.managers.GuildResourceManager;
@@ -122,6 +123,11 @@ public class ClientEvents implements Listener {
 
         if (LootRunManager.isRecording())
             LootRunManager.addChest(lastLocation); // add chest to the current lootrun recording
+
+        if(LootRunManager.isLootrunLoaded())
+            if(LootRunManager.isAnLootrunChest(lastLocation))
+                LootRunManager.addCurrentLootrunChest();
+                LootRunManager.addChestToSession();
 
         String tier = e.getGui().getLowerInv().getName().replace("Loot Chest ", "");
         if (!MapConfig.Waypoints.INSTANCE.chestTiers.isTierAboveThis(tier)) return;

--- a/src/main/java/com/wynntils/modules/map/managers/LootRunManager.java
+++ b/src/main/java/com/wynntils/modules/map/managers/LootRunManager.java
@@ -44,6 +44,12 @@ public class LootRunManager {
     private static LootRunPath lastRecorded = null;
     private final static List<PathWaypointProfile> mapPath = new ArrayList<>();
 
+    private static int sessionLootruns = 0;
+    private static int sessionLootrunsChests = 0;
+    private static boolean isLootrunLoaded = false;
+
+    private static int currentLootrunChests = 0;
+
     private final static List<CustomColor> pathColors = Arrays.asList(
         CommonColors.BLUE,
         CommonColors.GREEN,
@@ -103,6 +109,8 @@ public class LootRunManager {
             latestLootrun = path;
             latestLootrunName = lootRunName;
 
+            enableLootrun();
+
             return Optional.of(path);
         } catch (Exception ex) {
             ex.printStackTrace();
@@ -159,6 +167,7 @@ public class LootRunManager {
         activePaths.clear();
         recordingPath = null;
         updateMapPath();
+        disableLootrun();
     }
 
     public static Map<String, LootRunPath> getActivePaths() {
@@ -376,6 +385,85 @@ public class LootRunManager {
         }
     }
 
+    public static int getSessionLootruns() {
+        return sessionLootruns;
+    }
+
+    public static int getSessionLootrunsChests() {
+        return sessionLootrunsChests;
+    }
+
+    public static void setSessionLootruns(int i) {
+        sessionLootruns = i;
+    }
+
+    public static void setSessionLootrunsChests(int i) {
+        sessionLootrunsChests = i;
+    }
+
+    public static void addLootrunToSession() {
+        setSessionLootruns(getSessionLootruns() + 1);
+    }
+
+    public static void addChestToSession() {
+        setSessionLootrunsChests(getSessionLootrunsChests() + 1);
+    }
+
+    public static boolean isLootrunLoaded() {return isLootrunLoaded;}
+
+    public static boolean isAnLootrunChest(BlockPos pos) {
+        for(LootRunPath path : activePaths.values()) {
+            if(path.getChests().contains(pos)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+    public static String getLootrunNames() {
+        if (activePaths.size() > 0) {
+            String s = "";
+            for (String key : activePaths.keySet()) {
+                if (key != activePaths.keySet().toArray()[activePaths.keySet().toArray().length - 1]) {
+                    s = s + key + ", ";
+
+                }
+                else {
+                    s = s + key;
+                }
+            }
+            return s;
+        }
+        return "§c§l✖§r";
+    }
+
+    public static int getTotalLootrunChests() {
+        return latestLootrun.getChests().size();
+    }
+
+    public static int getCurrentLootrunChests() {
+        return currentLootrunChests;
+    }
+
+    public static void setCurrentLootrunChests(int i) {
+        currentLootrunChests = i;
+    }
+
+    public static void addCurrentLootrunChest() {
+        setCurrentLootrunChests(getCurrentLootrunChests() + 1);
+    }
+
+    public static void disableLootrun() {
+        isLootrunLoaded = false;
+        currentLootrunChests = 0;
+    }
+
+    public static void enableLootrun() {
+        isLootrunLoaded = true;
+
+    }
+
     private static class BlockPosSerializer implements JsonSerializer<Vec3i>, JsonDeserializer<Vec3i> {
         private static final String srg_x = "field_177962_a";
         private static final String srg_y = "field_177960_b";
@@ -399,5 +487,6 @@ public class LootRunManager {
             return o;
         }
     }
+
 
 }

--- a/src/main/java/com/wynntils/modules/utilities/instances/InfoFormatter.java
+++ b/src/main/java/com/wynntils/modules/utilities/instances/InfoFormatter.java
@@ -134,6 +134,7 @@ public class InfoFormatter {
                 Integer.toString(PlayerInfo.get(CharacterData.class).getMaxHealth()),
                 "health_max");
 
+
         // Health percentage
         registerFormatter((input) -> {
             double currentHealth = PlayerInfo.get(CharacterData.class).getCurrentHealth();

--- a/src/main/java/com/wynntils/modules/utilities/instances/InfoFormatter.java
+++ b/src/main/java/com/wynntils/modules/utilities/instances/InfoFormatter.java
@@ -531,7 +531,7 @@ public class InfoFormatter {
                 "" + LootRunManager.getTotalLootrunChests()),
                 "lootrun_chests");
 
-        
+
     }
 
     private void registerFormatter(InfoModule formatter, String... vars) {

--- a/src/main/java/com/wynntils/modules/utilities/instances/InfoFormatter.java
+++ b/src/main/java/com/wynntils/modules/utilities/instances/InfoFormatter.java
@@ -17,6 +17,7 @@ import com.wynntils.core.utils.objects.Location;
 import com.wynntils.core.utils.reference.EmeraldSymbols;
 import com.wynntils.modules.core.managers.CompassManager;
 import com.wynntils.modules.core.managers.PingManager;
+import com.wynntils.modules.map.managers.LootRunManager;
 import com.wynntils.modules.utilities.configs.UtilitiesConfig;
 import com.wynntils.modules.utilities.interfaces.InfoModule;
 import com.wynntils.modules.utilities.managers.*;
@@ -508,6 +509,29 @@ public class InfoFormatter {
         registerFormatter((input) ->
                         !UtilitiesConfig.INSTANCE.enableDryStreak ? "-" : String.valueOf(UtilitiesConfig.INSTANCE.dryStreakBoxes),
                 "dry_boxes", "dry_streak_boxes");
+
+        // Lootruns
+        registerFormatter((input ->
+                "" + LootRunManager.getSessionLootruns()),
+                "session_lootruns");
+
+        registerFormatter((input ->
+                "" + LootRunManager.getSessionLootrunsChests()),
+                "session_lootruns_chests");
+
+        registerFormatter((input ->
+                LootRunManager.getLootrunNames()),
+                "lootruns");
+
+        registerFormatter((input ->
+                "" + LootRunManager.getCurrentLootrunChests()),
+                "lootrun_opened_chests");
+
+        registerFormatter((input ->
+                "" + LootRunManager.getTotalLootrunChests()),
+                "lootrun_chests");
+
+        
     }
 
     private void registerFormatter(InfoModule formatter, String... vars) {

--- a/src/main/java/com/wynntils/modules/utilities/managers/LevelingManager.java
+++ b/src/main/java/com/wynntils/modules/utilities/managers/LevelingManager.java
@@ -67,4 +67,19 @@ public class LevelingManager {
         DecimalFormat df = new DecimalFormat("0.00");
         return df.format(PPM);
     }
+
+    /**
+     * Get expected grind time for leveling up
+     * @return The Grind Time for Leveling Up in Minutes
+     */
+    public static int getLevelingGrindTime() {
+        CharacterData p = PlayerInfo.get(CharacterData.class);
+        int perminute = getXpPerMinute();
+        int required = p.getXpNeededToLevelUp() - p.getCurrentXP();
+        if (perminute != 0) {
+            return required / perminute * 60;
+        } else {
+            return 0;
+        }
+    }
 }

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/LevelingOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/LevelingOverlay.java
@@ -53,7 +53,7 @@ public class LevelingOverlay extends Overlay {
                     .replace("%neededg%", GROUPED_FORMAT.format(data.getXpNeededToLevelUp() - data.getCurrentXP()))
                     .replace("%curlvl%", "" + data.getLevel())
                     .replace("%nextlvl%", data.getLevel() == 104 ? "" : "" + (data.getLevel() + 1))
-                    .replace("%grindtime%", StringUtils.durationIntegerToShortString(LevelingManager.getLevelingGrindTime()));
+                    .replace("%grindtime%", StringUtils.parseGrindTime(LevelingManager.getLevelingGrindTime()));
 
             drawString(text, 0, 0, CommonColors.LIGHT_BLUE, SmartFontRenderer.TextAlignment.MIDDLE, OverlayConfig.Leveling.INSTANCE.textShadow);
             staticSize.x = (int) getStringWidth(text);

--- a/src/main/java/com/wynntils/modules/utilities/overlays/hud/LevelingOverlay.java
+++ b/src/main/java/com/wynntils/modules/utilities/overlays/hud/LevelingOverlay.java
@@ -10,7 +10,10 @@ import com.wynntils.core.framework.overlays.Overlay;
 import com.wynntils.core.framework.rendering.SmartFontRenderer;
 import com.wynntils.core.framework.rendering.colors.CommonColors;
 import com.wynntils.core.framework.settings.annotations.Setting;
+import com.wynntils.core.utils.StringUtils;
 import com.wynntils.modules.utilities.configs.OverlayConfig;
+import com.wynntils.modules.utilities.managers.LevelingManager;
+import io.netty.util.internal.StringUtil;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent.ClientTickEvent;
@@ -49,7 +52,9 @@ public class LevelingOverlay extends Overlay {
                     .replace("%maxg%", GROUPED_FORMAT.format(data.getXpNeededToLevelUp()))
                     .replace("%neededg%", GROUPED_FORMAT.format(data.getXpNeededToLevelUp() - data.getCurrentXP()))
                     .replace("%curlvl%", "" + data.getLevel())
-                    .replace("%nextlvl%", data.getLevel() == 104 ? "" : "" + (data.getLevel() + 1));
+                    .replace("%nextlvl%", data.getLevel() == 104 ? "" : "" + (data.getLevel() + 1))
+                    .replace("%grindtime%", StringUtils.durationIntegerToShortString(LevelingManager.getLevelingGrindTime()));
+
             drawString(text, 0, 0, CommonColors.LIGHT_BLUE, SmartFontRenderer.TextAlignment.MIDDLE, OverlayConfig.Leveling.INSTANCE.textShadow);
             staticSize.x = (int) getStringWidth(text);
         }


### PR DESCRIPTION
** General Changelog:**
[+] Added Grind Time Parser
[+] Added some variables in LootrunManager
[+] Added a function to calculate grind time

** Leveling HUD Changelog:**
[+] Added the %grindtime% placeholder to the Leveling Hud to see how much time is left before hitting next lvl

**Info HUD Changelog:**
[+] Added the %session_lootruns% placeholder to see how much lootruns where done in the session
[+] Added the %lootruns% placeholder to see the loaded lootruns names
[+] Added the %lootrun_chests% placeholder to see how much chests the main loaded lootrun has
[+] Added the %lootrun_opened_chests% placeholder to see how much chests where opened in the currently loaded lootruns (reset every lootrun clear)
[+] Added the %session_lootruns_chests% placeholder to see how much chests where opened during the session

If there is any syntax issues tell me and i will fix it